### PR TITLE
feat(db): implement SQLite schema and migration system

### DIFF
--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/satsbook/satsbook/internal/config"
+	"github.com/satsbook/satsbook/internal/db"
 )
 
 func main() {
@@ -24,6 +25,14 @@ func main() {
 	log.Printf("Database: %s", cfg.DatabasePath)
 	log.Printf("App Port: %d", cfg.AppPort)
 	log.Printf("Log Level: %s", cfg.LogLevel)
+
+	// Initialize database
+	database, err := db.NewDB(cfg.DatabasePath)
+	if err != nil {
+		log.Fatalf("failed to initialize database: %v", err)
+	}
+	defer database.Close()
+	log.Printf("database initialized at %s", cfg.DatabasePath)
 
 	// TODO: Implement main application logic
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,178 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "modernc.org/sqlite"
+)
+
+// DB wraps a SQLite database connection.
+type DB struct {
+	db *sql.DB
+}
+
+// migrations is the list of SQL DDL statements applied in order.
+// Each migration is applied atomically in a transaction.
+var migrations = []string{
+	// Migration 0: Initial schema
+	`
+	CREATE TABLE IF NOT EXISTS schema_migrations (
+		id         INTEGER PRIMARY KEY,
+		applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS forwarding_events (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		timestamp   DATETIME NOT NULL,
+		chan_id_in  TEXT NOT NULL,
+		chan_id_out TEXT NOT NULL,
+		amt_in_msat INTEGER NOT NULL,
+		amt_out_msat INTEGER NOT NULL,
+		fee_msat    INTEGER NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS channels (
+		chan_id       TEXT PRIMARY KEY,
+		remote_pubkey TEXT NOT NULL,
+		local_balance INTEGER NOT NULL,
+		remote_balance INTEGER NOT NULL,
+		active        INTEGER NOT NULL,
+		updated_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS invoices (
+		payment_hash TEXT PRIMARY KEY,
+		amt_paid_msat INTEGER NOT NULL,
+		created_at   DATETIME NOT NULL,
+		settled_at   DATETIME
+	);
+
+	CREATE TABLE IF NOT EXISTS payments (
+		payment_hash TEXT PRIMARY KEY,
+		value_msat   INTEGER NOT NULL,
+		fee_msat     INTEGER NOT NULL,
+		created_at   DATETIME NOT NULL,
+		status       TEXT NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS onchain_txns (
+		tx_hash         TEXT PRIMARY KEY,
+		amount_sat      INTEGER NOT NULL,
+		num_confirmations INTEGER NOT NULL,
+		timestamp       DATETIME NOT NULL,
+		label           TEXT
+	);
+
+	CREATE TABLE IF NOT EXISTS btc_lots (
+		id           INTEGER PRIMARY KEY AUTOINCREMENT,
+		acquired_at  DATETIME NOT NULL,
+		amount_sat   INTEGER NOT NULL,
+		price_usd    REAL NOT NULL,
+		source       TEXT NOT NULL,
+		external_id  TEXT
+	);
+
+	CREATE TABLE IF NOT EXISTS disposals (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		disposed_at DATETIME NOT NULL,
+		amount_sat  INTEGER NOT NULL,
+		proceeds_usd REAL NOT NULL,
+		lot_id      INTEGER NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS exchange_imports (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		source      TEXT NOT NULL,
+		external_id TEXT NOT NULL,
+		imported_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		raw_data    TEXT NOT NULL,
+		UNIQUE(source, external_id)
+	);
+
+	CREATE TABLE IF NOT EXISTS sync_state (
+		source     TEXT PRIMARY KEY,
+		last_synced_at DATETIME,
+		last_offset INTEGER DEFAULT 0
+	);
+	`,
+}
+
+// NewDB opens a SQLite database at the given path, runs migrations, and returns a DB.
+func NewDB(path string) (*DB, error) {
+	sqldb, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	// Verify the connection works
+	if err := sqldb.Ping(); err != nil {
+		sqldb.Close()
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	db := &DB{db: sqldb}
+
+	// Run migrations
+	if err := migrate(sqldb); err != nil {
+		sqldb.Close()
+		return nil, err
+	}
+
+	return db, nil
+}
+
+// migrate applies pending migrations in order.
+// Each migration is wrapped in a transaction.
+func migrate(sqldb *sql.DB) error {
+	// Create schema_migrations table if not exists
+	createMigrationsTable := `
+	CREATE TABLE IF NOT EXISTS schema_migrations (
+		id         INTEGER PRIMARY KEY,
+		applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	`
+	if _, err := sqldb.Exec(createMigrationsTable); err != nil {
+		return fmt.Errorf("failed to create schema_migrations table: %w", err)
+	}
+
+	// Check how many migrations have been applied
+	var appliedCount int
+	err := sqldb.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&appliedCount)
+	if err != nil {
+		return fmt.Errorf("failed to count applied migrations: %w", err)
+	}
+
+	// Apply pending migrations
+	for i := appliedCount; i < len(migrations); i++ {
+		tx, err := sqldb.Begin()
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction for migration %d: %w", i, err)
+		}
+
+		if _, err := tx.Exec(migrations[i]); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("failed to apply migration %d: %w", i, err)
+		}
+
+		// Record the migration
+		if _, err := tx.Exec("INSERT INTO schema_migrations (id) VALUES (?)", i); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("failed to record migration %d: %w", i, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit migration %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// Close closes the database connection.
+func (d *DB) Close() error {
+	if d.db != nil {
+		return d.db.Close()
+	}
+	return nil
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestNewDB_CreatesDatabase verifies that NewDB creates a database successfully
+// and that the connection is valid.
+func TestNewDB_CreatesDatabase(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewDB failed: %v", err)
+	}
+
+	// Should be able to close without error
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+}
+
+// TestNewDB_InvalidPath verifies that NewDB returns an error for invalid paths.
+func TestNewDB_InvalidPath(t *testing.T) {
+	// Try to create a database in a non-existent directory
+	dbPath := filepath.Join(t.TempDir(), "nonexistent", "subdir", "test.db")
+
+	_, err := NewDB(dbPath)
+	if err == nil {
+		t.Fatal("expected error for invalid path, got nil")
+	}
+}
+
+// TestMigrations_TablesExist verifies that all expected tables are created.
+func TestMigrations_TablesExist(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewDB failed: %v", err)
+	}
+	defer db.Close()
+
+	expectedTables := []string{
+		"schema_migrations",
+		"forwarding_events",
+		"channels",
+		"invoices",
+		"payments",
+		"onchain_txns",
+		"btc_lots",
+		"disposals",
+		"exchange_imports",
+		"sync_state",
+	}
+
+	for _, tableName := range expectedTables {
+		var name string
+		err := db.db.QueryRow(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+			tableName,
+		).Scan(&name)
+
+		if err == sql.ErrNoRows {
+			t.Errorf("table %q was not created", tableName)
+		} else if err != nil {
+			t.Errorf("failed to query table %q: %v", tableName, err)
+		}
+	}
+}
+
+// TestMigrations_IdempotentOnReopen verifies that opening the database twice
+// does not fail or re-run migrations.
+func TestMigrations_IdempotentOnReopen(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	// First open
+	db1, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("first NewDB failed: %v", err)
+	}
+	db1.Close()
+
+	// Second open
+	db2, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("second NewDB failed: %v", err)
+	}
+	defer db2.Close()
+}
+
+// TestMigrations_NeverRerun verifies that migrations are only applied once.
+// After opening the database twice, schema_migrations should have exactly 1 row.
+func TestMigrations_NeverRerun(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	// First open
+	db1, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("first NewDB failed: %v", err)
+	}
+	db1.Close()
+
+	// Second open
+	db2, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("second NewDB failed: %v", err)
+	}
+	defer db2.Close()
+
+	// Count rows in schema_migrations
+	var count int
+	err = db2.db.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count schema_migrations rows: %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 row in schema_migrations, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary
Implements Task 0.4 — the foundational database layer for Satsbook with SQLite schema and atomic migrations.

- Atomic migration system with `schema_migrations` tracking
- 9 tables for Lightning routing, invoices, payments, on-chain transactions, and tax accounting
- `sync_state` table for incremental syncs without re-fetching
- White-box tests verifying migrations idempotency and table creation
- Database initialization integrated into main startup flow

## Test plan
- [x] All tests pass: `make test` (5 new db tests)
- [x] Binary builds: `make build`
- [x] Application runs and initializes database
- [x] Schema created correctly: all 10 tables present (9 data + schema_migrations)
- [x] Migrations are idempotent: re-opening DB doesn't re-run migrations
- [x] Error handling: invalid paths return proper errors

## Done when (Task 0.4)
- [x] DB struct, constructor, migration runner, Close method in `internal/db/db.go`
- [x] White-box tests in `internal/db/db_test.go` (stdlib only, using t.TempDir())
- [x] Database initialization in `cmd/satsbook/main.go` after config.Load()
- [x] All tables defined upfront in migration 0
- [x] Schema includes sync_state for incremental syncs

Closes #3