### PR TITLE
feat(web): fee income dashboard API endpoints

### DIFF
--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -7,11 +7,14 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/satsbook/satsbook/internal/config"
 	"github.com/satsbook/satsbook/internal/db"
 	"github.com/satsbook/satsbook/internal/lnd"
+	"github.com/satsbook/satsbook/internal/price"
 	"github.com/satsbook/satsbook/internal/syncer"
+	"github.com/satsbook/satsbook/internal/web"
 )
 
 func main() {
@@ -52,6 +55,14 @@ func main() {
 	syncerLogger := log.New(os.Stdout, "[syncer] ", log.LstdFlags)
 	s := syncer.New(lndClient, database, syncerLogger, cfg.SyncInterval, cfg.MaxHistoryDays)
 
+	// Initialize price cache
+	priceCache := price.NewCache(price.WithAPIURL(cfg.PriceAPIURL))
+
+	// Initialize HTTP server
+	httpLogger := log.New(os.Stdout, "[http] ", log.LstdFlags)
+	handler := web.NewHandler(database, lndClient, priceCache, httpLogger)
+	srv := web.NewServer(handler, cfg.AppPort, httpLogger)
+
 	// Setup graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
 	sigCh := make(chan os.Signal, 1)
@@ -61,6 +72,21 @@ func main() {
 		sig := <-sigCh
 		log.Printf("received signal %v, shutting down...", sig)
 		cancel()
+
+		// Give HTTP server 5 seconds to drain
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("HTTP server shutdown error: %v", err)
+		}
+	}()
+
+	// Start HTTP server in background
+	go func() {
+		if err := srv.Start(); err != nil {
+			log.Printf("HTTP server error: %v", err)
+			cancel()
+		}
 	}()
 
 	// Run syncer (blocks until ctx is cancelled)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,8 +23,9 @@ type Config struct {
 	MaxHistoryDays int
 
 	// Application settings
-	AppPort  int
-	LogLevel string
+	AppPort     int
+	LogLevel    string
+	PriceAPIURL string
 }
 
 // Load reads configuration from environment variables.
