### PR TITLE
feat: Phase 0 validation — on-chain tx syncing and test fixes

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -44,6 +44,15 @@ type Payment struct {
 	CreatedAt   time.Time
 }
 
+// OnchainTx represents an on-chain transaction stored in the database.
+type OnchainTx struct {
+	TxHash           string
+	AmountSat        int64
+	NumConfirmations int32
+	Timestamp        time.Time
+	Label            string
+}
+
 // WalletBalanceSnapshot represents a wallet balance snapshot.
 type WalletBalanceSnapshot struct {
 	CapturedAt      time.Time
@@ -176,6 +185,27 @@ func (t *dbSyncTx) UpsertPayments(payments []Payment) error {
 	return nil
 }
 
+// UpsertOnchainTxns inserts or updates on-chain transactions.
+// Confirmation count and label may change between syncs.
+func (t *dbSyncTx) UpsertOnchainTxns(txns []OnchainTx) error {
+	if len(txns) == 0 {
+		return nil
+	}
+
+	for _, tx := range txns {
+		_, err := t.tx.Exec(
+			`INSERT OR REPLACE INTO onchain_txns (tx_hash, amount_sat, num_confirmations, timestamp, label)
+			 VALUES (?, ?, ?, ?, ?)`,
+			tx.TxHash, tx.AmountSat, tx.NumConfirmations, tx.Timestamp, tx.Label,
+		)
+		if err != nil {
+			return fmt.Errorf("upsert onchain tx %s: %w", tx.TxHash, err)
+		}
+	}
+
+	return nil
+}
+
 // InsertWalletBalanceSnapshot inserts a wallet balance snapshot.
 func (t *dbSyncTx) InsertWalletBalanceSnapshot(s WalletBalanceSnapshot) error {
 	_, err := t.tx.Exec(
@@ -223,6 +253,7 @@ type SyncTx interface {
 	UpsertChannels(channels []Channel) error
 	UpsertInvoices(invoices []Invoice) error
 	UpsertPayments(payments []Payment) error
+	UpsertOnchainTxns(txns []OnchainTx) error
 	InsertWalletBalanceSnapshot(s WalletBalanceSnapshot) error
 }
 

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -345,6 +345,79 @@ func TestUpsertPayments_Empty(t *testing.T) {
 	}
 }
 
+func TestUpsertOnchainTxns(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	txns := []OnchainTx{
+		{
+			TxHash:           "abc123",
+			AmountSat:        50000,
+			NumConfirmations: 3,
+			Timestamp:        now,
+			Label:            "channel open",
+		},
+	}
+
+	err := d.RunSync(context.Background(), func(tx SyncTx) error {
+		return tx.UpsertOnchainTxns(txns)
+	})
+	if err != nil {
+		t.Fatalf("failed to upsert onchain txns: %v", err)
+	}
+
+	// Upsert with updated confirmations
+	updatedTxns := []OnchainTx{
+		{
+			TxHash:           "abc123",
+			AmountSat:        50000,
+			NumConfirmations: 6,
+			Timestamp:        now,
+			Label:            "channel open",
+		},
+	}
+
+	err = d.RunSync(context.Background(), func(tx SyncTx) error {
+		return tx.UpsertOnchainTxns(updatedTxns)
+	})
+	if err != nil {
+		t.Fatalf("failed to update onchain txn: %v", err)
+	}
+
+	var confs int32
+	err = d.db.QueryRow("SELECT num_confirmations FROM onchain_txns WHERE tx_hash = ?", "abc123").Scan(&confs)
+	if err != nil {
+		t.Fatalf("failed to query onchain txn: %v", err)
+	}
+
+	if confs != 6 {
+		t.Errorf("expected 6 confirmations, got %d", confs)
+	}
+
+	// Verify only 1 row (upsert, not duplicate)
+	var count int
+	err = d.db.QueryRow("SELECT COUNT(*) FROM onchain_txns").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count onchain txns: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 onchain txn, got %d", count)
+	}
+}
+
+func TestUpsertOnchainTxns_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	err := d.RunSync(context.Background(), func(tx SyncTx) error {
+		return tx.UpsertOnchainTxns(nil)
+	})
+	if err != nil {
+		t.Fatalf("upserting empty onchain txns should not error: %v", err)
+	}
+}
+
 func TestInsertWalletBalanceSnapshot(t *testing.T) {
 	d := newTestDB(t)
 	defer d.Close()

--- a/internal/lnd/client.go
+++ b/internal/lnd/client.go
@@ -334,3 +334,37 @@ func (c *Client) WalletBalance(ctx context.Context) (*WalletBalance, error) {
 		UnconfirmedBalance: resp.UnconfirmedBalance,
 	}, nil
 }
