### PR TITLE
Task 0.2: Config loading from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,65 @@
+# Satsbook Configuration
+# Copy this file to .env and customize for local development
+
+# ============================================
+# LND Connection Settings
+# ============================================
+# These are typically injected by Umbrel, but can be set manually for local development
+
+# LND host address (Umbrel injects as LND_IP)
+SATSBOOK_LND_HOST=localhost
+# LND_IP=localhost  # Alternative: Umbrel-injected variable
+
+# LND gRPC port (Umbrel injects as LND_GRPC_PORT)
+SATSBOOK_LND_PORT=10009
+# LND_GRPC_PORT=10009  # Alternative: Umbrel-injected variable
+
+# Path to LND macaroon file (Umbrel injects as LND_MACAROON_PATH)
+# REQUIRED - no default value
+SATSBOOK_LND_MACAROON_PATH=/path/to/admin.macaroon
+# LND_MACAROON_PATH=/path/to/admin.macaroon  # Alternative: Umbrel-injected variable
+
+# Path to LND TLS certificate (Umbrel injects as LND_TLS_CERT_PATH)
+# REQUIRED - no default value
+SATSBOOK_LND_TLS_CERT_PATH=/path/to/tls.cert
+# LND_TLS_CERT_PATH=/path/to/tls.cert  # Alternative: Umbrel-injected variable
+
+# ============================================
+# Database Settings
+# ============================================
+
+# Path to SQLite database file
+# Default: ./satsbook.db
+SATSBOOK_DATABASE_PATH=./satsbook.db
+
+# ============================================
+# Application Settings
+# ============================================
+
+# HTTP server port
+# Default: 8080
+SATSBOOK_APP_PORT=8080
+
+# Logging level (debug, info, warn, error)
+# Default: info
+SATSBOOK_LOG_LEVEL=info
+
+# ============================================
+# Notes
+# ============================================
+#
+# Variable Priority:
+# 1. SATSBOOK_* prefixed variables take precedence
+# 2. Umbrel-injected variables (LND_IP, LND_GRPC_PORT, etc.) are used as fallbacks
+# 3. Defaults are applied if neither is set
+#
+# Required Variables (must be set):
+# - LND macaroon path (SATSBOOK_LND_MACAROON_PATH or LND_MACAROON_PATH)
+# - LND TLS cert path (SATSBOOK_LND_TLS_CERT_PATH or LND_TLS_CERT_PATH)
+#
+# Umbrel Deployment:
+# When deployed on Umbrel, the following variables are automatically injected:
+# - LND_IP: LND container hostname
+# - LND_GRPC_PORT: LND gRPC port
+# - LND_MACAROON_PATH: Path to mounted macaroon
+# - LND_TLS_CERT_PATH: Path to mounted TLS certificate

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries
-satsbook
-lndcheck
+/satsbook
+/lndcheck
 *.exe
 *.dll
 *.so
@@ -24,12 +24,14 @@ credentials.json
 *.out
 coverage.html
 
-# IDE
+# IDE/Tools
 .vscode/
 .idea/
 *.swp
 *.swo
 *~
+.claude
+CLAUDE.MD
 
 # OS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 .PHONY: build run test clean
 