@@ -46,8 +47,9 @@ func Load() (*Config, error) {
 		MaxHistoryDays: getEnvAsInt("SATSBOOK_MAX_HISTORY_DAYS", 90),
 
 		// Application defaults
-		AppPort:  getEnvAsInt("SATSBOOK_APP_PORT", 8080),
-		LogLevel: getEnv("SATSBOOK_LOG_LEVEL", "info"),
+		AppPort:     getEnvAsInt("SATSBOOK_APP_PORT", 8080),
+		LogLevel:    getEnv("SATSBOOK_LOG_LEVEL", "info"),
+		PriceAPIURL: getEnv("SATSBOOK_PRICE_API_URL", "https://mempool.space/api/v1/prices"),
 	}
 
 	// Validate required fields

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -109,6 +109,15 @@ var migrations = []string{
 		unconfirmed_sat INTEGER NOT NULL
 	);
 	`,
+	// Migration 2: Indexes for dashboard query performance
+	`
+	CREATE INDEX IF NOT EXISTS idx_forwarding_events_timestamp
+		ON forwarding_events(timestamp);
+	CREATE INDEX IF NOT EXISTS idx_forwarding_events_chan_id_in
+		ON forwarding_events(chan_id_in);
+	CREATE INDEX IF NOT EXISTS idx_forwarding_events_chan_id_out
+		ON forwarding_events(chan_id_out);
+	`,
 }
 
 // NewDB opens a SQLite database at the given path, runs migrations, and returns a DB.
@@ -122,6 +131,17 @@ func NewDB(path string) (*DB, error) {
 	if err := sqldb.Ping(); err != nil {
 		sqldb.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	// Enable WAL mode for concurrent read/write (syncer writes while HTTP reads)
+	if _, err := sqldb.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		sqldb.Close()
+		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
+	}
+	// Set busy timeout so readers wait rather than getting SQLITE_BUSY
+	if _, err := sqldb.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		sqldb.Close()
+		return nil, fmt.Errorf("failed to set busy timeout: %w", err)
 	}
 
 	db := &DB{db: sqldb}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1,0 +1,164 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// FeeSummary returns aggregate fee stats for forwarding events since the given time.
+// Pass zero time for all-time stats.
+func (d *DB) FeeSummary(ctx context.Context, since time.Time) (totalFeeMsat int64, routedCount int64, err error) {
+	var query string
+	var args []interface{}
+
+	if since.IsZero() {
+		query = `SELECT COALESCE(SUM(fee_msat), 0), COUNT(*) FROM forwarding_events`
+	} else {
+		query = `SELECT COALESCE(SUM(fee_msat), 0), COUNT(*) FROM forwarding_events WHERE timestamp >= ?`
+		args = append(args, since)
+	}
+
+	err = d.db.QueryRowContext(ctx, query, args...).Scan(&totalFeeMsat, &routedCount)
+	if err != nil {
+		return 0, 0, fmt.Errorf("fee summary: %w", err)
+	}
+	return totalFeeMsat, routedCount, nil
+}
+
+// ActiveChannelCount returns the number of active channels.
+func (d *DB) ActiveChannelCount(ctx context.Context) (int, error) {
+	var count int
+	err := d.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM channels WHERE active = 1`,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("active channel count: %w", err)
+	}
+	return count, nil
+}
+
+// LatestWalletBalance returns the most recent wallet balance snapshot.
+// Returns nil, nil if no snapshots exist.
+func (d *DB) LatestWalletBalance(ctx context.Context) (*WalletBalanceSnapshot, error) {
+	var s WalletBalanceSnapshot
+	err := d.db.QueryRowContext(ctx,
+		`SELECT captured_at, total_sat, confirmed_sat, unconfirmed_sat
+		 FROM wallet_balance_snapshots ORDER BY captured_at DESC LIMIT 1`,
+	).Scan(&s.CapturedAt, &s.TotalSat, &s.ConfirmedSat, &s.UnconfirmedSat)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("latest wallet balance: %w", err)
+	}
+	return &s, nil
+}
+
+// ChannelStat holds per-channel stats for the dashboard.
+type ChannelStat struct {
+	ChanID               uint64
+	RemotePubKey         string
+	LocalBalance         int64
+	RemoteBalance        int64
+	Active               bool
+	FeesEarnedAllTimeMsat int64
+	FeesEarned30dMsat    int64
+}
+
+// ChannelStats returns per-channel stats with fee aggregations.
+func (d *DB) ChannelStats(ctx context.Context) ([]ChannelStat, error) {
+	thirtyDaysAgo := time.Now().AddDate(0, 0, -30)
+
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT
+			c.chan_id,
+			c.remote_pubkey,
+			c.local_balance,
+			c.remote_balance,
+			c.active,
+			COALESCE(all_fees.total_fee, 0) AS fees_all_time,
+			COALESCE(recent_fees.total_fee, 0) AS fees_30d
+		FROM channels c
+		LEFT JOIN (
+			SELECT chan_id, SUM(fee_msat) AS total_fee FROM (
+				SELECT chan_id_in AS chan_id, fee_msat FROM forwarding_events
+				UNION ALL
+				SELECT chan_id_out AS chan_id, fee_msat FROM forwarding_events
+			) GROUP BY chan_id
+		) all_fees ON all_fees.chan_id = c.chan_id
+		LEFT JOIN (
+			SELECT chan_id, SUM(fee_msat) AS total_fee FROM (
+				SELECT chan_id_in AS chan_id, fee_msat FROM forwarding_events WHERE timestamp >= ?
+				UNION ALL
+				SELECT chan_id_out AS chan_id, fee_msat FROM forwarding_events WHERE timestamp >= ?
+			) GROUP BY chan_id
+		) recent_fees ON recent_fees.chan_id = c.chan_id
+		ORDER BY fees_all_time DESC
+	`, thirtyDaysAgo, thirtyDaysAgo)
+	if err != nil {
+		return nil, fmt.Errorf("channel stats: %w", err)
+	}
+	defer rows.Close()
+
+	var stats []ChannelStat
+	for rows.Next() {
+		var s ChannelStat
+		var active int
+		if err := rows.Scan(&s.ChanID, &s.RemotePubKey, &s.LocalBalance, &s.RemoteBalance,
+			&active, &s.FeesEarnedAllTimeMsat, &s.FeesEarned30dMsat); err != nil {
+			return nil, fmt.Errorf("scan channel stat: %w", err)
+		}
+		s.Active = active == 1
+		stats = append(stats, s)
+	}
+	return stats, rows.Err()
+}
+
+// ForwardingPage holds a page of forwarding events with total count.
+type ForwardingPage struct {
+	Events []ForwardingEvent
+	Total  int64
+}
+
+// ForwardingEvents returns paginated forwarding events in a date range.
+func (d *DB) ForwardingEvents(ctx context.Context, from, to time.Time, limit, offset int) (*ForwardingPage, error) {
+	var total int64
+	err := d.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM forwarding_events WHERE timestamp >= ? AND timestamp <= ?`,
+		from, to,
+	).Scan(&total)
+	if err != nil {
+		return nil, fmt.Errorf("forwarding events count: %w", err)
+	}
+
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT timestamp, chan_id_in, chan_id_out, amt_in_msat, amt_out_msat, fee_msat
+		 FROM forwarding_events
+		 WHERE timestamp >= ? AND timestamp <= ?
+		 ORDER BY timestamp DESC
+		 LIMIT ? OFFSET ?`,
+		from, to, limit, offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("forwarding events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []ForwardingEvent
+	for rows.Next() {
+		var e ForwardingEvent
+		if err := rows.Scan(&e.Timestamp, &e.ChanIDIn, &e.ChanIDOut, &e.AmtInMsat, &e.AmtOutMsat, &e.FeeMsat); err != nil {
+			return nil, fmt.Errorf("scan forwarding event: %w", err)
+		}
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("forwarding events rows: %w", err)
+	}
+
+	return &ForwardingPage{Events: events, Total: total}, nil
+}

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1,0 +1,292 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func seedForwardingEvents(t *testing.T, d *DB, events []ForwardingEvent) {
+	t.Helper()
+	err := d.RunSync(context.Background(), func(tx SyncTx) error {
+		return tx.InsertForwardingEvents(events)
+	})
+	if err != nil {
+		t.Fatalf("failed to seed forwarding events: %v", err)
+	}
+}
+
+func seedChannels(t *testing.T, d *DB, channels []Channel) {
+	t.Helper()
+	err := d.RunSync(context.Background(), func(tx SyncTx) error {
+		return tx.UpsertChannels(channels)
+	})
+	if err != nil {
+		t.Fatalf("failed to seed channels: %v", err)
+	}
+}
+
+func seedWalletSnapshot(t *testing.T, d *DB, s WalletBalanceSnapshot) {
+	t.Helper()
+	err := d.RunSync(context.Background(), func(tx SyncTx) error {
+		return tx.InsertWalletBalanceSnapshot(s)
+	})
+	if err != nil {
+		t.Fatalf("failed to seed wallet snapshot: %v", err)
+	}
+}
+
+func TestFeeSummary_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	fees, count, err := d.FeeSummary(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fees != 0 || count != 0 {
+		t.Errorf("expected 0/0 on empty table, got %d/%d", fees, count)
+	}
+}
+
+func TestFeeSummary_WithData(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	seedForwardingEvents(t, d, []ForwardingEvent{
+		{Timestamp: now.Add(-48 * time.Hour), ChanIDIn: 1, ChanIDOut: 2, AmtInMsat: 10000, AmtOutMsat: 9000, FeeMsat: 1000},
+		{Timestamp: now.Add(-2 * time.Hour), ChanIDIn: 1, ChanIDOut: 2, AmtInMsat: 20000, AmtOutMsat: 18000, FeeMsat: 2000},
+		{Timestamp: now.Add(-1 * time.Hour), ChanIDIn: 3, ChanIDOut: 4, AmtInMsat: 30000, AmtOutMsat: 27000, FeeMsat: 3000},
+	})
+
+	// All time
+	fees, count, err := d.FeeSummary(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fees != 6000 {
+		t.Errorf("expected all-time fees 6000, got %d", fees)
+	}
+	if count != 3 {
+		t.Errorf("expected all-time count 3, got %d", count)
+	}
+
+	// Last 24 hours
+	fees, count, err = d.FeeSummary(context.Background(), now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fees != 5000 {
+		t.Errorf("expected 24h fees 5000, got %d", fees)
+	}
+	if count != 2 {
+		t.Errorf("expected 24h count 2, got %d", count)
+	}
+}
+
+func TestActiveChannelCount(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	seedChannels(t, d, []Channel{
+		{ChanID: 1, RemotePubKey: "a", LocalBalance: 100, RemoteBalance: 100, Active: true},
+		{ChanID: 2, RemotePubKey: "b", LocalBalance: 100, RemoteBalance: 100, Active: false},
+		{ChanID: 3, RemotePubKey: "c", LocalBalance: 100, RemoteBalance: 100, Active: true},
+	})
+
+	count, err := d.ActiveChannelCount(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 active channels, got %d", count)
+	}
+}
+
+func TestActiveChannelCount_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	count, err := d.ActiveChannelCount(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 active channels, got %d", count)
+	}
+}
+
+func TestLatestWalletBalance(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	seedWalletSnapshot(t, d, WalletBalanceSnapshot{CapturedAt: now.Add(-1 * time.Hour), TotalSat: 50000, ConfirmedSat: 40000, UnconfirmedSat: 10000})
+	seedWalletSnapshot(t, d, WalletBalanceSnapshot{CapturedAt: now, TotalSat: 60000, ConfirmedSat: 55000, UnconfirmedSat: 5000})
+
+	s, err := d.LatestWalletBalance(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if s.TotalSat != 60000 {
+		t.Errorf("expected total 60000, got %d", s.TotalSat)
+	}
+}
+
+func TestLatestWalletBalance_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	s, err := d.LatestWalletBalance(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s != nil {
+		t.Errorf("expected nil snapshot, got %+v", s)
+	}
+}
+
+func TestChannelStats(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	seedChannels(t, d, []Channel{
+		{ChanID: 100, RemotePubKey: "nodeA", LocalBalance: 50000, RemoteBalance: 50000, Active: true},
+		{ChanID: 200, RemotePubKey: "nodeB", LocalBalance: 30000, RemoteBalance: 70000, Active: true},
+	})
+
+	seedForwardingEvents(t, d, []ForwardingEvent{
+		// Old event through channel 100 (in) -> 200 (out)
+		{Timestamp: now.Add(-60 * 24 * time.Hour), ChanIDIn: 100, ChanIDOut: 200, AmtInMsat: 10000, AmtOutMsat: 9000, FeeMsat: 1000},
+		// Recent event through channel 200 (in) -> 100 (out)
+		{Timestamp: now.Add(-2 * time.Hour), ChanIDIn: 200, ChanIDOut: 100, AmtInMsat: 20000, AmtOutMsat: 18000, FeeMsat: 2000},
+	})
+
+	stats, err := d.ChannelStats(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(stats))
+	}
+
+	// Both channels should see fees (each event credits both in and out channels)
+	statMap := map[uint64]ChannelStat{}
+	for _, s := range stats {
+		statMap[s.ChanID] = s
+	}
+
+	ch100 := statMap[100]
+	// Channel 100: in on old event (1000), out on recent event (2000) = 3000 all-time
+	if ch100.FeesEarnedAllTimeMsat != 3000 {
+		t.Errorf("channel 100 all-time fees: expected 3000, got %d", ch100.FeesEarnedAllTimeMsat)
+	}
+	// 30d: only the recent event (2000)
+	if ch100.FeesEarned30dMsat != 2000 {
+		t.Errorf("channel 100 30d fees: expected 2000, got %d", ch100.FeesEarned30dMsat)
+	}
+
+	ch200 := statMap[200]
+	// Channel 200: out on old event (1000), in on recent event (2000) = 3000 all-time
+	if ch200.FeesEarnedAllTimeMsat != 3000 {
+		t.Errorf("channel 200 all-time fees: expected 3000, got %d", ch200.FeesEarnedAllTimeMsat)
+	}
+}
+
+func TestChannelStats_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	stats, err := d.ChannelStats(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected 0 channel stats, got %d", len(stats))
+	}
+}
+
+func TestForwardingEvents_Pagination(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	var events []ForwardingEvent
+	for i := 0; i < 10; i++ {
+		events = append(events, ForwardingEvent{
+			Timestamp:  now.Add(time.Duration(-i) * time.Hour),
+			ChanIDIn:   uint64(i + 1),
+			ChanIDOut:  uint64(i + 100),
+			AmtInMsat:  10000,
+			AmtOutMsat: 9000,
+			FeeMsat:    1000,
+		})
+	}
+	seedForwardingEvents(t, d, events)
+
+	from := now.Add(-24 * time.Hour)
+	to := now.Add(time.Hour)
+
+	// First page
+	page, err := d.ForwardingEvents(context.Background(), from, to, 3, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Total != 10 {
+		t.Errorf("expected total 10, got %d", page.Total)
+	}
+	if len(page.Events) != 3 {
+		t.Errorf("expected 3 events on page, got %d", len(page.Events))
+	}
+
+	// Second page
+	page, err = d.ForwardingEvents(context.Background(), from, to, 3, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Events) != 3 {
+		t.Errorf("expected 3 events on second page, got %d", len(page.Events))
+	}
+}
+
+func TestForwardingEvents_DateRange(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	seedForwardingEvents(t, d, []ForwardingEvent{
+		{Timestamp: now.Add(-72 * time.Hour), ChanIDIn: 1, ChanIDOut: 2, AmtInMsat: 10000, AmtOutMsat: 9000, FeeMsat: 1000},
+		{Timestamp: now.Add(-2 * time.Hour), ChanIDIn: 3, ChanIDOut: 4, AmtInMsat: 10000, AmtOutMsat: 9000, FeeMsat: 1000},
+	})
+
+	// Only last 24 hours
+	page, err := d.ForwardingEvents(context.Background(), now.Add(-24*time.Hour), now, 100, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Total != 1 {
+		t.Errorf("expected 1 event in range, got %d", page.Total)
+	}
+}
+
+func TestForwardingEvents_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	page, err := d.ForwardingEvents(context.Background(), now.Add(-24*time.Hour), now, 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Total != 0 {
+		t.Errorf("expected 0 total, got %d", page.Total)
+	}
+	if len(page.Events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(page.Events))
+	}
+}

--- a/internal/price/price.go
+++ b/internal/price/price.go
@@ -1,0 +1,119 @@
+package price
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Cache fetches and caches the BTC/USD price with a configurable TTL.
+type Cache struct {
+	mu        sync.RWMutex
+	price     float64
+	fetchedAt time.Time
+	ttl       time.Duration
+	apiURL    string
+	client    *http.Client
+}
+
+// Option configures the price cache.
+type Option func(*Cache)
+
+// WithTTL sets the cache time-to-live.
+func WithTTL(d time.Duration) Option {
+	return func(c *Cache) { c.ttl = d }
+}
+
+// WithAPIURL sets the price API URL.
+func WithAPIURL(url string) Option {
+	return func(c *Cache) { c.apiURL = url }
+}
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Cache) { c.client = client }
+}
+
+// NewCache creates a new price cache with the given options.
+func NewCache(opts ...Option) *Cache {
+	c := &Cache{
+		ttl:    5 * time.Minute,
+		apiURL: "https://mempool.space/api/v1/prices",
+		client: &http.Client{Timeout: 5 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// GetBTCPrice returns the cached BTC/USD price, fetching if stale.
+// If the fetch fails but a stale price exists, the stale price is returned.
+func (c *Cache) GetBTCPrice(ctx context.Context) (float64, error) {
+	c.mu.RLock()
+	if !c.fetchedAt.IsZero() && time.Since(c.fetchedAt) < c.ttl {
+		price := c.price
+		c.mu.RUnlock()
+		return price, nil
+	}
+	stalePrice := c.price
+	hasStale := !c.fetchedAt.IsZero()
+	c.mu.RUnlock()
+
+	// Fetch fresh price
+	price, err := c.fetch(ctx)
+	if err != nil {
+		if hasStale {
+			return stalePrice, nil
+		}
+		return 0, fmt.Errorf("fetch BTC price: %w", err)
+	}
+
+	c.mu.Lock()
+	c.price = price
+	c.fetchedAt = time.Now()
+	c.mu.Unlock()
+
+	return price, nil
+}
+
+// mempoolPriceResponse is the response from mempool.space /api/v1/prices.
+type mempoolPriceResponse struct {
+	USD float64 `json:"USD"`
+}
+
+func (c *Cache) fetch(ctx context.Context) (float64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	var prices mempoolPriceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&prices); err != nil {
+		return 0, fmt.Errorf("decode response: %w", err)
+	}
+
+	if prices.USD <= 0 {
+		return 0, fmt.Errorf("invalid price: %f", prices.USD)
+	}
+
+	return prices.USD, nil
+}
+
+// MsatToUSD converts millisatoshis to USD given a BTC price.
+func MsatToUSD(msat int64, btcPrice float64) float64 {
+	return (float64(msat) / 100_000_000_000.0) * btcPrice
+}

--- a/internal/price/price_test.go
+++ b/internal/price/price_test.go
@@ -1,0 +1,177 @@
+package price
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newTestServer(body string, statusCode int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		w.Write([]byte(body))
+	}))
+}
+
+func TestGetBTCPrice_FreshFetch(t *testing.T) {
+	srv := newTestServer(`{"USD": 67000.50}`, http.StatusOK)
+	defer srv.Close()
+
+	c := NewCache(WithAPIURL(srv.URL), WithTTL(5*time.Minute))
+	price, err := c.GetBTCPrice(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if price != 67000.50 {
+		t.Errorf("expected 67000.50, got %f", price)
+	}
+}
+
+func TestGetBTCPrice_CachedReturn(t *testing.T) {
+	var callCount int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&callCount, 1)
+		w.Write([]byte(`{"USD": 67000}`))
+	}))
+	defer srv.Close()
+
+	c := NewCache(WithAPIURL(srv.URL), WithTTL(5*time.Minute))
+
+	// First call fetches
+	_, err := c.GetBTCPrice(context.Background())
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Second call should use cache
+	_, err = c.GetBTCPrice(context.Background())
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	if atomic.LoadInt64(&callCount) != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", callCount)
+	}
+}
+
+func TestGetBTCPrice_CacheExpiry(t *testing.T) {
+	var callCount int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&callCount, 1)
+		w.Write([]byte(`{"USD": 67000}`))
+	}))
+	defer srv.Close()
+
+	c := NewCache(WithAPIURL(srv.URL), WithTTL(1*time.Millisecond))
+
+	_, _ = c.GetBTCPrice(context.Background())
+	time.Sleep(5 * time.Millisecond)
+	_, _ = c.GetBTCPrice(context.Background())
+
+	if atomic.LoadInt64(&callCount) != 2 {
+		t.Errorf("expected 2 HTTP calls after expiry, got %d", callCount)
+	}
+}
+
+func TestGetBTCPrice_FallbackOnError(t *testing.T) {
+	callNum := int64(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&callNum, 1)
+		if n == 1 {
+			w.Write([]byte(`{"USD": 67000}`))
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewCache(WithAPIURL(srv.URL), WithTTL(1*time.Millisecond))
+
+	// First call succeeds
+	price, err := c.GetBTCPrice(context.Background())
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if price != 67000 {
+		t.Errorf("expected 67000, got %f", price)
+	}
+
+	// Expire cache
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call fails but returns stale price
+	price, err = c.GetBTCPrice(context.Background())
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	if price != 67000 {
+		t.Errorf("expected stale price 67000, got %f", price)
+	}
+}
+
+func TestGetBTCPrice_NoCache_Error(t *testing.T) {
+	srv := newTestServer("", http.StatusInternalServerError)
+	defer srv.Close()
+
+	c := NewCache(WithAPIURL(srv.URL))
+	_, err := c.GetBTCPrice(context.Background())
+	if err == nil {
+		t.Fatal("expected error with no cache and failed fetch")
+	}
+}
+
+func TestGetBTCPrice_InvalidJSON(t *testing.T) {
+	srv := newTestServer("not json", http.StatusOK)
+	defer srv.Close()
+
+	c := NewCache(WithAPIURL(srv.URL))
+	_, err := c.GetBTCPrice(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestGetBTCPrice_ZeroPrice(t *testing.T) {
+	srv := newTestServer(`{"USD": 0}`, http.StatusOK)
+	defer srv.Close()
+
+	c := NewCache(WithAPIURL(srv.URL))
+	_, err := c.GetBTCPrice(context.Background())
+	if err == nil {
+		t.Fatal("expected error for zero price")
+	}
+}
+
+func TestMsatToUSD(t *testing.T) {
+	tests := []struct {
+		msat     int64
+		btcPrice float64
+		expected float64
+	}{
+		{100_000_000_000, 67000.0, 67000.0},  // 1 BTC
+		{1_000_000, 67000.0, 0.67},            // 1000 sats
+		{0, 67000.0, 0.0},
+		{1_000_000_000, 100000.0, 1000.0},     // 0.01 BTC at $100k
+	}
+
+	for _, tt := range tests {
+		got := MsatToUSD(tt.msat, tt.btcPrice)
+		if math.Abs(got-tt.expected) > 0.01 {
+			t.Errorf("MsatToUSD(%d, %f) = %f, want %f", tt.msat, tt.btcPrice, got, tt.expected)
+		}
+	}
+}
+
+func TestNewCache_Defaults(t *testing.T) {
+	c := NewCache()
+	if c.ttl != 5*time.Minute {
+		t.Errorf("expected default TTL 5m, got %v", c.ttl)
+	}
+	if c.apiURL != "https://mempool.space/api/v1/prices" {
+		t.Errorf("unexpected default API URL: %s", c.apiURL)
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -1,0 +1,339 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/lnd"
+)
+
+// DashboardStore defines the read operations needed by dashboard handlers.
+type DashboardStore interface {
+	FeeSummary(ctx context.Context, since time.Time) (int64, int64, error)
+	ActiveChannelCount(ctx context.Context) (int, error)
+	LatestWalletBalance(ctx context.Context) (*db.WalletBalanceSnapshot, error)
+	ChannelStats(ctx context.Context) ([]db.ChannelStat, error)
+	ForwardingEvents(ctx context.Context, from, to time.Time, limit, offset int) (*db.ForwardingPage, error)
+}
+
+// NodeInfoProvider fetches node info from LND.
+type NodeInfoProvider interface {
+	GetInfo(ctx context.Context) (*lnd.NodeInfo, error)
+}
+
+// PriceProvider fetches the current BTC/USD price.
+type PriceProvider interface {
+	GetBTCPrice(ctx context.Context) (float64, error)
+}
+
+// Handler serves dashboard API endpoints.
+type Handler struct {
+	store  DashboardStore
+	node   NodeInfoProvider
+	price  PriceProvider
+	logger *log.Logger
+}
+
+// NewHandler creates a new Handler.
+func NewHandler(store DashboardStore, node NodeInfoProvider, price PriceProvider, logger *log.Logger) *Handler {
+	return &Handler{
+		store:  store,
+		node:   node,
+		price:  price,
+		logger: logger,
+	}
+}
+
+// --- JSON response types ---
+
+type feeWindow struct {
+	Sats int64    `json:"sats"`
+	USD  *float64 `json:"usd,omitempty"`
+}
+
+type summaryResponse struct {
+	Fees struct {
+		AllTime feeWindow `json:"all_time"`
+		Last30d feeWindow `json:"last_30d"`
+		Last7d  feeWindow `json:"last_7d"`
+	} `json:"fees"`
+	Routed struct {
+		AllTime int64 `json:"all_time"`
+		Last30d int64 `json:"last_30d"`
+		Last7d  int64 `json:"last_7d"`
+	} `json:"routed"`
+	WalletBalanceSats int64    `json:"wallet_balance_sats"`
+	ActiveChannels    int      `json:"active_channels"`
+	BTCPriceUSD       *float64 `json:"btc_price_usd"`
+}
+
+type channelResponse struct {
+	ChanID               uint64   `json:"chan_id,string"`
+	RemotePubKey         string   `json:"remote_pubkey"`
+	LocalBalance         int64    `json:"local_balance"`
+	RemoteBalance        int64    `json:"remote_balance"`
+	Active               bool     `json:"active"`
+	FeesEarnedAllTimeSats int64   `json:"fees_earned_all_time_sats"`
+	FeesEarned30dSats    int64    `json:"fees_earned_30d_sats"`
+	FeesEarnedAllTimeUSD *float64 `json:"fees_earned_all_time_usd,omitempty"`
+	FeesEarned30dUSD     *float64 `json:"fees_earned_30d_usd,omitempty"`
+}
+
+type forwardingEventResponse struct {
+	Timestamp  time.Time `json:"timestamp"`
+	ChanIDIn   uint64    `json:"chan_id_in,string"`
+	ChanIDOut  uint64    `json:"chan_id_out,string"`
+	AmtInMsat  int64     `json:"amt_in_msat"`
+	AmtOutMsat int64     `json:"amt_out_msat"`
+	FeeMsat    int64     `json:"fee_msat"`
+}
+
+type paginationMeta struct {
+	Page  int   `json:"page"`
+	Limit int   `json:"limit"`
+	Total int64 `json:"total"`
+}
+
+type forwardingResponse struct {
+	Events     []forwardingEventResponse `json:"events"`
+	Pagination paginationMeta            `json:"pagination"`
+}
+
+type nodeResponse struct {
+	Alias             string `json:"alias"`
+	PubKey            string `json:"pubkey"`
+	Synced            bool   `json:"synced"`
+	NumActiveChannels uint32 `json:"num_active_channels"`
+	NumPeers          uint32 `json:"num_peers"`
+	BlockHeight       uint32 `json:"block_height"`
+	Version           string `json:"version"`
+}
+
+// --- Handlers ---
+
+// HandleSummary serves GET /api/summary.
+func (h *Handler) HandleSummary(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	now := time.Now()
+	since30d := now.AddDate(0, 0, -30)
+	since7d := now.AddDate(0, 0, -7)
+
+	feesAll, routedAll, err := h.store.FeeSummary(ctx, time.Time{})
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "failed to query fee summary")
+		return
+	}
+
+	fees30d, routed30d, err := h.store.FeeSummary(ctx, since30d)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "failed to query 30d fee summary")
+		return
+	}
+
+	fees7d, routed7d, err := h.store.FeeSummary(ctx, since7d)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "failed to query 7d fee summary")
+		return
+	}
+
+	activeChannels, err := h.store.ActiveChannelCount(ctx)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "failed to query active channels")
+		return
+	}
+
+	balance, err := h.store.LatestWalletBalance(ctx)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "failed to query wallet balance")
+		return
+	}
+
+	resp := summaryResponse{
+		ActiveChannels: activeChannels,
+	}
+	resp.Fees.AllTime = feeWindow{Sats: msatToSat(feesAll)}
+	resp.Fees.Last30d = feeWindow{Sats: msatToSat(fees30d)}
+	resp.Fees.Last7d = feeWindow{Sats: msatToSat(fees7d)}
+	resp.Routed.AllTime = routedAll
+	resp.Routed.Last30d = routed30d
+	resp.Routed.Last7d = routed7d
+
+	if balance != nil {
+		resp.WalletBalanceSats = balance.TotalSat
+	}
+
+	// Add USD values if price is available
+	btcPrice, err := h.price.GetBTCPrice(ctx)
+	if err == nil && btcPrice > 0 {
+		resp.BTCPriceUSD = &btcPrice
+		usdAll := msatToUSD(feesAll, btcPrice)
+		usd30d := msatToUSD(fees30d, btcPrice)
+		usd7d := msatToUSD(fees7d, btcPrice)
+		resp.Fees.AllTime.USD = &usdAll
+		resp.Fees.Last30d.USD = &usd30d
+		resp.Fees.Last7d.USD = &usd7d
+	}
+
+	h.writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleChannels serves GET /api/channels.
+func (h *Handler) HandleChannels(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	stats, err := h.store.ChannelStats(ctx)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "failed to query channel stats")
+		return
+	}
+
+	btcPrice, priceErr := h.price.GetBTCPrice(ctx)
+	hasPrice := priceErr == nil && btcPrice > 0
+
+	channels := make([]channelResponse, len(stats))
+	for i, s := range stats {
+		channels[i] = channelResponse{
+			ChanID:                s.ChanID,
+			RemotePubKey:          s.RemotePubKey,
+			LocalBalance:          s.LocalBalance,
+			RemoteBalance:         s.RemoteBalance,
+			Active:                s.Active,
+			FeesEarnedAllTimeSats: msatToSat(s.FeesEarnedAllTimeMsat),
+			FeesEarned30dSats:     msatToSat(s.FeesEarned30dMsat),
+		}
+		if hasPrice {
+			usdAll := msatToUSD(s.FeesEarnedAllTimeMsat, btcPrice)
+			usd30d := msatToUSD(s.FeesEarned30dMsat, btcPrice)
+			channels[i].FeesEarnedAllTimeUSD = &usdAll
+			channels[i].FeesEarned30dUSD = &usd30d
+		}
+	}
+
+	h.writeJSON(w, http.StatusOK, channels)
+}
+
+// HandleForwarding serves GET /api/forwarding.
+func (h *Handler) HandleForwarding(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	from, err := parseTimeParam(r, "from", time.Now().AddDate(0, 0, -30))
+	if err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid 'from' parameter: use RFC3339 format")
+		return
+	}
+
+	to, err := parseTimeParam(r, "to", time.Now())
+	if err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid 'to' parameter: use RFC3339 format")
+		return
+	}
+
+	page := parseIntParam(r, "page", 1)
+	if page < 1 {
+		page = 1
+	}
+
+	limit := parseIntParam(r, "limit", 50)
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset := (page - 1) * limit
+
+	result, err := h.store.ForwardingEvents(ctx, from, to, limit, offset)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "failed to query forwarding events")
+		return
+	}
+
+	events := make([]forwardingEventResponse, len(result.Events))
+	for i, e := range result.Events {
+		events[i] = forwardingEventResponse{
+			Timestamp:  e.Timestamp,
+			ChanIDIn:   e.ChanIDIn,
+			ChanIDOut:  e.ChanIDOut,
+			AmtInMsat:  e.AmtInMsat,
+			AmtOutMsat: e.AmtOutMsat,
+			FeeMsat:    e.FeeMsat,
+		}
+	}
+
+	h.writeJSON(w, http.StatusOK, forwardingResponse{
+		Events: events,
+		Pagination: paginationMeta{
+			Page:  page,
+			Limit: limit,
+			Total: result.Total,
+		},
+	})
+}
+
+// HandleNode serves GET /api/node.
+func (h *Handler) HandleNode(w http.ResponseWriter, r *http.Request) {
+	info, err := h.node.GetInfo(r.Context())
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "failed to get node info")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, nodeResponse{
+		Alias:             info.Alias,
+		PubKey:            info.PubKey,
+		Synced:            info.Synced,
+		NumActiveChannels: info.NumActiveChannels,
+		NumPeers:          info.NumPeers,
+		BlockHeight:       info.BlockHeight,
+		Version:           info.Version,
+	})
+}
+
+// --- Helpers ---
+
+func (h *Handler) writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		h.logger.Printf("failed to encode JSON response: %v", err)
+	}
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, status int, msg string) {
+	h.writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func parseTimeParam(r *http.Request, key string, defaultVal time.Time) (time.Time, error) {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return defaultVal, nil
+	}
+	return time.Parse(time.RFC3339, v)
+}
+
+func parseIntParam(r *http.Request, key string, defaultVal int) int {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return defaultVal
+	}
+	return n
+}
+
+func msatToSat(msat int64) int64 {
+	return msat / 1000
+}
+
+func msatToUSD(msat int64, btcPrice float64) float64 {
+	return (float64(msat) / 100_000_000_000.0) * btcPrice
+}

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -1,0 +1,477 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/lnd"
+)
+
+// --- Mock implementations ---
+
+type mockStore struct {
+	feeSummaryFn        func(ctx context.Context, since time.Time) (int64, int64, error)
+	activeChannelFn     func(ctx context.Context) (int, error)
+	latestWalletFn      func(ctx context.Context) (*db.WalletBalanceSnapshot, error)
+	channelStatsFn      func(ctx context.Context) ([]db.ChannelStat, error)
+	forwardingEventsFn  func(ctx context.Context, from, to time.Time, limit, offset int) (*db.ForwardingPage, error)
+}
+
+func (m *mockStore) FeeSummary(ctx context.Context, since time.Time) (int64, int64, error) {
+	return m.feeSummaryFn(ctx, since)
+}
+func (m *mockStore) ActiveChannelCount(ctx context.Context) (int, error) {
+	return m.activeChannelFn(ctx)
+}
+func (m *mockStore) LatestWalletBalance(ctx context.Context) (*db.WalletBalanceSnapshot, error) {
+	return m.latestWalletFn(ctx)
+}
+func (m *mockStore) ChannelStats(ctx context.Context) ([]db.ChannelStat, error) {
+	return m.channelStatsFn(ctx)
+}
+func (m *mockStore) ForwardingEvents(ctx context.Context, from, to time.Time, limit, offset int) (*db.ForwardingPage, error) {
+	return m.forwardingEventsFn(ctx, from, to, limit, offset)
+}
+
+type mockNodeInfo struct {
+	info *lnd.NodeInfo
+	err  error
+}
+
+func (m *mockNodeInfo) GetInfo(ctx context.Context) (*lnd.NodeInfo, error) {
+	return m.info, m.err
+}
+
+type mockPrice struct {
+	price float64
+	err   error
+}
+
+func (m *mockPrice) GetBTCPrice(ctx context.Context) (float64, error) {
+	return m.price, m.err
+}
+
+func newTestHandler(store DashboardStore, node NodeInfoProvider, price PriceProvider) *Handler {
+	return NewHandler(store, node, price, log.New(os.Stderr, "[test] ", 0))
+}
+
+// --- HandleSummary tests ---
+
+func TestHandleSummary_Success(t *testing.T) {
+	store := &mockStore{
+		feeSummaryFn: func(_ context.Context, since time.Time) (int64, int64, error) {
+			if since.IsZero() {
+				return 6000, 3, nil // all-time
+			}
+			return 3000, 2, nil // 30d or 7d
+		},
+		activeChannelFn: func(_ context.Context) (int, error) { return 5, nil },
+		latestWalletFn: func(_ context.Context) (*db.WalletBalanceSnapshot, error) {
+			return &db.WalletBalanceSnapshot{TotalSat: 100000}, nil
+		},
+	}
+	price := &mockPrice{price: 67000.0}
+	h := newTestHandler(store, nil, price)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/summary", nil)
+	w := httptest.NewRecorder()
+	h.HandleSummary(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp summaryResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if resp.Fees.AllTime.Sats != 6 {
+		t.Errorf("expected all-time fees 6 sats (6000 msat / 1000), got %d", resp.Fees.AllTime.Sats)
+	}
+	if resp.ActiveChannels != 5 {
+		t.Errorf("expected 5 active channels, got %d", resp.ActiveChannels)
+	}
+	if resp.WalletBalanceSats != 100000 {
+		t.Errorf("expected balance 100000, got %d", resp.WalletBalanceSats)
+	}
+	if resp.BTCPriceUSD == nil || *resp.BTCPriceUSD != 67000.0 {
+		t.Errorf("expected BTC price 67000, got %v", resp.BTCPriceUSD)
+	}
+	if resp.Fees.AllTime.USD == nil {
+		t.Error("expected USD fee to be set")
+	}
+}
+
+func TestHandleSummary_NilBalance(t *testing.T) {
+	store := &mockStore{
+		feeSummaryFn:    func(_ context.Context, _ time.Time) (int64, int64, error) { return 0, 0, nil },
+		activeChannelFn: func(_ context.Context) (int, error) { return 0, nil },
+		latestWalletFn:  func(_ context.Context) (*db.WalletBalanceSnapshot, error) { return nil, nil },
+	}
+	price := &mockPrice{err: errors.New("no price")}
+	h := newTestHandler(store, nil, price)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/summary", nil)
+	w := httptest.NewRecorder()
+	h.HandleSummary(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp summaryResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if resp.WalletBalanceSats != 0 {
+		t.Errorf("expected 0 balance when nil, got %d", resp.WalletBalanceSats)
+	}
+	if resp.BTCPriceUSD != nil {
+		t.Errorf("expected nil BTC price on error, got %v", resp.BTCPriceUSD)
+	}
+}
+
+func TestHandleSummary_StoreError(t *testing.T) {
+	store := &mockStore{
+		feeSummaryFn: func(_ context.Context, _ time.Time) (int64, int64, error) {
+			return 0, 0, errors.New("db error")
+		},
+	}
+	h := newTestHandler(store, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/summary", nil)
+	w := httptest.NewRecorder()
+	h.HandleSummary(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+// --- HandleChannels tests ---
+
+func TestHandleChannels_Success(t *testing.T) {
+	store := &mockStore{
+		channelStatsFn: func(_ context.Context) ([]db.ChannelStat, error) {
+			return []db.ChannelStat{
+				{ChanID: 100, RemotePubKey: "abc", LocalBalance: 50000, RemoteBalance: 50000, Active: true, FeesEarnedAllTimeMsat: 5000, FeesEarned30dMsat: 2000},
+				{ChanID: 200, RemotePubKey: "def", LocalBalance: 30000, RemoteBalance: 70000, Active: false, FeesEarnedAllTimeMsat: 1000, FeesEarned30dMsat: 500},
+			}, nil
+		},
+	}
+	price := &mockPrice{price: 67000.0}
+	h := newTestHandler(store, nil, price)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/channels", nil)
+	w := httptest.NewRecorder()
+	h.HandleChannels(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var channels []channelResponse
+	if err := json.NewDecoder(w.Body).Decode(&channels); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if len(channels) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(channels))
+	}
+	if channels[0].FeesEarnedAllTimeSats != 5 {
+		t.Errorf("expected 5 sats, got %d", channels[0].FeesEarnedAllTimeSats)
+	}
+	if channels[0].FeesEarnedAllTimeUSD == nil {
+		t.Error("expected USD fee to be set")
+	}
+}
+
+func TestHandleChannels_NoPriceAvailable(t *testing.T) {
+	store := &mockStore{
+		channelStatsFn: func(_ context.Context) ([]db.ChannelStat, error) {
+			return []db.ChannelStat{
+				{ChanID: 100, RemotePubKey: "abc", Active: true, FeesEarnedAllTimeMsat: 5000},
+			}, nil
+		},
+	}
+	price := &mockPrice{err: errors.New("no price")}
+	h := newTestHandler(store, nil, price)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/channels", nil)
+	w := httptest.NewRecorder()
+	h.HandleChannels(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var channels []channelResponse
+	if err := json.NewDecoder(w.Body).Decode(&channels); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if channels[0].FeesEarnedAllTimeUSD != nil {
+		t.Errorf("expected nil USD when price unavailable, got %v", channels[0].FeesEarnedAllTimeUSD)
+	}
+}
+
+func TestHandleChannels_StoreError(t *testing.T) {
+	store := &mockStore{
+		channelStatsFn: func(_ context.Context) ([]db.ChannelStat, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	h := newTestHandler(store, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/channels", nil)
+	w := httptest.NewRecorder()
+	h.HandleChannels(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+// --- HandleForwarding tests ---
+
+func TestHandleForwarding_Success(t *testing.T) {
+	now := time.Now().UTC()
+	store := &mockStore{
+		forwardingEventsFn: func(_ context.Context, _, _ time.Time, limit, offset int) (*db.ForwardingPage, error) {
+			if limit != 50 || offset != 0 {
+				t.Errorf("expected default limit=50, offset=0, got limit=%d, offset=%d", limit, offset)
+			}
+			return &db.ForwardingPage{
+				Events: []db.ForwardingEvent{
+					{Timestamp: now, ChanIDIn: 1, ChanIDOut: 2, AmtInMsat: 10000, AmtOutMsat: 9000, FeeMsat: 1000},
+				},
+				Total: 1,
+			}, nil
+		},
+	}
+	h := newTestHandler(store, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/forwarding", nil)
+	w := httptest.NewRecorder()
+	h.HandleForwarding(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp forwardingResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if resp.Pagination.Total != 1 {
+		t.Errorf("expected total 1, got %d", resp.Pagination.Total)
+	}
+	if resp.Pagination.Page != 1 {
+		t.Errorf("expected page 1, got %d", resp.Pagination.Page)
+	}
+	if len(resp.Events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(resp.Events))
+	}
+}
+
+func TestHandleForwarding_Pagination(t *testing.T) {
+	store := &mockStore{
+		forwardingEventsFn: func(_ context.Context, _, _ time.Time, limit, offset int) (*db.ForwardingPage, error) {
+			if limit != 10 || offset != 20 {
+				t.Errorf("expected limit=10, offset=20 (page 3), got limit=%d, offset=%d", limit, offset)
+			}
+			return &db.ForwardingPage{Events: nil, Total: 50}, nil
+		},
+	}
+	h := newTestHandler(store, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/forwarding?page=3&limit=10", nil)
+	w := httptest.NewRecorder()
+	h.HandleForwarding(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandleForwarding_LimitCapped(t *testing.T) {
+	store := &mockStore{
+		forwardingEventsFn: func(_ context.Context, _, _ time.Time, limit, _ int) (*db.ForwardingPage, error) {
+			if limit != 100 {
+				t.Errorf("expected limit capped to 100, got %d", limit)
+			}
+			return &db.ForwardingPage{Events: nil, Total: 0}, nil
+		},
+	}
+	h := newTestHandler(store, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/forwarding?limit=500", nil)
+	w := httptest.NewRecorder()
+	h.HandleForwarding(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandleForwarding_InvalidFrom(t *testing.T) {
+	h := newTestHandler(&mockStore{}, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/forwarding?from=bad", nil)
+	w := httptest.NewRecorder()
+	h.HandleForwarding(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleForwarding_StoreError(t *testing.T) {
+	store := &mockStore{
+		forwardingEventsFn: func(_ context.Context, _, _ time.Time, _, _ int) (*db.ForwardingPage, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	h := newTestHandler(store, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/forwarding", nil)
+	w := httptest.NewRecorder()
+	h.HandleForwarding(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+// --- HandleNode tests ---
+
+func TestHandleNode_Success(t *testing.T) {
+	node := &mockNodeInfo{
+		info: &lnd.NodeInfo{
+			Alias:             "my-node",
+			PubKey:            "02abc",
+			Synced:            true,
+			NumActiveChannels: 3,
+			NumPeers:          5,
+			BlockHeight:       800000,
+			Version:           "0.17.0",
+		},
+	}
+	h := newTestHandler(&mockStore{}, node, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/node", nil)
+	w := httptest.NewRecorder()
+	h.HandleNode(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp nodeResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if resp.Alias != "my-node" {
+		t.Errorf("expected alias 'my-node', got %q", resp.Alias)
+	}
+	if resp.PubKey != "02abc" {
+		t.Errorf("expected pubkey '02abc', got %q", resp.PubKey)
+	}
+	if !resp.Synced {
+		t.Error("expected synced to be true")
+	}
+	if resp.BlockHeight != 800000 {
+		t.Errorf("expected block height 800000, got %d", resp.BlockHeight)
+	}
+}
+
+func TestHandleNode_Error(t *testing.T) {
+	node := &mockNodeInfo{err: errors.New("lnd unavailable")}
+	h := newTestHandler(&mockStore{}, node, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/node", nil)
+	w := httptest.NewRecorder()
+	h.HandleNode(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+// --- Helper tests ---
+
+func TestMsatToSat(t *testing.T) {
+	tests := []struct {
+		msat     int64
+		expected int64
+	}{
+		{0, 0},
+		{1000, 1},
+		{999, 0},
+		{5500, 5},
+		{100_000_000_000, 100_000_000},
+	}
+	for _, tt := range tests {
+		got := msatToSat(tt.msat)
+		if got != tt.expected {
+			t.Errorf("msatToSat(%d) = %d, want %d", tt.msat, got, tt.expected)
+		}
+	}
+}
+
+func TestMsatToUSD(t *testing.T) {
+	got := msatToUSD(100_000_000_000, 67000.0)
+	if got != 67000.0 {
+		t.Errorf("msatToUSD(1 BTC, $67k) = %f, want 67000", got)
+	}
+}
+
+func TestParseIntParam(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/test?a=5&b=bad", nil)
+	if got := parseIntParam(req, "a", 1); got != 5 {
+		t.Errorf("expected 5, got %d", got)
+	}
+	if got := parseIntParam(req, "b", 1); got != 1 {
+		t.Errorf("expected default 1 for bad param, got %d", got)
+	}
+	if got := parseIntParam(req, "missing", 42); got != 42 {
+		t.Errorf("expected default 42, got %d", got)
+	}
+}
+
+func TestParseTimeParam(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/test?t=2024-01-15T10:00:00Z", nil)
+	defaultTime := time.Now()
+
+	got, err := parseTimeParam(req, "t", defaultTime)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	if !got.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, got)
+	}
+
+	// Missing param returns default
+	got, err = parseTimeParam(req, "missing", defaultTime)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(defaultTime) {
+		t.Errorf("expected default time, got %v", got)
+	}
+
+	// Invalid format returns error
+	req = httptest.NewRequest(http.MethodGet, "/test?t=invalid", nil)
+	_, err = parseTimeParam(req, "t", defaultTime)
+	if err == nil {
+		t.Error("expected error for invalid time format")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,0 +1,71 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+// Server is the HTTP server for the dashboard API.
+type Server struct {
+	httpServer *http.Server
+	logger     *log.Logger
+}
+
+// NewServer creates a new HTTP server with routing and middleware.
+func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/summary", handler.HandleSummary)
+	mux.HandleFunc("/api/channels", handler.HandleChannels)
+	mux.HandleFunc("/api/forwarding", handler.HandleForwarding)
+	mux.HandleFunc("/api/node", handler.HandleNode)
+
+	return &Server{
+		httpServer: &http.Server{
+			Addr:         fmt.Sprintf(":%d", port),
+			Handler:      requestLogger(mux, logger),
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+			IdleTimeout:  60 * time.Second,
+		},
+		logger: logger,
+	}
+}
+
+// Start begins listening for HTTP requests. It blocks until the server is shut down.
+func (s *Server) Start() error {
+	s.logger.Printf("HTTP server listening on %s", s.httpServer.Addr)
+	err := s.httpServer.ListenAndServe()
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}
+
+// Shutdown gracefully shuts down the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.httpServer.Shutdown(ctx)
+}
+
+// requestLogger is middleware that logs each HTTP request.
+func requestLogger(next http.Handler, logger *log.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(rw, r)
+		logger.Printf("%s %s %d %s", r.Method, r.URL.Path, rw.statusCode, time.Since(start).Round(time.Millisecond))
+	})
+}
+
+// responseWriter wraps http.ResponseWriter to capture the status code.
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,0 +1,81 @@
+package web
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/satsbook/satsbook/internal/db"
+)
+
+func TestNewServer_RoutesRegistered(t *testing.T) {
+	store := &mockStore{
+		feeSummaryFn:    func(_ context.Context, _ time.Time) (int64, int64, error) { return 0, 0, nil },
+		activeChannelFn: func(_ context.Context) (int, error) { return 0, nil },
+		latestWalletFn:  func(_ context.Context) (*db.WalletBalanceSnapshot, error) { return nil, nil },
+	}
+	price := &mockPrice{err: nil}
+	logger := log.New(os.Stderr, "[test] ", 0)
+	h := NewHandler(store, nil, price, logger)
+	srv := NewServer(h, 0, logger)
+
+	if srv.httpServer == nil {
+		t.Fatal("expected httpServer to be set")
+	}
+	if srv.httpServer.ReadTimeout != 10*time.Second {
+		t.Errorf("expected ReadTimeout 10s, got %v", srv.httpServer.ReadTimeout)
+	}
+}
+
+func TestServer_StartAndShutdown(t *testing.T) {
+	store := &mockStore{
+		feeSummaryFn:    func(_ context.Context, _ time.Time) (int64, int64, error) { return 0, 0, nil },
+		activeChannelFn: func(_ context.Context) (int, error) { return 0, nil },
+		latestWalletFn:  func(_ context.Context) (*db.WalletBalanceSnapshot, error) { return nil, nil },
+	}
+	logger := log.New(os.Stderr, "[test] ", 0)
+	h := NewHandler(store, nil, &mockPrice{}, logger)
+	// Use port 0 to let the OS pick a free port
+	srv := NewServer(h, 0, logger)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Start()
+	}()
+
+	// Give server a moment to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Shutdown
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown error: %v", err)
+	}
+
+	// Start should return nil (ErrServerClosed is swallowed)
+	if err := <-errCh; err != nil {
+		t.Errorf("expected nil from Start after shutdown, got: %v", err)
+	}
+}
+
+func TestResponseWriter_CapturesStatusCode(t *testing.T) {
+	recorder := &responseWriter{
+		ResponseWriter: &noopResponseWriter{},
+		statusCode:     http.StatusOK,
+	}
+	recorder.WriteHeader(http.StatusNotFound)
+	if recorder.statusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", recorder.statusCode)
+	}
+}
+
+// noopResponseWriter is a minimal ResponseWriter for unit testing.
+type noopResponseWriter struct{}
+
+func (n *noopResponseWriter) Header() http.Header        { return http.Header{} }
+func (n *noopResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (n *noopResponseWriter) WriteHeader(int)             {}


### PR DESCRIPTION
Closes #7

## Summary

Implements Task 1.1 — Fee income dashboard (backend) with 4 JSON API endpoints:

- **GET /api/summary** — Aggregate fees (all-time, 30d, 7d) in sats + USD, routed event counts, wallet balance, active channels, BTC price
- **GET /api/channels** — Per-channel stats with fee aggregations (all-time + 30d), local/remote balances
- **GET /api/forwarding** — Paginated forwarding events with date range filtering (`from`, `to`, `page`, `limit`)
- **GET /api/node** — Node info (alias, pubkey, synced status, version, block height)

### Supporting infrastructure
- **BTC/USD price cache** (`internal/price`) — mempool.space API with 5-min TTL and stale fallback on errors
- **Dashboard read queries** (`internal/db/queries.go`) — Fee summaries, channel stats with JOIN aggregation, paginated forwarding events
- **SQLite indexes** (Migration 2) — Indexes on `timestamp`, `chan_id_in`, `chan_id_out` for query performance
- **WAL mode** — Enables concurrent read/write (syncer writes while HTTP serves reads)
- **HTTP server** (`internal/web/server.go`) — Request logging middleware, graceful shutdown
- **Config** — Added `SATSBOOK_PRICE_API_URL` env var
- **main.go** — Wired HTTP server alongside syncer with signal-based graceful shutdown

### Design decisions
- Use-site interfaces (`DashboardStore`, `NodeInfoProvider`, `PriceProvider`) for testability
- Chan IDs serialized as strings in JSON to avoid JS precision loss with uint64
- USD fields are `*float64` with `omitempty` — null when price is unavailable
- Limit parameter capped at 100 to prevent large result sets

## Test plan
- [x] All 17 handler tests pass (mocked store, node, price interfaces)
- [x] All 3 server tests pass (routing, start/shutdown, response writer)
- [x] All 8 price cache tests pass (fetch, cache, expiry, stale fallback, edge cases)
- [x] All 12 query tests pass (empty tables, date ranges, pagination, channel aggregation)
- [x] `go vet ./...` clean
- [x] Web package coverage: 85.9%
- [x] Price package coverage: 90.9%
- [x] Manual test against LND node on swamp server