+
+// OnchainTx represents an on-chain transaction.
+type OnchainTx struct {
+	TxHash           string
+	Amount           int64
+	NumConfirmations int32
+	Timestamp        time.Time
+	Label            string
+}
+
+// GetTransactions returns on-chain transactions from the wallet.
+// It fetches all transactions from block height 0 to the current tip (including unconfirmed).
+func (c *Client) GetTransactions(ctx context.Context) ([]OnchainTx, error) {
+	resp, err := c.client.GetTransactions(ctx, &lnrpc.GetTransactionsRequest{
+		StartHeight: 0,
+		EndHeight:   -1, // include unconfirmed
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get transactions: %w", err)
+	}
+
+	txns := make([]OnchainTx, len(resp.Transactions))
+	for i, tx := range resp.Transactions {
+		txns[i] = OnchainTx{
+			TxHash:           tx.TxHash,
+			Amount:           tx.Amount,
+			NumConfirmations: tx.NumConfirmations,
+			Timestamp:        time.Unix(tx.TimeStamp, 0),
+			Label:            tx.Label,
+		}
+	}
+
+	return txns, nil
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -15,6 +15,7 @@ type LNDClient interface {
 	ForwardingHistory(ctx context.Context, start, end time.Time) ([]lnd.ForwardingEvent, error)
 	ListInvoices(ctx context.Context, offset uint64) ([]lnd.Invoice, uint64, error)
 	ListPayments(ctx context.Context, offset uint64) ([]lnd.Payment, uint64, error)
+	GetTransactions(ctx context.Context) ([]lnd.OnchainTx, error)
 	WalletBalance(ctx context.Context) (*lnd.WalletBalance, error)
 }
 
@@ -87,6 +88,10 @@ func (s *Syncer) syncCycle(ctx context.Context, tx db.SyncTx) error {
 	}
 
 	if err := s.syncPayments(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := s.syncOnchainTxns(ctx, tx); err != nil {
 		return err
 	}
 
@@ -243,6 +248,37 @@ func (s *Syncer) syncPayments(ctx context.Context, tx db.SyncTx) error {
 	}
 
 	s.logger.Printf("synced %d payments", len(dbPayments))
+	return nil
+}
+
+// syncOnchainTxns syncs on-chain transactions from the wallet.
+// This always fetches the full list and upserts — confirmation counts change over time.
+func (s *Syncer) syncOnchainTxns(ctx context.Context, tx db.SyncTx) error {
+	txns, err := s.lnd.GetTransactions(ctx)
+	if err != nil {
+		return err
+	}
+
+	dbTxns := make([]db.OnchainTx, len(txns))
+	for i, t := range txns {
+		dbTxns[i] = db.OnchainTx{
+			TxHash:           t.TxHash,
+			AmountSat:        t.Amount,
+			NumConfirmations: t.NumConfirmations,
+			Timestamp:        t.Timestamp,
+			Label:            t.Label,
+		}
+	}
+
+	if err := tx.UpsertOnchainTxns(dbTxns); err != nil {
+		return err
+	}
+
+	if err := tx.SetSyncState("onchain", time.Now(), 0); err != nil {
+		return err
+	}
+
+	s.logger.Printf("synced %d on-chain transactions", len(dbTxns))
 	return nil
 }
 

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -18,6 +18,7 @@ type mockLNDClient struct {
 	forwardingHistory []lnd.ForwardingEvent
 	invoices          []lnd.Invoice
 	payments          []lnd.Payment
+	onchainTxns       []lnd.OnchainTx
 	walletBalance     *lnd.WalletBalance
 
 	// Per-method errors for targeted failure testing
@@ -25,6 +26,7 @@ type mockLNDClient struct {
 	forwardingHistoryErr error
 	invoicesErr          error
 	paymentsErr          error
+	onchainTxnsErr       error
 	walletBalanceErr     error
 }
 
@@ -54,6 +56,13 @@ func (m *mockLNDClient) ListPayments(ctx context.Context, offset uint64) ([]lnd.
 		return nil, 0, m.paymentsErr
 	}
 	return m.payments, offset + uint64(len(m.payments)), nil
+}
+
+func (m *mockLNDClient) GetTransactions(ctx context.Context) ([]lnd.OnchainTx, error) {
+	if m.onchainTxnsErr != nil {
+		return nil, m.onchainTxnsErr
+	}
+	return m.onchainTxns, nil
 }
 
 func (m *mockLNDClient) WalletBalance(ctx context.Context) (*lnd.WalletBalance, error) {
@@ -93,6 +102,7 @@ type mockSyncTx struct {
 	channelsUpserted         []db.Channel
 	invoicesUpserted         []db.Invoice
 	paymentsUpserted         []db.Payment
+	onchainTxnsUpserted      []db.OnchainTx
 	balanceSnapshots         []db.WalletBalanceSnapshot
 }
 
@@ -128,6 +138,11 @@ func (m *mockSyncTx) UpsertInvoices(invoices []db.Invoice) error {
 
 func (m *mockSyncTx) UpsertPayments(payments []db.Payment) error {
 	m.paymentsUpserted = append(m.paymentsUpserted, payments...)
+	return nil
+}
+
+func (m *mockSyncTx) UpsertOnchainTxns(txns []db.OnchainTx) error {
+	m.onchainTxnsUpserted = append(m.onchainTxnsUpserted, txns...)
 	return nil
 }
 
@@ -174,7 +189,7 @@ func TestSync_FirstRun(t *testing.T) {
 	}
 
 	// Verify all sync sources wrote state
-	for _, source := range []string{"forwarding", "invoices", "payments", "wallet"} {
+	for _, source := range []string{"forwarding", "invoices", "payments", "onchain", "wallet"} {
 		entry, ok := store.syncState[source]
 		if !ok {
 			t.Errorf("expected sync state for %q", source)
@@ -357,6 +372,24 @@ func TestSync_PaymentsError(t *testing.T) {
 	}
 }
 
+func TestSync_OnchainTxnsError(t *testing.T) {
+	store := newMockStore()
+	mockLND := &mockLNDClient{
+		forwardingHistory: []lnd.ForwardingEvent{},
+		channels:          []lnd.Channel{},
+		invoices:          []lnd.Invoice{},
+		payments:          []lnd.Payment{},
+		onchainTxnsErr:    errors.New("transactions unavailable"),
+		walletBalance:     defaultMockBalance(),
+	}
+
+	s := newTestSyncer(mockLND, store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from onchain txns failure")
+	}
+}
+
 func TestSync_WalletBalanceError(t *testing.T) {
 	store := newMockStore()
 	mockLND := &mockLNDClient{
@@ -364,6 +397,7 @@ func TestSync_WalletBalanceError(t *testing.T) {
 		channels:          []lnd.Channel{},
 		invoices:          []lnd.Invoice{},
 		payments:          []lnd.Payment{},
+		onchainTxns:       []lnd.OnchainTx{},
 		walletBalanceErr:  errors.New("wallet unavailable"),
 	}
 
@@ -391,8 +425,8 @@ func TestSync_EmptyResults(t *testing.T) {
 	}
 
 	// Sync should still complete and write state for all sources
-	if len(store.syncState) < 4 {
-		t.Errorf("expected at least 4 sync state entries, got %d", len(store.syncState))
+	if len(store.syncState) < 5 {
+		t.Errorf("expected at least 5 sync state entries, got %d", len(store.syncState))
 	}
 }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -212,11 +212,12 @@ stop_satsbook
 SYNC_STATES=$(db_count "sync_state")
 SNAPSHOTS=$(db_count "wallet_balance_snapshots")
 CHANNELS=$(db_count "channels")
+ONCHAIN=$(db_count "onchain_txns")
 
-if [[ "$SYNC_STATES" -ge 4 ]]; then
-  pass "sync_state has $SYNC_STATES entries (expected >= 4)"
+if [[ "$SYNC_STATES" -ge 5 ]]; then
+  pass "sync_state has $SYNC_STATES entries (expected >= 5)"
 else
-  fail "sync_state has $SYNC_STATES entries (expected >= 4)"
+  fail "sync_state has $SYNC_STATES entries (expected >= 5)"
 fi
 
 if [[ "$SNAPSHOTS" -ge 1 ]]; then
@@ -225,10 +226,14 @@ else
   fail "wallet_balance_snapshots is empty"
 fi
 
-if [[ "$CHANNELS" -ge 0 ]]; then
-  # Channels might be 0 if the node has none — that's ok, just report
-  info "channels: $CHANNELS, forwarding_events: $(db_count forwarding_events), invoices: $(db_count invoices), payments: $(db_count payments)"
+if [[ "$ONCHAIN" -ge 1 ]]; then
+  pass "onchain_txns has $ONCHAIN row(s)"
+else
+  fail "onchain_txns is empty (expected at least 1 on-chain transaction)"
 fi
+
+# Report all table counts
+info "channels: $CHANNELS, forwarding_events: $(db_count forwarding_events), invoices: $(db_count invoices), payments: $(db_count payments), onchain_txns: $ONCHAIN"
 
 SNAP_AFTER_FIRST=$SNAPSHOTS
 
@@ -358,6 +363,7 @@ sqlite3 "$DB_PATH" "
   UNION ALL SELECT 'channels', COUNT(*) FROM channels
   UNION ALL SELECT 'invoices', COUNT(*) FROM invoices
   UNION ALL SELECT 'payments', COUNT(*) FROM payments
+  UNION ALL SELECT 'onchain_txns', COUNT(*) FROM onchain_txns
   UNION ALL SELECT 'wallet_snapshots', COUNT(*) FROM wallet_balance_snapshots;
 " 2>/dev/null | sed 's/|/: /' | sed 's/^/  /'
 


### PR DESCRIPTION
## Summary
- Add on-chain transaction syncing (`GetTransactions` → `onchain_txns` table) — closes the last Phase 0 data gap
- Update smoke test to verify `onchain_txns` is populated
- Add syncer + db tests for the new sync source

This PR will also be used for any patches that come up during Phase 0 validation on swamp.

Relates to #5

## Changes
- `internal/lnd/client.go` — add `GetTransactions` (fetches all wallet txns including unconfirmed)
- `internal/db/store.go` — add `OnchainTx` type and `UpsertOnchainTxns` (upserts by tx_hash)
- `internal/syncer/syncer.go` — wire `syncOnchainTxns` into the sync cycle
- `scripts/smoke-test.sh` — check `onchain_txns >= 1`, update sync_state count to 5

## Test plan
- [x] `go test -race ./internal/...` passes
- [x] Coverage holds at 80.6%
- [x] Smoke test passes on swamp (`./scripts/smoke-test.sh`)
- [x] `onchain_txns` populated with real data matching `lncli listchaintxns`