### PR TITLE
feat: River CSV import parser (task 1.8)

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -387,6 +387,80 @@ func (d *DB) ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*I
 	return summary, nil
 }
 
+// ImportRiverCSV imports parsed River CSV rows into exchange_imports and btc_lots.
+// The entire operation runs in a single transaction.
+func (d *DB) ImportRiverCSV(ctx context.Context, rows []exchange.RiverRow) (*ImportSummary, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin import transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	summary := &ImportSummary{Total: len(rows)}
+
+	for _, row := range rows {
+		rawData, _ := json.Marshal(row)
+
+		h := sha256.Sum256([]byte(row.RawLine))
+		contentHash := hex.EncodeToString(h[:])
+
+		res, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO exchange_imports (source, external_id, tx_type, raw_data)
+			 VALUES (?, ?, ?, ?)`,
+			"river", contentHash, row.Type, string(rawData),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("insert exchange import: %w", err)
+		}
+
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("rows affected: %w", err)
+		}
+
+		if affected == 0 {
+			summary.Duplicates++
+			continue
+		}
+
+		// Create btc_lot for completed purchases
+		if row.IsPurchase() && row.AmountSat > 0 {
+			var exists int
+			err := tx.QueryRowContext(ctx,
+				`SELECT 1 FROM btc_lots WHERE source = ? AND external_id = ?`,
+				"river", contentHash,
+			).Scan(&exists)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("check btc_lot %q: %w", contentHash, err)
+			}
+			if errors.Is(err, sql.ErrNoRows) {
+				priceUSD := row.CostBasisUSD
+				if priceUSD == 0 {
+					priceUSD = row.AmountUSD
+				}
+				if priceUSD == 0 {
+					continue
+				}
+				_, err = tx.ExecContext(ctx,
+					`INSERT INTO btc_lots (acquired_at, amount_sat, price_usd, source, external_id)
+					 VALUES (?, ?, ?, ?, ?)`,
+					row.Date, row.AmountSat, priceUSD, "river", contentHash,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("insert btc_lot %q: %w", contentHash, err)
+				}
+				summary.NewPurchases++
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit import: %w", err)
+	}
+
+	return summary, nil
+}
+
 // ExchangeBalance returns the net BTC balance (in sats) for a given exchange source
 // by summing AmountBTC only from rows that actually move BTC (non-zero AmountBTC).
 // USD-only transactions (e.g. cash withdrawals) are excluded.

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -718,3 +718,186 @@ func TestExchangeSummary_DateFiltering(t *testing.T) {
 		t.Errorf("filtered cost basis: expected 150.00, got %f", filtered.TotalCostBasisUSD)
 	}
 }
+
+// --- River CSV import tests ---
+
+func testRiverRows() []exchange.RiverRow {
+	return []exchange.RiverRow{
+		{
+			Date:         time.Date(2024, 9, 26, 19, 59, 41, 0, time.UTC),
+			Type:         "buy",
+			AmountBTC:    0.00006093,
+			AmountSat:    6093,
+			AmountUSD:    3.96,
+			FeeUSD:       0.04,
+			CostBasisUSD: 3.96,
+			RawLine:      "2024-09-26 19:59:41,3.96,USD,0.00006093,BTC,0.04,USD,Buy",
+		},
+		{
+			Date:         time.Date(2024, 10, 3, 20, 0, 2, 0, time.UTC),
+			Type:         "buy",
+			AmountBTC:    0.00006536,
+			AmountSat:    6536,
+			AmountUSD:    4.00,
+			CostBasisUSD: 4.00,
+			RawLine:      "2024-10-03 20:00:02,4.00,USD,0.00006536,BTC,,,Buy",
+		},
+		{
+			Date:      time.Date(2024, 11, 27, 0, 36, 42, 0, time.UTC),
+			Type:      "send",
+			AmountBTC: -0.00482484,
+			AmountSat: -482484,
+			FeeBTC:    0.00000242,
+			RawLine:   "2024-11-27 00:36:42,0.00482484,BTC,,,0.00000242,BTC,",
+		},
+	}
+}
+
+func TestImportRiverCSV_Basic(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := testRiverRows()
+	summary, err := d.ImportRiverCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if summary.Total != 3 {
+		t.Errorf("expected total 3, got %d", summary.Total)
+	}
+	if summary.NewPurchases != 2 {
+		t.Errorf("expected 2 new purchases, got %d", summary.NewPurchases)
+	}
+	if summary.Duplicates != 0 {
+		t.Errorf("expected 0 duplicates, got %d", summary.Duplicates)
+	}
+
+	// Verify exchange_imports has 3 rows
+	var count int
+	d.db.QueryRow("SELECT COUNT(*) FROM exchange_imports WHERE source = 'river'").Scan(&count)
+	if count != 3 {
+		t.Errorf("expected 3 exchange_imports rows, got %d", count)
+	}
+
+	// Verify btc_lots has 2 rows (only purchases)
+	d.db.QueryRow("SELECT COUNT(*) FROM btc_lots WHERE source = 'river'").Scan(&count)
+	if count != 2 {
+		t.Errorf("expected 2 btc_lots rows, got %d", count)
+	}
+}
+
+func TestImportRiverCSV_Dedup(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := testRiverRows()
+
+	// First import
+	_, err := d.ImportRiverCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("first import error: %v", err)
+	}
+
+	// Second import — all should be duplicates
+	summary, err := d.ImportRiverCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("second import error: %v", err)
+	}
+	if summary.Duplicates != 3 {
+		t.Errorf("expected 3 duplicates, got %d", summary.Duplicates)
+	}
+	if summary.NewPurchases != 0 {
+		t.Errorf("expected 0 new purchases, got %d", summary.NewPurchases)
+	}
+}
+
+func TestImportRiverCSV_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	summary, err := d.ImportRiverCSV(context.Background(), []exchange.RiverRow{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.Total != 0 {
+		t.Errorf("expected total 0, got %d", summary.Total)
+	}
+}
+
+func TestImportRiverCSV_SendNoLot(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := []exchange.RiverRow{
+		{
+			Date:      time.Date(2024, 11, 27, 0, 36, 42, 0, time.UTC),
+			Type:      "send",
+			AmountBTC: -0.00482484,
+			AmountSat: -482484,
+			RawLine:   "2024-11-27 00:36:42,0.00482484,BTC,,,,,Withdrawal",
+		},
+	}
+
+	summary, err := d.ImportRiverCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.NewPurchases != 0 {
+		t.Errorf("expected 0 new purchases for send, got %d", summary.NewPurchases)
+	}
+
+	var count int
+	d.db.QueryRow("SELECT COUNT(*) FROM btc_lots WHERE source = 'river'").Scan(&count)
+	if count != 0 {
+		t.Errorf("expected 0 btc_lots for send, got %d", count)
+	}
+}
+
+func TestRiverExchangeBalance(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := testRiverRows()
+	_, err := d.ImportRiverCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("import error: %v", err)
+	}
+
+	bal, err := d.ExchangeBalance(context.Background(), "river")
+	if err != nil {
+		t.Fatalf("balance error: %v", err)
+	}
+
+	// 6093 + 6536 - 482484 = -469855
+	expected := int64(-469855)
+	if bal != expected {
+		t.Errorf("expected balance %d sats, got %d", expected, bal)
+	}
+}
+
+func TestRiverExchangeSummary(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := testRiverRows()
+	_, err := d.ImportRiverCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("import error: %v", err)
+	}
+
+	summary, err := d.ExchangeSummary(context.Background(), "river", time.Time{})
+	if err != nil {
+		t.Fatalf("summary error: %v", err)
+	}
+
+	if summary.PurchasedSats != 12629 {
+		t.Errorf("expected purchased 12629 sats, got %d", summary.PurchasedSats)
+	}
+	if summary.SentSats != 482484 {
+		t.Errorf("expected sent 482484 sats, got %d", summary.SentSats)
+	}
+	if summary.TotalCostBasisUSD != 7.96 {
+		t.Errorf("expected cost basis 7.96, got %f", summary.TotalCostBasisUSD)
+	}
+}

--- a/internal/exchange/river.go
+++ b/internal/exchange/river.go
@@ -1,0 +1,225 @@
+// River CSV format (as of 2026-03)
+// Expected header: Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+package exchange
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"time"
+)
+
+// RiverRow represents a single parsed row from a River CSV export.
+// JSON field names match StrikeRow so ExchangeSummary/ExchangeBalance queries work unchanged.
+type RiverRow struct {
+	Date         time.Time `json:"Date"`
+	Type         string    `json:"Type"`         // "buy", "send"
+	AmountBTC    float64   `json:"AmountBTC"`    // positive for buys, negative for sends
+	AmountSat    int64     `json:"-"`            // derived from AmountBTC
+	AmountUSD    float64   `json:"AmountUSD"`    // USD involved (cost for buys, 0 for sends)
+	FeeUSD       float64   `json:"FeeUSD"`       // fee in USD (0 when fee is in BTC)
+	FeeBTC       float64   `json:"FeeBTC"`       // fee in BTC (0 when fee is in USD)
+	CostBasisUSD float64   `json:"CostBasisUSD"` // for buys: total USD spent (sent amount)
+	RawLine      string    `json:"-"`
+}
+
+// RiverResult holds the result of parsing a River CSV.
+type RiverResult struct {
+	Rows   []RiverRow
+	Errors []string
+}
+
+// IsPurchase returns true if the row represents a BTC purchase.
+func (r RiverRow) IsPurchase() bool {
+	return r.Type == "buy"
+}
+
+var expectedRiverHeader = []string{
+	"Date", "Sent Amount", "Sent Currency", "Received Amount",
+	"Received Currency", "Fee Amount", "Fee Currency", "Tag",
+}
+
+const riverMinColumns = 8
+
+// ParseRiverCSV parses a River Financial transaction export CSV.
+// It validates the header strictly and parses each data row.
+// Invalid rows are recorded as errors but do not halt parsing.
+func ParseRiverCSV(r io.Reader) (*RiverResult, error) {
+	reader := csv.NewReader(r)
+	reader.TrimLeadingSpace = true
+	reader.FieldsPerRecord = -1
+
+	// Read and validate header
+	header, err := reader.Read()
+	if err != nil {
+		if err == io.EOF {
+			return nil, fmt.Errorf("empty CSV file")
+		}
+		return nil, fmt.Errorf("failed to read CSV header: %w", err)
+	}
+
+	if err := validateRiverHeader(header); err != nil {
+		return nil, err
+	}
+
+	result := &RiverResult{}
+
+	for rowNum := 2; ; rowNum++ {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("row %d: %v", rowNum, err))
+			continue
+		}
+
+		if len(record) < riverMinColumns {
+			result.Errors = append(result.Errors, fmt.Sprintf("row %d: expected %d columns, got %d", rowNum, riverMinColumns, len(record)))
+			continue
+		}
+
+		row, err := parseRiverRow(record)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("row %d: %v", rowNum, err))
+			continue
+		}
+
+		row.RawLine = strings.Join(record, ",")
+		result.Rows = append(result.Rows, row)
+	}
+
+	return result, nil
+}
+
+func validateRiverHeader(header []string) error {
+	if len(header) < riverMinColumns {
+		return fmt.Errorf("invalid River CSV format: expected %d columns, got %d", riverMinColumns, len(header))
+	}
+	for i, expected := range expectedRiverHeader {
+		got := strings.TrimSpace(header[i])
+		if !strings.EqualFold(got, expected) {
+			return fmt.Errorf("invalid River CSV format: expected column %d to be %q, got %q", i+1, expected, got)
+		}
+	}
+	return nil
+}
+
+// riverTimeFormats lists date formats River may use, tried in order.
+var riverTimeFormats = []string{
+	"2006-01-02 15:04:05",
+	"2006-01-02T15:04:05Z",
+	"2006-01-02T15:04:05-07:00",
+	time.RFC3339,
+	"01/02/2006 15:04:05",
+	"2006-01-02",
+}
+
+func parseRiverRow(record []string) (RiverRow, error) {
+	dateStr := strings.TrimSpace(record[0])
+	sentAmtStr := strings.TrimSpace(record[1])
+	sentCurrency := strings.TrimSpace(record[2])
+	recvAmtStr := strings.TrimSpace(record[3])
+	recvCurrency := strings.TrimSpace(record[4])
+	feeAmtStr := strings.TrimSpace(record[5])
+	feeCurrency := strings.TrimSpace(record[6])
+	tag := strings.TrimSpace(record[7])
+
+	// Parse date
+	var date time.Time
+	var parseErr error
+	for _, format := range riverTimeFormats {
+		date, parseErr = time.Parse(format, dateStr)
+		if parseErr == nil {
+			break
+		}
+	}
+	if parseErr != nil {
+		return RiverRow{}, fmt.Errorf("invalid date %q", dateStr)
+	}
+
+	// Parse amounts
+	sentAmt, err := parseOptionalFloat(sentAmtStr)
+	if err != nil {
+		return RiverRow{}, fmt.Errorf("invalid sent amount %q", sentAmtStr)
+	}
+	recvAmt, err := parseOptionalFloat(recvAmtStr)
+	if err != nil {
+		return RiverRow{}, fmt.Errorf("invalid received amount %q", recvAmtStr)
+	}
+	feeAmt, err := parseOptionalFloat(feeAmtStr)
+	if err != nil {
+		return RiverRow{}, fmt.Errorf("invalid fee amount %q", feeAmtStr)
+	}
+
+	row := RiverRow{Date: date}
+
+	switch strings.ToLower(tag) {
+	case "buy":
+		// Buy: sent USD, received BTC
+		row.Type = "buy"
+		row.AmountBTC = recvAmt
+		row.AmountUSD = sentAmt
+		row.CostBasisUSD = sentAmt
+		if strings.EqualFold(feeCurrency, "USD") {
+			row.FeeUSD = feeAmt
+		} else if strings.EqualFold(feeCurrency, "BTC") {
+			row.FeeBTC = feeAmt
+		}
+
+	case "withdrawal", "":
+		// Withdrawal or unnamed BTC send (empty tag = on-chain send)
+		row.Type = "send"
+		if strings.EqualFold(sentCurrency, "BTC") {
+			// Sent amount is the total BTC leaving the account (may include fee)
+			row.AmountBTC = -sentAmt
+			if strings.EqualFold(feeCurrency, "BTC") {
+				row.FeeBTC = feeAmt
+			}
+		} else if strings.EqualFold(sentCurrency, "USD") {
+			// USD withdrawal — no BTC movement
+			row.AmountUSD = sentAmt
+			if strings.EqualFold(feeCurrency, "USD") {
+				row.FeeUSD = feeAmt
+			}
+		}
+
+	case "sell":
+		row.Type = "sale"
+		if strings.EqualFold(sentCurrency, "BTC") {
+			row.AmountBTC = -sentAmt
+		}
+		if strings.EqualFold(recvCurrency, "USD") {
+			row.AmountUSD = recvAmt
+		}
+		if strings.EqualFold(feeCurrency, "USD") {
+			row.FeeUSD = feeAmt
+		} else if strings.EqualFold(feeCurrency, "BTC") {
+			row.FeeBTC = feeAmt
+		}
+
+	case "receive":
+		row.Type = "receive"
+		if strings.EqualFold(recvCurrency, "BTC") {
+			row.AmountBTC = recvAmt
+		}
+
+	default:
+		// Unknown tag — treat as send if BTC is being sent, receive if BTC is received
+		if sentAmt > 0 && strings.EqualFold(sentCurrency, "BTC") {
+			row.Type = "send"
+			row.AmountBTC = -sentAmt
+		} else if recvAmt > 0 && strings.EqualFold(recvCurrency, "BTC") {
+			row.Type = "receive"
+			row.AmountBTC = recvAmt
+		} else {
+			return RiverRow{}, fmt.Errorf("unknown tag %q with no BTC movement", tag)
+		}
+	}
+
+	row.AmountSat = int64(math.Round(row.AmountBTC * 1e8))
+
+	return row, nil
+}

--- a/internal/exchange/river_test.go
+++ b/internal/exchange/river_test.go
@@ -1,0 +1,258 @@
+package exchange
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRiverCSV_ValidBuys(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+2024-09-26 19:59:41,3.96,USD,0.00006093,BTC,0.04,USD,Buy
+2024-10-03 20:00:02,4.00,USD,0.00006536,BTC,,,Buy`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(result.Rows))
+	}
+
+	// First row: buy with fee
+	r := result.Rows[0]
+	if r.Type != "buy" {
+		t.Errorf("expected type 'buy', got %q", r.Type)
+	}
+	if r.AmountBTC != 0.00006093 {
+		t.Errorf("expected AmountBTC 0.00006093, got %f", r.AmountBTC)
+	}
+	if r.AmountSat != 6093 {
+		t.Errorf("expected AmountSat 6093, got %d", r.AmountSat)
+	}
+	if r.AmountUSD != 3.96 {
+		t.Errorf("expected AmountUSD 3.96, got %f", r.AmountUSD)
+	}
+	if r.CostBasisUSD != 3.96 {
+		t.Errorf("expected CostBasisUSD 3.96, got %f", r.CostBasisUSD)
+	}
+	if r.FeeUSD != 0.04 {
+		t.Errorf("expected FeeUSD 0.04, got %f", r.FeeUSD)
+	}
+	if !r.IsPurchase() {
+		t.Error("expected IsPurchase() to be true")
+	}
+
+	// Second row: buy with no fee
+	r2 := result.Rows[1]
+	if r2.FeeUSD != 0 {
+		t.Errorf("expected FeeUSD 0, got %f", r2.FeeUSD)
+	}
+	if r2.AmountBTC != 0.00006536 {
+		t.Errorf("expected AmountBTC 0.00006536, got %f", r2.AmountBTC)
+	}
+}
+
+func TestParseRiverCSV_Withdrawal(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+2026-03-16 11:24:47,0.01336638,BTC,,,,,Withdrawal`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "send" {
+		t.Errorf("expected type 'send', got %q", r.Type)
+	}
+	if r.AmountBTC != -0.01336638 {
+		t.Errorf("expected AmountBTC -0.01336638, got %f", r.AmountBTC)
+	}
+	if r.AmountSat != -1336638 {
+		t.Errorf("expected AmountSat -1336638, got %d", r.AmountSat)
+	}
+	if r.IsPurchase() {
+		t.Error("expected IsPurchase() to be false")
+	}
+}
+
+func TestParseRiverCSV_EmptyTagBTCSend(t *testing.T) {
+	// Empty tag with BTC sent = on-chain send
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+2024-11-27 00:36:42,0.00482484,BTC,,,0.00000242,BTC,`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "send" {
+		t.Errorf("expected type 'send', got %q", r.Type)
+	}
+	if r.AmountBTC != -0.00482484 {
+		t.Errorf("expected AmountBTC -0.00482484, got %f", r.AmountBTC)
+	}
+	if r.FeeBTC != 0.00000242 {
+		t.Errorf("expected FeeBTC 0.00000242, got %f", r.FeeBTC)
+	}
+}
+
+func TestParseRiverCSV_MixedTransactions(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+2024-09-26 19:59:41,3.96,USD,0.00006093,BTC,0.04,USD,Buy
+2024-11-27 00:36:42,0.00482484,BTC,,,0.00000242,BTC,
+2024-11-27 00:37:44,41.58,USD,0.00045038,BTC,0.42,USD,Buy
+2026-03-16 11:24:47,0.01336638,BTC,,,,,Withdrawal`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 4 {
+		t.Fatalf("expected 4 rows, got %d", len(result.Rows))
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+
+	// Verify types
+	types := []string{"buy", "send", "buy", "send"}
+	for i, expected := range types {
+		if result.Rows[i].Type != expected {
+			t.Errorf("row %d: expected type %q, got %q", i, expected, result.Rows[i].Type)
+		}
+	}
+}
+
+func TestParseRiverCSV_InvalidHeader(t *testing.T) {
+	csv := `Wrong,Header,Format
+1,2,3`
+
+	_, err := ParseRiverCSV(strings.NewReader(csv))
+	if err == nil {
+		t.Fatal("expected error for invalid header")
+	}
+}
+
+func TestParseRiverCSV_EmptyFile(t *testing.T) {
+	_, err := ParseRiverCSV(strings.NewReader(""))
+	if err == nil {
+		t.Fatal("expected error for empty file")
+	}
+}
+
+func TestParseRiverCSV_HeaderOnly(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(result.Rows))
+	}
+}
+
+func TestParseRiverCSV_MalformedRow(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+not-a-date,3.96,USD,0.00006093,BTC,0.04,USD,Buy
+2024-09-26 19:59:41,3.96,USD,0.00006093,BTC,0.04,USD,Buy`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Errorf("expected 1 valid row, got %d", len(result.Rows))
+	}
+	if len(result.Errors) != 1 {
+		t.Errorf("expected 1 error, got %d", len(result.Errors))
+	}
+}
+
+func TestParseRiverCSV_RawLinePopulated(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+2024-09-26 19:59:41,3.96,USD,0.00006093,BTC,0.04,USD,Buy`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Rows[0].RawLine == "" {
+		t.Error("expected RawLine to be populated")
+	}
+}
+
+func TestParseRiverCSV_TooFewColumns(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+2024-09-26,3.96,USD`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(result.Rows))
+	}
+	if len(result.Errors) != 1 {
+		t.Errorf("expected 1 error, got %d", len(result.Errors))
+	}
+}
+
+func TestParseRiverCSV_SellTransaction(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+2024-09-26 19:59:41,0.001,BTC,65.00,USD,0.50,USD,Sell`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "sale" {
+		t.Errorf("expected type 'sale', got %q", r.Type)
+	}
+	if r.AmountBTC != -0.001 {
+		t.Errorf("expected AmountBTC -0.001, got %f", r.AmountBTC)
+	}
+	if r.AmountUSD != 65.00 {
+		t.Errorf("expected AmountUSD 65.00, got %f", r.AmountUSD)
+	}
+	if r.FeeUSD != 0.50 {
+		t.Errorf("expected FeeUSD 0.50, got %f", r.FeeUSD)
+	}
+}
+
+func TestParseRiverCSV_ReceiveTransaction(t *testing.T) {
+	csv := `Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag
+2024-09-26 19:59:41,,,0.005,BTC,,,Receive`
+
+	result, err := ParseRiverCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "receive" {
+		t.Errorf("expected type 'receive', got %q", r.Type)
+	}
+	if r.AmountBTC != 0.005 {
+		t.Errorf("expected AmountBTC 0.005, got %f", r.AmountBTC)
+	}
+	if r.AmountSat != 500000 {
+		t.Errorf("expected AmountSat 500000, got %d", r.AmountSat)
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -40,6 +40,7 @@ type PriceProvider interface {
 // ImportStore defines operations for importing exchange data.
 type ImportStore interface {
 	ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
+	ImportRiverCSV(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error)
 }
 
 // Handler serves dashboard API and HTML endpoints.
@@ -419,4 +420,65 @@ type importResponse struct {
 	NewPurchases int      `json:"new_purchases"`
 	Duplicates   int      `json:"duplicates"`
 	ParseErrors  []string `json:"parse_errors,omitempty"`
+}
+
+// HandleRiverImport serves POST /api/import/river.
+func (h *Handler) HandleRiverImport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// 10MB max upload
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		h.logger.Printf("river import: failed to parse multipart form: %v", err)
+		h.writeError(w, http.StatusBadRequest, "failed to parse upload: file may be too large (10MB max)")
+		return
+	}
+
+	file, fh, err := r.FormFile("file")
+	if err != nil {
+		h.logger.Printf("river import: missing file field: %v", err)
+		h.writeError(w, http.StatusBadRequest, "missing 'file' field in upload")
+		return
+	}
+	defer file.Close()
+	h.logger.Printf("river import: received file %q (%d bytes)", fh.Filename, fh.Size)
+
+	result, err := exchange.ParseRiverCSV(file)
+	if err != nil {
+		h.logger.Printf("river import: CSV parse error: %v", err)
+		h.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if len(result.Rows) == 0 {
+		h.writeError(w, http.StatusBadRequest, "CSV contains no valid data rows")
+		return
+	}
+
+	summary, err := h.importStore.ImportRiverCSV(r.Context(), result.Rows)
+	if err != nil {
+		h.logger.Printf("river import failed: %v", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to import transactions")
+		return
+	}
+
+	resp := importResponse{
+		Total:        summary.Total,
+		NewPurchases: summary.NewPurchases,
+		Duplicates:   summary.Duplicates,
+		ParseErrors:  result.Errors,
+	}
+
+	// HTMX request — render partial
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := h.renderer.Render(w, "import_result", resp); err != nil {
+			h.logger.Printf("failed to render import result: %v", err)
+		}
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -35,8 +35,12 @@ type DashboardData struct {
 	WalletBalanceUSD  float64
 
 	// Exchange balances
-	StrikeBalanceSats int64
-	StrikeBalanceUSD  float64
+	StrikeBalanceSats   int64
+	StrikeBalanceUSD    float64
+	RiverBalanceSats    int64
+	RiverBalanceUSD     float64
+	ExchangeBalanceSats int64
+	ExchangeBalanceUSD  float64
 
 	// Price
 	BTCPriceUSD    float64
@@ -103,6 +107,7 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		btcPrice               float64
 		priceFetched           time.Time
 		strikeBalance          int64
+		riverBalance           int64
 	}
 	var res result
 
@@ -217,6 +222,15 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	})
 
+	fetch(func() {
+		bal, err := h.store.ExchangeBalance(ctx, "river")
+		if err == nil {
+			mu.Lock()
+			res.riverBalance = bal
+			mu.Unlock()
+		}
+	})
+
 	wg.Wait()
 
 	// Assemble template data
@@ -244,6 +258,8 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data.StrikeBalanceSats = res.strikeBalance
+	data.RiverBalanceSats = res.riverBalance
+	data.ExchangeBalanceSats = res.strikeBalance + res.riverBalance
 
 	if res.btcPrice > 0 {
 		data.BTCPriceUSD = res.btcPrice
@@ -251,6 +267,8 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		data.FeesAllTimeUSD = msatToUSD(res.feesAll, res.btcPrice)
 		data.WalletBalanceUSD = float64(data.WalletBalanceSats) / 100_000_000.0 * res.btcPrice
 		data.StrikeBalanceUSD = float64(res.strikeBalance) / 100_000_000.0 * res.btcPrice
+		data.RiverBalanceUSD = float64(res.riverBalance) / 100_000_000.0 * res.btcPrice
+		data.ExchangeBalanceUSD = float64(data.ExchangeBalanceSats) / 100_000_000.0 * res.btcPrice
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -415,13 +433,14 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 	var wg sync.WaitGroup
 
 	type result struct {
-		feesMsat     int64
-		routedCount  int64
-		exchSummary  *db.ExchangeSummaryResult
-		nodeInfo     *lnd.NodeInfo
-		lastSynced   time.Time
-		btcPrice     float64
-		priceFetched time.Time
+		feesMsat       int64
+		routedCount    int64
+		strikeSummary  *db.ExchangeSummaryResult
+		riverSummary   *db.ExchangeSummaryResult
+		nodeInfo       *lnd.NodeInfo
+		lastSynced     time.Time
+		btcPrice       float64
+		priceFetched   time.Time
 	}
 	var res result
 
@@ -447,7 +466,16 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 		summary, err := h.store.ExchangeSummary(ctx, "strike", since)
 		if err == nil {
 			mu.Lock()
-			res.exchSummary = summary
+			res.strikeSummary = summary
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		summary, err := h.store.ExchangeSummary(ctx, "river", since)
+		if err == nil {
+			mu.Lock()
+			res.riverSummary = summary
 			mu.Unlock()
 		}
 	})
@@ -495,14 +523,17 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 	data.RoutingFeeSats = res.feesMsat / 1000
 	data.RoutedCount = res.routedCount
 
-	if res.exchSummary != nil {
-		data.PurchasedSats = res.exchSummary.PurchasedSats
-		data.ReceivedSats = res.exchSummary.ReceivedSats
-		data.SoldSats = res.exchSummary.SoldSats
-		data.SentSats = res.exchSummary.SentSats
-		data.TotalCostBasisUSD = res.exchSummary.TotalCostBasisUSD
-		data.TotalSaleProceedsUSD = res.exchSummary.TotalSaleProceedsUSD
-		data.FeesPaidUSD = res.exchSummary.FeesPaidUSD
+	// Aggregate exchange summaries across all sources
+	for _, s := range []*db.ExchangeSummaryResult{res.strikeSummary, res.riverSummary} {
+		if s != nil {
+			data.PurchasedSats += s.PurchasedSats
+			data.ReceivedSats += s.ReceivedSats
+			data.SoldSats += s.SoldSats
+			data.SentSats += s.SentSats
+			data.TotalCostBasisUSD += s.TotalCostBasisUSD
+			data.TotalSaleProceedsUSD += s.TotalSaleProceedsUSD
+			data.FeesPaidUSD += s.FeesPaidUSD
+		}
 	}
 
 	// Net BTC = routing fees + purchased + received - sold - sent

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -390,6 +390,8 @@ type PLPageData struct {
 	TotalCostBasisUSD    float64
 	TotalSaleProceedsUSD float64
 	FeesPaidUSD          float64
+	StrikeFeesPaidUSD    float64
+	RiverFeesPaidUSD     float64
 
 	// Net position
 	NetBTCSats int64
@@ -534,6 +536,12 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 			data.TotalSaleProceedsUSD += s.TotalSaleProceedsUSD
 			data.FeesPaidUSD += s.FeesPaidUSD
 		}
+	}
+	if res.strikeSummary != nil {
+		data.StrikeFeesPaidUSD = res.strikeSummary.FeesPaidUSD
+	}
+	if res.riverSummary != nil {
+		data.RiverFeesPaidUSD = res.riverSummary.FeesPaidUSD
 	}
 
 	// Net BTC = routing fees + purchased + received - sold - sent

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -97,11 +97,19 @@ func (m *mockPrice) FetchedAt() time.Time {
 
 type mockImportStore struct {
 	importStrikeFn func(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
+	importRiverFn  func(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error)
 }
 
 func (m *mockImportStore) ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error) {
 	if m.importStrikeFn != nil {
 		return m.importStrikeFn(ctx, rows)
+	}
+	return &db.ImportSummary{}, nil
+}
+
+func (m *mockImportStore) ImportRiverCSV(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error) {
+	if m.importRiverFn != nil {
+		return m.importRiverFn(ctx, rows)
 	}
 	return &db.ImportSummary{}, nil
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -35,6 +35,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
 	mux.HandleFunc("/api/forwarding", handler.HandleForwarding)
 	mux.HandleFunc("/api/node", handler.HandleNode)
 	mux.HandleFunc("/api/import/strike", handler.HandleStrikeImport)
+	mux.HandleFunc("/api/import/river", handler.HandleRiverImport)
 
 	return &Server{
 		httpServer: &http.Server{

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -31,11 +31,15 @@
     {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .WalletBalanceUSD}}</div>{{end}}
   </div>
 
-  {{if .StrikeBalanceSats}}
+  {{if or .StrikeBalanceSats .RiverBalanceSats}}
   <div class="card">
-    <div class="card-label">Strike Balance <span style="font-size:0.75em;color:#999;">(from CSV import)</span></div>
-    <div class="card-value">{{formatSats .StrikeBalanceSats}} <small>sats</small></div>
-    {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .StrikeBalanceUSD}}</div>{{end}}
+    <div class="card-label">Exchange Balance <span style="font-size:0.75em;color:#999;">(from CSV import)</span></div>
+    <div class="card-value">{{formatSats .ExchangeBalanceSats}} <small>sats</small></div>
+    {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .ExchangeBalanceUSD}}</div>{{end}}
+    <div style="margin-top: 8px; font-size: 0.8em; color: #999;">
+      {{if .StrikeBalanceSats}}<div>Strike: {{formatSats .StrikeBalanceSats}} sats</div>{{end}}
+      {{if .RiverBalanceSats}}<div>River: {{formatSats .RiverBalanceSats}} sats</div>{{end}}
+    </div>
   </div>
   {{end}}
 </div>

--- a/internal/web/templates/import.html
+++ b/internal/web/templates/import.html
@@ -1,11 +1,15 @@
 {{define "import_content"}}
 <h1 style="margin-bottom: 24px; font-size: 1.25rem;">Import Transactions</h1>
 
-<div class="card" style="max-width: 600px;">
+<div style="display: flex; gap: 16px; margin-bottom: 16px;">
+  <button class="filter-form" id="tab-strike" onclick="showTab('strike')" style="display: inline-block;">Strike</button>
+  <button class="filter-form" id="tab-river" onclick="showTab('river')" style="display: inline-block; opacity: 0.6;">River</button>
+</div>
+
+<div id="panel-strike" class="card" style="max-width: 600px;">
   <div class="card-label">Upload Strike CSV</div>
   <p class="card-sub" style="margin-bottom: 16px;">
-    Import your Strike transaction history. Supported format: Strike CSV export
-    (Transaction ID, Date, Type, Amount BTC, Amount USD, Fee USD, Status).
+    Import your Strike transaction history. Export from Strike app: Profile &gt; Account &gt; Transaction History &gt; Download CSV.
   </p>
 
   <form hx-post="/api/import/strike"
@@ -24,5 +28,36 @@
   </form>
 </div>
 
+<div id="panel-river" class="card" style="max-width: 600px; display: none;">
+  <div class="card-label">Upload River CSV</div>
+  <p class="card-sub" style="margin-bottom: 16px;">
+    Import your River Financial transaction history. Export from River app: Settings &gt; Account &gt; Download Activity.
+  </p>
+
+  <form hx-post="/api/import/river"
+        hx-target="#import-result"
+        hx-swap="innerHTML"
+        hx-encoding="multipart/form-data"
+        hx-indicator="#import-loading-river">
+    <div style="margin-bottom: 12px;">
+      <input type="file" name="file" accept=".csv" required
+             style="background: var(--bg); border: 1px solid var(--border); border-radius: 4px; color: var(--text); padding: 8px; width: 100%;">
+    </div>
+    <button type="submit" class="filter-form" style="display: inline-block;">
+      Upload
+    </button>
+    <span id="import-loading-river" class="htmx-indicator">Importing...</span>
+  </form>
+</div>
+
 <div id="import-result" style="margin-top: 20px;"></div>
+
+<script>
+function showTab(name) {
+  document.getElementById('panel-strike').style.display = name === 'strike' ? 'block' : 'none';
+  document.getElementById('panel-river').style.display = name === 'river' ? 'block' : 'none';
+  document.getElementById('tab-strike').style.opacity = name === 'strike' ? '1' : '0.6';
+  document.getElementById('tab-river').style.opacity = name === 'river' ? '1' : '0.6';
+}
+</script>
 {{end}}

--- a/internal/web/templates/pl.html
+++ b/internal/web/templates/pl.html
@@ -29,7 +29,7 @@
 </div>
 
 <!-- Exchange Activity Section -->
-<h2 style="font-size: 1rem; color: var(--text-muted); margin: 24px 0 12px;">Strike Activity <span style="font-size: 0.75em;">(from CSV import)</span></h2>
+<h2 style="font-size: 1rem; color: var(--text-muted); margin: 24px 0 12px;">Exchange Activity <span style="font-size: 0.75em;">(from CSV import)</span></h2>
 <div class="cards">
   <div class="card">
     <div class="card-label">BTC Purchased</div>
@@ -54,8 +54,14 @@
   </div>
 
   <div class="card">
-    <div class="card-label">Fees Paid (Strike)</div>
+    <div class="card-label">Fees Paid</div>
     <div class="card-value">{{formatUSD .FeesPaidUSD}}</div>
+    {{if or .StrikeFeesPaidUSD .RiverFeesPaidUSD}}
+    <div style="margin-top: 8px; font-size: 0.8em; color: #999;">
+      {{if .StrikeFeesPaidUSD}}<div>Strike: {{formatUSD .StrikeFeesPaidUSD}}</div>{{end}}
+      {{if .RiverFeesPaidUSD}}<div>River: {{formatUSD .RiverFeesPaidUSD}}</div>{{end}}
+    </div>
+    {{end}}
   </div>
 </div>
 


### PR DESCRIPTION
Closes #49

## Summary

- Add River Financial CSV import parser with support for Buy, Sell, Send, Receive, Withdrawal, and unnamed on-chain sends
- Tabbed import UI (Strike / River) on the `/import` page
- Dashboard shows River balance card when data exists
- P&L page aggregates exchange activity across both Strike and River sources
- 12 unit tests for the parser, all passing
- Tested against real River CSV export (83 rows, 0 errors)

## Test plan

- [x] Import a River CSV on swamp — verify row count, balance, and deduplication
- [x] Verify dashboard shows River balance card
- [x] Verify P&L page includes River data in totals
- [x] Re-import same CSV — verify all rows are deduplicated
- [x] Import Strike CSV still works as before