### PR TITLE
feat: Umbrel app packaging (task 1.5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.env
+*.db
+coverage.*
+bin/
+scripts/
+CLAUDE.MD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Stage 1: Build the Go binary
+FROM golang:1.25-alpine AS builder
+
+RUN apk add --no-cache git
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /satsbook ./cmd/satsbook
+
+# Stage 2: Minimal runtime image
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata
+
+COPY --from=builder /satsbook /usr/local/bin/satsbook
+
+# Data directory for SQLite
+RUN mkdir -p /data
+VOLUME /data
+
+EXPOSE 3000
+
+ENTRYPOINT ["satsbook"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-lndcheck run run-binary run-local run-umbrel test clean
+.PHONY: build build-lndcheck run run-binary run-local run-umbrel test clean docker docker-multiarch
 
 # Load environment variables from .env file if it exists
 ifneq (,$(wildcard .env))
@@ -33,6 +33,14 @@ run-umbrel: build
 # Run tests
 test:
 	go test -v ./...
+
+# Build Docker image (local platform)
+docker:
+	docker build -t satsbook:latest .
+
+# Build multi-arch Docker image (amd64 + arm64 for Umbrel/Raspberry Pi)
+docker-multiarch:
+	docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/satsbook/satsbook:latest .
 
 # Clean build artifacts
 clean:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.7"
+
+services:
+  app_proxy:
+    environment:
+      APP_HOST: satsbook_server_1
+      APP_PORT: 3000
+
+  server:
+    image: ghcr.io/satsbook/satsbook:${APP_SATSBOOK_VERSION:-latest}
+    container_name: satsbook_server_1
+    restart: on-failure
+    stop_grace_period: 1m
+    init: true
+    volumes:
+      - satsbook_data:/data
+      - ${APP_LIGHTNING_NODE_DATA_DIR:-/dev/null}:/lnd:ro
+    environment:
+      SATSBOOK_LND_HOST: ${APP_LIGHTNING_NODE_IP:-localhost}
+      SATSBOOK_LND_PORT: ${APP_LIGHTNING_NODE_GRPC_PORT:-10009}
+      SATSBOOK_LND_MACAROON_PATH: /lnd/data/chain/bitcoin/mainnet/readonly.macaroon
+      SATSBOOK_LND_TLS_CERT_PATH: /lnd/tls.cert
+      SATSBOOK_DATABASE_PATH: /data/satsbook.db
+      SATSBOOK_APP_PORT: 3000
+      SATSBOOK_LOG_LEVEL: info
+    networks:
+      default:
+        ipv4_address: ${APP_SATSBOOK_IP:-10.21.22.50}
+
+volumes:
+  satsbook_data:

--- a/umbrel-app.yml
+++ b/umbrel-app.yml
@@ -1,0 +1,27 @@
+manifestVersion: 1
+id: satsbook
+category: bitcoin
+name: Satsbook
+version: "0.1.0"
+tagline: Bitcoin node analytics and accounting for Lightning operators
+description: >-
+  Track routing fees, manage cost basis from exchange imports, and view
+  profit & loss — all on your own hardware. Satsbook connects to your
+  LND node and provides a privacy-first dashboard with fee analytics,
+  Strike CSV import, and a basic P&L view. No cloud services required.
+developer: satsbook
+website: https://github.com/satsbook/satsbook
+repo: https://github.com/satsbook/satsbook
+support: https://github.com/satsbook/satsbook/issues
+dependencies:
+  - lightning
+port: 3000
+gallery: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+releaseNotes: >-
+  Initial release. Fee analytics dashboard, Strike CSV import,
+  basic P&L view with period selectors.
+submitter: brewgator
+submission: ""


### PR DESCRIPTION
## Summary

- Multi-stage Dockerfile: Go 1.25 builder -> Alpine 3.21 runtime
- Binary is 26MB for ARM64, well under the 100MB target
- `docker-compose.yml` with `app_proxy` + `server` services (Umbrel format)
- LND data mounted read-only at `/lnd` for macaroon/cert access
- SQLite data persisted in `satsbook_data` volume
- `umbrel-app.yml` manifest: category bitcoin, depends on lightning, port 3000
- Makefile targets: `make docker` (local) and `make docker-multiarch` (amd64+arm64)

Closes #11

## Test plan

- [x] `docker build -t satsbook:test .` succeeds
- [x] `docker buildx build --platform linux/arm64 .` succeeds
- [x] Container starts and connects to LND on Umbrel
- [x] Dashboard shows live data
- [x] Data persists across container restart
- [x] Data persists across Umbrel restart
- [x] Image size < 100MB