+# Load environment variables from .env file if it exists
+ifneq (,$(wildcard .env))
+	include .env
+	export
+endif
+
 # Build the binary
 build:
 	go build -o satsbook ./cmd/satsbook

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/satsbook/satsbook/internal/config"
+)
+
+func main() {
+	fmt.Println("satsbook - Bitcoin node analytics and accounting")
+
+	// Load configuration
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Log configuration (without sensitive data)
+	log.Printf("Configuration loaded successfully")
+	log.Printf("LND Host: %s:%d", cfg.LNDHost, cfg.LNDPort)
+	log.Printf("Database: %s", cfg.DatabasePath)
+	log.Printf("App Port: %d", cfg.AppPort)
+	log.Printf("Log Level: %s", cfg.LogLevel)
+
+	// TODO: Implement main application logic
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,107 @@
 package config
 
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
 // Config holds all runtime configuration for the application.
 type Config struct {
-	// TODO: Add configuration field
+	// LND connection settings
+	LNDHost         string
+	LNDPort         int
+	LNDMacaroonPath string
+	LNDTLSCertPath  string
+
+	// Database settings
+	DatabasePath string
+
+	// Application settings
+	AppPort  int
+	LogLevel string
+}
+
+// Load reads configuration from environment variables.
+// It prioritizes SATSBOOK_* prefixed variables, but falls back to
+// Umbrel-injected variables (LND_IP, LND_GRPC_PORT, etc.) as defaults.
+func Load() (*Config, error) {
+	cfg := &Config{
+		// LND defaults - prefer SATSBOOK_ prefix, fall back to Umbrel vars
+		LNDHost:         getEnv("SATSBOOK_LND_HOST", getEnv("LND_IP", "localhost")),
+		LNDPort:         getEnvAsInt("SATSBOOK_LND_PORT", getEnvAsInt("LND_GRPC_PORT", 10009)),
+		LNDMacaroonPath: getEnv("SATSBOOK_LND_MACAROON_PATH", getEnv("LND_MACAROON_PATH", "")),
+		LNDTLSCertPath:  getEnv("SATSBOOK_LND_TLS_CERT_PATH", getEnv("LND_TLS_CERT_PATH", "")),
+
+		// Database defaults
+		DatabasePath: getEnv("SATSBOOK_DATABASE_PATH", "./satsbook.db"),
+
+		// Application defaults
+		AppPort:  getEnvAsInt("SATSBOOK_APP_PORT", 8080),
+		LogLevel: getEnv("SATSBOOK_LOG_LEVEL", "info"),
+	}
+
+	// Validate required fields
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// validate checks that required configuration values are present.
+func (c *Config) validate() error {
+	if c.LNDHost == "" {
+		return fmt.Errorf("LND host is required (set SATSBOOK_LND_HOST or LND_IP)")
+	}
+
+	if c.LNDPort <= 0 || c.LNDPort > 65535 {
+		return fmt.Errorf("LND port must be between 1 and 65535, got %d", c.LNDPort)
+	}
+
+	if c.LNDMacaroonPath == "" {
+		return fmt.Errorf("LND macaroon path is required (set SATSBOOK_LND_MACAROON_PATH or LND_MACAROON_PATH)")
+	}
+
+	if c.LNDTLSCertPath == "" {
+		return fmt.Errorf("LND TLS cert path is required (set SATSBOOK_LND_TLS_CERT_PATH or LND_TLS_CERT_PATH)")
+	}
+
+	if c.DatabasePath == "" {
+		return fmt.Errorf("database path is required (set SATSBOOK_DATABASE_PATH)")
+	}
+
+	if c.AppPort <= 0 || c.AppPort > 65535 {
+		return fmt.Errorf("app port must be between 1 and 65535, got %d", c.AppPort)
+	}
+
+	validLogLevels := map[string]bool{
+		"debug": true,
+		"info":  true,
+		"warn":  true,
+		"error": true,
+	}
+	if !validLogLevels[c.LogLevel] {
+		return fmt.Errorf("log level must be one of [debug, info, warn, error], got %q", c.LogLevel)
+	}
+
+	return nil
+}
+
+// getEnv retrieves an environment variable or returns a default value.
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+// getEnvAsInt retrieves an environment variable as an integer or returns a default value.
+func getEnvAsInt(key string, defaultValue int) int {
+	if value := os.Getenv(key); value != "" {
+		if intValue, err := strconv.Atoi(value); err == nil {
+			return intValue
+		}
+	}
+	return defaultValue
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,241 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoad_WithSatsbookPrefix(t *testing.T) {
+	// Set up environment variables with SATSBOOK_ prefix
+	os.Setenv("SATSBOOK_LND_HOST", "testhost")
+	os.Setenv("SATSBOOK_LND_PORT", "10010")
+	os.Setenv("SATSBOOK_LND_MACAROON_PATH", "/test/macaroon.path")
+	os.Setenv("SATSBOOK_LND_TLS_CERT_PATH", "/test/tls.cert")
+	os.Setenv("SATSBOOK_DATABASE_PATH", "/test/db.sqlite")
+	os.Setenv("SATSBOOK_APP_PORT", "9000")
+	os.Setenv("SATSBOOK_LOG_LEVEL", "debug")
+	defer clearEnv()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if cfg.LNDHost != "testhost" {
+		t.Errorf("LNDHost = %q, want %q", cfg.LNDHost, "testhost")
+	}
+	if cfg.LNDPort != 10010 {
+		t.Errorf("LNDPort = %d, want %d", cfg.LNDPort, 10010)
+	}
+	if cfg.LNDMacaroonPath != "/test/macaroon.path" {
+		t.Errorf("LNDMacaroonPath = %q, want %q", cfg.LNDMacaroonPath, "/test/macaroon.path")
+	}
+	if cfg.LNDTLSCertPath != "/test/tls.cert" {
+		t.Errorf("LNDTLSCertPath = %q, want %q", cfg.LNDTLSCertPath, "/test/tls.cert")
+	}
+	if cfg.DatabasePath != "/test/db.sqlite" {
+		t.Errorf("DatabasePath = %q, want %q", cfg.DatabasePath, "/test/db.sqlite")
+	}
+	if cfg.AppPort != 9000 {
+		t.Errorf("AppPort = %d, want %d", cfg.AppPort, 9000)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, "debug")
+	}
+}
+
+func TestLoad_WithUmbrelVariables(t *testing.T) {
+	// Set up Umbrel-injected variables (without SATSBOOK_ prefix)
+	os.Setenv("LND_IP", "umbrel-host")
+	os.Setenv("LND_GRPC_PORT", "10011")
+	os.Setenv("LND_MACAROON_PATH", "/umbrel/macaroon.path")
+	os.Setenv("LND_TLS_CERT_PATH", "/umbrel/tls.cert")
+	defer clearEnv()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if cfg.LNDHost != "umbrel-host" {
+		t.Errorf("LNDHost = %q, want %q", cfg.LNDHost, "umbrel-host")
+	}
+	if cfg.LNDPort != 10011 {
+		t.Errorf("LNDPort = %d, want %d", cfg.LNDPort, 10011)
+	}
+	if cfg.LNDMacaroonPath != "/umbrel/macaroon.path" {
+		t.Errorf("LNDMacaroonPath = %q, want %q", cfg.LNDMacaroonPath, "/umbrel/macaroon.path")
+	}
+	if cfg.LNDTLSCertPath != "/umbrel/tls.cert" {
+		t.Errorf("LNDTLSCertPath = %q, want %q", cfg.LNDTLSCertPath, "/umbrel/tls.cert")
+	}
+
+	// Check defaults for non-LND settings
+	if cfg.DatabasePath != "./satsbook.db" {
+		t.Errorf("DatabasePath = %q, want %q", cfg.DatabasePath, "./satsbook.db")
+	}
+	if cfg.AppPort != 8080 {
+		t.Errorf("AppPort = %d, want %d", cfg.AppPort, 8080)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, "info")
+	}
+}
+
+func TestLoad_SatsbookPrefixTakesPrecedence(t *testing.T) {
+	// Set both SATSBOOK_ and Umbrel variables
+	// SATSBOOK_ should take precedence
+	os.Setenv("SATSBOOK_LND_HOST", "satsbook-host")
+	os.Setenv("LND_IP", "umbrel-host")
+	os.Setenv("SATSBOOK_LND_PORT", "10012")
+	os.Setenv("LND_GRPC_PORT", "10011")
+	os.Setenv("SATSBOOK_LND_MACAROON_PATH", "/satsbook/macaroon")
+	os.Setenv("LND_MACAROON_PATH", "/umbrel/macaroon")
+	os.Setenv("SATSBOOK_LND_TLS_CERT_PATH", "/satsbook/tls.cert")
+	os.Setenv("LND_TLS_CERT_PATH", "/umbrel/tls.cert")
+	defer clearEnv()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if cfg.LNDHost != "satsbook-host" {
+		t.Errorf("LNDHost = %q, want %q (SATSBOOK_ prefix should take precedence)", cfg.LNDHost, "satsbook-host")
+	}
+	if cfg.LNDPort != 10012 {
+		t.Errorf("LNDPort = %d, want %d (SATSBOOK_ prefix should take precedence)", cfg.LNDPort, 10012)
+	}
+	if cfg.LNDMacaroonPath != "/satsbook/macaroon" {
+		t.Errorf("LNDMacaroonPath = %q, want %q (SATSBOOK_ prefix should take precedence)", cfg.LNDMacaroonPath, "/satsbook/macaroon")
+	}
+	if cfg.LNDTLSCertPath != "/satsbook/tls.cert" {
+		t.Errorf("LNDTLSCertPath = %q, want %q (SATSBOOK_ prefix should take precedence)", cfg.LNDTLSCertPath, "/satsbook/tls.cert")
+	}
+}
+
+func TestLoad_MissingRequiredMacaroon(t *testing.T) {
+	// Set all required vars except macaroon
+	os.Setenv("SATSBOOK_LND_HOST", "testhost")
+	os.Setenv("SATSBOOK_LND_TLS_CERT_PATH", "/test/tls.cert")
+	defer clearEnv()
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() should fail when macaroon path is missing")
+	}
+
+	expectedMsg := "config validation failed: LND macaroon path is required"
+	if err.Error()[:len(expectedMsg)] != expectedMsg {
+		t.Errorf("Error message = %q, want to start with %q", err.Error(), expectedMsg)
+	}
+}
+
+func TestLoad_MissingRequiredTLSCert(t *testing.T) {
+	// Set all required vars except TLS cert
+	os.Setenv("SATSBOOK_LND_HOST", "testhost")
+	os.Setenv("SATSBOOK_LND_MACAROON_PATH", "/test/macaroon")
+	defer clearEnv()
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() should fail when TLS cert path is missing")
+	}
+
+	expectedMsg := "config validation failed: LND TLS cert path is required"
+	if err.Error()[:len(expectedMsg)] != expectedMsg {
+		t.Errorf("Error message = %q, want to start with %q", err.Error(), expectedMsg)
+	}
+}
+
+func TestLoad_InvalidPort(t *testing.T) {
+	os.Setenv("SATSBOOK_LND_HOST", "testhost")
+	os.Setenv("SATSBOOK_LND_PORT", "99999") // Invalid port
+	os.Setenv("SATSBOOK_LND_MACAROON_PATH", "/test/macaroon")
+	os.Setenv("SATSBOOK_LND_TLS_CERT_PATH", "/test/tls.cert")
+	defer clearEnv()
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() should fail with invalid port")
+	}
+
+	expectedMsg := "config validation failed: LND port must be between 1 and 65535"
+	if err.Error()[:len(expectedMsg)] != expectedMsg {
+		t.Errorf("Error message = %q, want to start with %q", err.Error(), expectedMsg)
+	}
+}
+
+func TestLoad_InvalidLogLevel(t *testing.T) {
+	os.Setenv("SATSBOOK_LND_HOST", "testhost")
+	os.Setenv("SATSBOOK_LND_MACAROON_PATH", "/test/macaroon")
+	os.Setenv("SATSBOOK_LND_TLS_CERT_PATH", "/test/tls.cert")
+	os.Setenv("SATSBOOK_LOG_LEVEL", "invalid")
+	defer clearEnv()
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() should fail with invalid log level")
+	}
+
+	expectedMsg := "config validation failed: log level must be one of"
+	if err.Error()[:len(expectedMsg)] != expectedMsg {
+		t.Errorf("Error message = %q, want to start with %q", err.Error(), expectedMsg)
+	}
+}
+
+func TestLoad_ValidLogLevels(t *testing.T) {
+	validLevels := []string{"debug", "info", "warn", "error"}
+
+	for _, level := range validLevels {
+		t.Run(level, func(t *testing.T) {
+			os.Setenv("SATSBOOK_LND_HOST", "testhost")
+			os.Setenv("SATSBOOK_LND_MACAROON_PATH", "/test/macaroon")
+			os.Setenv("SATSBOOK_LND_TLS_CERT_PATH", "/test/tls.cert")
+			os.Setenv("SATSBOOK_LOG_LEVEL", level)
+			defer clearEnv()
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() failed with valid log level %q: %v", level, err)
+			}
+
+			if cfg.LogLevel != level {
+				t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, level)
+			}
+		})
+	}
+}
+
+func TestGetEnvAsInt_InvalidValue(t *testing.T) {
+	os.Setenv("TEST_INT", "not-a-number")
+	defer os.Unsetenv("TEST_INT")
+
+	result := getEnvAsInt("TEST_INT", 42)
+	if result != 42 {
+		t.Errorf("getEnvAsInt with invalid value should return default, got %d, want %d", result, 42)
+	}
+}
+
+func TestGetEnvAsInt_ValidValue(t *testing.T) {
+	os.Setenv("TEST_INT", "123")
+	defer os.Unsetenv("TEST_INT")
+
+	result := getEnvAsInt("TEST_INT", 42)
+	if result != 123 {
+		t.Errorf("getEnvAsInt = %d, want %d", result, 123)
+	}
+}
+
+// clearEnv clears all test environment variables
+func clearEnv() {
+	testVars := []string{
+		"SATSBOOK_LND_HOST", "SATSBOOK_LND_PORT", "SATSBOOK_LND_MACAROON_PATH",
+		"SATSBOOK_LND_TLS_CERT_PATH", "SATSBOOK_DATABASE_PATH",
+		"SATSBOOK_APP_PORT", "SATSBOOK_LOG_LEVEL",
+		"LND_IP", "LND_GRPC_PORT", "LND_MACAROON_PATH", "LND_TLS_CERT_PATH",
+	}
+	for _, v := range testVars {
+		os.Unsetenv(v)
+	}
+}


### PR DESCRIPTION
## Summary
Implements Task 0.2 - Config loading from environment variables

- ✅ Config struct covers all required fields (LND, database, app settings)
- ✅ Loads from SATSBOOK_* prefixed environment variables
- ✅ Falls back to Umbrel-injected variables (LND_IP, LND_GRPC_PORT, etc.)
- ✅ Clear validation errors at startup, not mid-execution
- ✅ .env.example file documents all variables
- ✅ Comprehensive test coverage (10 tests)
- ✅ Makefile supports .env file for local development

## Test Results
```
PASS
ok  	github.com/satsbook/satsbook/internal/config	0.570s
```

## Changes
- `internal/config/config.go` - Config struct and loading logic
- `internal/config/config_test.go` - Comprehensive test coverage
- `.env.example` - Documentation for all environment variables
- `Makefile` - Auto-load .env file for local development
- `cmd/satsbook/main.go` - Load and log config at startup
- `.gitignore` - Fix to only ignore root binaries, not source files

Closes #2