### PR TITLE
feat(exchange): add Coinbase CSV import parser

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -461,6 +461,80 @@ func (d *DB) ImportRiverCSV(ctx context.Context, rows []exchange.RiverRow) (*Imp
 	return summary, nil
 }
 
+// ImportCoinbaseCSV imports parsed Coinbase CSV rows into exchange_imports and btc_lots.
+// The entire operation runs in a single transaction.
+func (d *DB) ImportCoinbaseCSV(ctx context.Context, rows []exchange.CoinbaseRow) (*ImportSummary, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin import transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	summary := &ImportSummary{Total: len(rows)}
+
+	for _, row := range rows {
+		rawData, _ := json.Marshal(row)
+
+		h := sha256.Sum256([]byte(row.RawLine))
+		contentHash := hex.EncodeToString(h[:])
+
+		res, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO exchange_imports (source, external_id, tx_type, raw_data)
+			 VALUES (?, ?, ?, ?)`,
+			"coinbase", contentHash, row.Type, string(rawData),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("insert exchange import: %w", err)
+		}
+
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("rows affected: %w", err)
+		}
+
+		if affected == 0 {
+			summary.Duplicates++
+			continue
+		}
+
+		// Create btc_lot for completed purchases
+		if row.IsPurchase() && row.AmountSat > 0 {
+			var exists int
+			err := tx.QueryRowContext(ctx,
+				`SELECT 1 FROM btc_lots WHERE source = ? AND external_id = ?`,
+				"coinbase", contentHash,
+			).Scan(&exists)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("check btc_lot %q: %w", contentHash, err)
+			}
+			if errors.Is(err, sql.ErrNoRows) {
+				priceUSD := row.CostBasisUSD
+				if priceUSD == 0 {
+					priceUSD = row.AmountUSD
+				}
+				if priceUSD == 0 {
+					continue
+				}
+				_, err = tx.ExecContext(ctx,
+					`INSERT INTO btc_lots (acquired_at, amount_sat, price_usd, source, external_id)
+					 VALUES (?, ?, ?, ?, ?)`,
+					row.Date, row.AmountSat, priceUSD, "coinbase", contentHash,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("insert btc_lot %q: %w", contentHash, err)
+				}
+				summary.NewPurchases++
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit import: %w", err)
+	}
+
+	return summary, nil
+}
+
 // ExchangeBalance returns the net BTC balance (in sats) for a given exchange source
 // by summing AmountBTC only from rows that actually move BTC (non-zero AmountBTC).
 // USD-only transactions (e.g. cash withdrawals) are excluded.

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -901,3 +901,183 @@ func TestRiverExchangeSummary(t *testing.T) {
 		t.Errorf("expected cost basis 7.96, got %f", summary.TotalCostBasisUSD)
 	}
 }
+
+// --- Coinbase CSV DB tests ---
+
+func testCoinbaseRows() []exchange.CoinbaseRow {
+	return []exchange.CoinbaseRow{
+		{
+			Date:         time.Date(2023, 8, 1, 19, 50, 7, 0, time.UTC),
+			Type:         "buy",
+			AmountBTC:    0.001,
+			AmountSat:    100000,
+			AmountUSD:    29.24,
+			FeeUSD:       1.00,
+			CostBasisUSD: 30.24,
+			RawLine:      "abc123,2023-08-01 19:50:07 UTC,Buy,BTC,0.001,USD,$29244.04,$29.24,$30.24,$1.00,Bought BTC",
+		},
+		{
+			Date:         time.Date(2023, 8, 1, 19, 50, 7, 0, time.UTC),
+			Type:         "buy",
+			AmountBTC:    0.002,
+			AmountSat:    200000,
+			AmountUSD:    58.48,
+			FeeUSD:       2.00,
+			CostBasisUSD: 60.48,
+			RawLine:      "abc456,2023-08-01 19:50:07 UTC,Buy,BTC,0.002,USD,$29244.04,$58.48,$60.48,$2.00,Bought BTC",
+		},
+		{
+			Date:      time.Date(2023, 8, 1, 19, 50, 7, 0, time.UTC),
+			Type:      "send",
+			AmountBTC: -0.006132,
+			AmountSat: -613200,
+			RawLine:   "def789,2023-08-01 19:50:07 UTC,Send,BTC,-0.006132,USD,$29244.04,-$179.32,-$179.32,$0.00,Sent BTC",
+		},
+	}
+}
+
+func TestImportCoinbaseCSV_Basic(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := testCoinbaseRows()
+	summary, err := d.ImportCoinbaseCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if summary.Total != 3 {
+		t.Errorf("expected total 3, got %d", summary.Total)
+	}
+	if summary.NewPurchases != 2 {
+		t.Errorf("expected 2 new purchases, got %d", summary.NewPurchases)
+	}
+	if summary.Duplicates != 0 {
+		t.Errorf("expected 0 duplicates, got %d", summary.Duplicates)
+	}
+
+	var count int
+	d.db.QueryRow("SELECT COUNT(*) FROM exchange_imports WHERE source = 'coinbase'").Scan(&count)
+	if count != 3 {
+		t.Errorf("expected 3 exchange_imports rows, got %d", count)
+	}
+
+	d.db.QueryRow("SELECT COUNT(*) FROM btc_lots WHERE source = 'coinbase'").Scan(&count)
+	if count != 2 {
+		t.Errorf("expected 2 btc_lots rows, got %d", count)
+	}
+}
+
+func TestImportCoinbaseCSV_Dedup(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := testCoinbaseRows()
+	_, err := d.ImportCoinbaseCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("first import error: %v", err)
+	}
+
+	summary, err := d.ImportCoinbaseCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("second import error: %v", err)
+	}
+	if summary.Duplicates != 3 {
+		t.Errorf("expected 3 duplicates, got %d", summary.Duplicates)
+	}
+	if summary.NewPurchases != 0 {
+		t.Errorf("expected 0 new purchases, got %d", summary.NewPurchases)
+	}
+}
+
+func TestImportCoinbaseCSV_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	summary, err := d.ImportCoinbaseCSV(context.Background(), []exchange.CoinbaseRow{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.Total != 0 {
+		t.Errorf("expected total 0, got %d", summary.Total)
+	}
+}
+
+func TestImportCoinbaseCSV_SendNoLot(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := []exchange.CoinbaseRow{
+		{
+			Date:      time.Date(2023, 8, 1, 19, 50, 7, 0, time.UTC),
+			Type:      "send",
+			AmountBTC: -0.006132,
+			AmountSat: -613200,
+			RawLine:   "def789,2023-08-01 19:50:07 UTC,Send,BTC,-0.006132,USD,$29244.04,-$179.32,-$179.32,$0.00,Sent BTC",
+		},
+	}
+
+	summary, err := d.ImportCoinbaseCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.NewPurchases != 0 {
+		t.Errorf("expected 0 new purchases for send, got %d", summary.NewPurchases)
+	}
+
+	var count int
+	d.db.QueryRow("SELECT COUNT(*) FROM btc_lots WHERE source = 'coinbase'").Scan(&count)
+	if count != 0 {
+		t.Errorf("expected 0 btc_lots for send, got %d", count)
+	}
+}
+
+func TestCoinbaseExchangeBalance(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := testCoinbaseRows()
+	_, err := d.ImportCoinbaseCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("import error: %v", err)
+	}
+
+	bal, err := d.ExchangeBalance(context.Background(), "coinbase")
+	if err != nil {
+		t.Fatalf("balance error: %v", err)
+	}
+
+	// 100000 + 200000 - 613200 = -313200
+	if bal != -313200 {
+		t.Errorf("expected balance -313200, got %d", bal)
+	}
+}
+
+func TestCoinbaseExchangeSummary(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	rows := testCoinbaseRows()
+	_, err := d.ImportCoinbaseCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("import error: %v", err)
+	}
+
+	summary, err := d.ExchangeSummary(context.Background(), "coinbase", time.Time{})
+	if err != nil {
+		t.Fatalf("summary error: %v", err)
+	}
+
+	if summary.PurchasedSats != 300000 {
+		t.Errorf("expected purchased 300000 sats, got %d", summary.PurchasedSats)
+	}
+	if summary.SentSats != 613200 {
+		t.Errorf("expected sent 613200 sats, got %d", summary.SentSats)
+	}
+	if summary.TotalCostBasisUSD != 90.72 {
+		t.Errorf("expected cost basis 90.72, got %f", summary.TotalCostBasisUSD)
+	}
+	if summary.FeesPaidUSD != 3.00 {
+		t.Errorf("expected fees 3.00, got %f", summary.FeesPaidUSD)
+	}
+}

--- a/internal/exchange/coinbase.go
+++ b/internal/exchange/coinbase.go
@@ -1,0 +1,228 @@
+// Coinbase retail CSV format (as of 2026-03)
+// CSV has preamble lines before the header. Header row starts with "ID".
+// Expected header: ID,Timestamp,Transaction Type,Asset,Quantity Transacted,
+//   Price Currency,Price at Transaction,Subtotal,Total (inclusive of fees and/or spread),
+//   Fees and/or Spread,Notes
+package exchange
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CoinbaseRow represents a single parsed row from a Coinbase CSV export.
+// JSON field names match StrikeRow/RiverRow so ExchangeSummary/ExchangeBalance queries work unchanged.
+type CoinbaseRow struct {
+	Date         time.Time `json:"Date"`
+	Type         string    `json:"Type"`         // "buy", "sale", "send", "receive"
+	AmountBTC    float64   `json:"AmountBTC"`    // positive for buys/receives, negative for sends/sales
+	AmountSat    int64     `json:"-"`            // derived from AmountBTC
+	AmountUSD    float64   `json:"AmountUSD"`
+	FeeUSD       float64   `json:"FeeUSD"`
+	CostBasisUSD float64   `json:"CostBasisUSD"` // for buys: total USD spent
+	RawLine      string    `json:"-"`
+}
+
+// CoinbaseResult holds the result of parsing a Coinbase CSV.
+type CoinbaseResult struct {
+	Rows    []CoinbaseRow
+	Errors  []string
+	Skipped int // count of non-BTC rows skipped
+}
+
+// IsPurchase returns true if the row represents a BTC purchase.
+func (r CoinbaseRow) IsPurchase() bool {
+	return r.Type == "buy"
+}
+
+// Coinbase CSV column indices (after header).
+const (
+	cbColTimestamp = 1
+	cbColTxType   = 2
+	cbColAsset    = 3
+	cbColQuantity = 4
+	cbColSubtotal = 7
+	cbColTotal    = 8
+	cbColFees     = 9
+	cbMinColumns  = 11
+)
+
+const coinbaseTimeFormat = "2006-01-02 15:04:05 MST"
+
+// parseCoinbaseUSD strips $ prefix and handles negative USD amounts like "-$179.32".
+func parseCoinbaseUSD(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "-" {
+		return 0, nil
+	}
+
+	negative := false
+	if strings.HasPrefix(s, "-") {
+		negative = true
+		s = s[1:]
+	}
+
+	s = strings.TrimPrefix(s, "$")
+	s = strings.ReplaceAll(s, ",", "")
+
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, err
+	}
+	if negative {
+		v = -v
+	}
+	return v, nil
+}
+
+// ParseCoinbaseCSV parses a Coinbase retail transaction export CSV.
+// It skips preamble lines until finding the header row (starts with "ID"),
+// filters to BTC-only rows, and maps transaction types accordingly.
+// Invalid rows are recorded as errors but do not halt parsing.
+func ParseCoinbaseCSV(r io.Reader) (*CoinbaseResult, error) {
+	reader := csv.NewReader(r)
+	reader.TrimLeadingSpace = true
+	reader.FieldsPerRecord = -1 // handle Notes field with commas
+	reader.LazyQuotes = true
+
+	// Skip preamble lines until we find the header row starting with "ID".
+	var header []string
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			return nil, fmt.Errorf("no header row found in Coinbase CSV")
+		}
+		if err != nil {
+			// Skip malformed preamble lines.
+			continue
+		}
+		if len(record) > 0 && strings.TrimSpace(record[0]) == "ID" {
+			header = record
+			break
+		}
+	}
+
+	if len(header) < cbMinColumns {
+		return nil, fmt.Errorf("invalid Coinbase CSV format: expected at least %d columns, got %d", cbMinColumns, len(header))
+	}
+
+	result := &CoinbaseResult{}
+
+	for rowNum := 1; ; rowNum++ {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("row %d: %v", rowNum, err))
+			continue
+		}
+
+		if len(record) < cbMinColumns {
+			result.Errors = append(result.Errors, fmt.Sprintf("row %d: expected at least %d columns, got %d", rowNum, cbMinColumns, len(record)))
+			continue
+		}
+
+		asset := strings.TrimSpace(record[cbColAsset])
+		if !strings.EqualFold(asset, "BTC") {
+			result.Skipped++
+			continue
+		}
+
+		row, err := parseCoinbaseRow(record)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("row %d: %v", rowNum, err))
+			continue
+		}
+
+		row.RawLine = strings.Join(record, ",")
+		result.Rows = append(result.Rows, row)
+	}
+
+	return result, nil
+}
+
+func parseCoinbaseRow(record []string) (CoinbaseRow, error) {
+	dateStr := strings.TrimSpace(record[cbColTimestamp])
+	txType := strings.TrimSpace(record[cbColTxType])
+	qtyStr := strings.TrimSpace(record[cbColQuantity])
+	subtotalStr := strings.TrimSpace(record[cbColSubtotal])
+	totalStr := strings.TrimSpace(record[cbColTotal])
+	feesStr := strings.TrimSpace(record[cbColFees])
+
+	// Parse date.
+	date, err := time.Parse(coinbaseTimeFormat, dateStr)
+	if err != nil {
+		return CoinbaseRow{}, fmt.Errorf("invalid date %q: %w", dateStr, err)
+	}
+
+	// Parse quantity (can be negative for sends).
+	qty, err := parseOptionalFloat(qtyStr)
+	if err != nil {
+		return CoinbaseRow{}, fmt.Errorf("invalid quantity %q: %w", qtyStr, err)
+	}
+
+	// Parse USD amounts (may have $ prefix).
+	subtotal, err := parseCoinbaseUSD(subtotalStr)
+	if err != nil {
+		return CoinbaseRow{}, fmt.Errorf("invalid subtotal %q: %w", subtotalStr, err)
+	}
+
+	total, err := parseCoinbaseUSD(totalStr)
+	if err != nil {
+		return CoinbaseRow{}, fmt.Errorf("invalid total %q: %w", totalStr, err)
+	}
+
+	fees, err := parseCoinbaseUSD(feesStr)
+	if err != nil {
+		return CoinbaseRow{}, fmt.Errorf("invalid fees %q: %w", feesStr, err)
+	}
+
+	row := CoinbaseRow{Date: date}
+
+	switch strings.ToLower(txType) {
+	case "buy", "advanced trade buy":
+		row.Type = "buy"
+		row.AmountBTC = math.Abs(qty)
+		row.CostBasisUSD = math.Abs(total)
+		row.FeeUSD = math.Abs(fees)
+
+	case "sell", "advanced trade sell":
+		row.Type = "sale"
+		row.AmountBTC = -math.Abs(qty)
+		row.AmountUSD = math.Abs(subtotal)
+		row.FeeUSD = math.Abs(fees)
+
+	case "send":
+		row.Type = "send"
+		row.AmountBTC = qty // already negative
+
+	case "receive":
+		row.Type = "receive"
+		row.AmountBTC = qty // positive
+
+	case "convert":
+		// Convert with Asset=BTC means selling BTC (negative quantity).
+		row.Type = "sale"
+		row.AmountBTC = qty // negative
+		row.AmountUSD = math.Abs(subtotal)
+		row.FeeUSD = math.Abs(fees)
+
+	case "staking income":
+		row.Type = "receive"
+		row.AmountBTC = qty
+		row.CostBasisUSD = math.Abs(subtotal)
+
+	default:
+		return CoinbaseRow{}, fmt.Errorf("unknown BTC transaction type %q", txType)
+	}
+
+	row.AmountSat = int64(math.Round(row.AmountBTC * 1e8))
+
+	return row, nil
+}

--- a/internal/exchange/coinbase_test.go
+++ b/internal/exchange/coinbase_test.go
@@ -1,0 +1,282 @@
+package exchange
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func coinbasePreamble(csvData string) string {
+	return "\nTransactions\nUser,Test User,test-uuid\n" + csvData
+}
+
+const coinbaseHeader = "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes"
+
+func TestParseCoinbaseCSV_BTCBuy(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"abc123,2023-08-01 19:50:07 UTC,Buy,BTC,0.001,USD,$29244.04,$29.24,$30.24,$1.00,Bought 0.001 BTC\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "buy" {
+		t.Errorf("expected type 'buy', got %q", r.Type)
+	}
+	if r.AmountBTC != 0.001 {
+		t.Errorf("expected AmountBTC 0.001, got %f", r.AmountBTC)
+	}
+	if r.AmountBTC <= 0 {
+		t.Error("expected positive AmountBTC for buy")
+	}
+	if math.Abs(r.CostBasisUSD-30.24) > 0.001 {
+		t.Errorf("expected CostBasisUSD 30.24 (abs of Total), got %f", r.CostBasisUSD)
+	}
+	if math.Abs(r.FeeUSD-1.00) > 0.001 {
+		t.Errorf("expected FeeUSD 1.00, got %f", r.FeeUSD)
+	}
+}
+
+func TestParseCoinbaseCSV_BTCSend(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"def456,2023-08-01 19:50:07 UTC,Send,BTC,-0.006132,USD,$29244.04,-$179.32,-$179.32,$0.00,Sent BTC\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "send" {
+		t.Errorf("expected type 'send', got %q", r.Type)
+	}
+	if r.AmountBTC >= 0 {
+		t.Errorf("expected negative AmountBTC for send, got %f", r.AmountBTC)
+	}
+}
+
+func TestParseCoinbaseCSV_BTCReceive(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"ghi789,2023-08-01 19:14:09 UTC,Receive,BTC,0.00054535,USD,$29215.145,$15.93,$15.93,$0.00,Received BTC\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "receive" {
+		t.Errorf("expected type 'receive', got %q", r.Type)
+	}
+	if r.AmountBTC != 0.00054535 {
+		t.Errorf("expected AmountBTC 0.00054535, got %f", r.AmountBTC)
+	}
+	if r.AmountBTC <= 0 {
+		t.Error("expected positive AmountBTC for receive")
+	}
+}
+
+func TestParseCoinbaseCSV_FilterNonBTC(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"eth1,2023-08-01 19:50:07 UTC,Buy,ETH,0.5,USD,$1800.00,$900.00,$910.00,$10.00,Bought ETH\n" +
+		"usdc1,2023-08-01 19:50:07 UTC,Sell,USDC,-100,USD,$1.00,-$100.00,-$100.50,$0.50,Sold USDC\n" +
+		"btc1,2023-08-01 19:50:07 UTC,Buy,BTC,0.001,USD,$29244.04,$29.24,$30.24,$1.00,Bought BTC\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 BTC row, got %d", len(result.Rows))
+	}
+	if result.Skipped != 2 {
+		t.Errorf("expected 2 skipped non-BTC rows, got %d", result.Skipped)
+	}
+	if result.Rows[0].Type != "buy" {
+		t.Errorf("expected type 'buy', got %q", result.Rows[0].Type)
+	}
+}
+
+func TestParseCoinbaseCSV_ConvertFromBTC(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"conv1,2023-03-01 22:05:37 UTC,Convert,BTC,-0.00332439,USD,$23541.785,$74.32,$76.27,$1.96,Converted BTC to MATIC\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "sale" {
+		t.Errorf("expected type 'sale' for convert with negative BTC, got %q", r.Type)
+	}
+	if r.AmountBTC >= 0 {
+		t.Errorf("expected negative AmountBTC for convert-from-BTC, got %f", r.AmountBTC)
+	}
+}
+
+func TestParseCoinbaseCSV_SkipPreamble(t *testing.T) {
+	input := "\nTransactions\nUser,Test User,test-uuid\n" +
+		coinbaseHeader + "\n" +
+		"abc123,2023-08-01 19:50:07 UTC,Buy,BTC,0.001,USD,$29244.04,$29.24,$30.24,$1.00,Bought 0.001 BTC\n"
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row after preamble, got %d", len(result.Rows))
+	}
+	if result.Rows[0].Type != "buy" {
+		t.Errorf("expected type 'buy', got %q", result.Rows[0].Type)
+	}
+}
+
+func TestParseCoinbaseCSV_EmptyFile(t *testing.T) {
+	_, err := ParseCoinbaseCSV(strings.NewReader(""))
+	if err == nil {
+		t.Fatal("expected error for empty file, got nil")
+	}
+}
+
+func TestParseCoinbaseCSV_HeaderOnly(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 0 {
+		t.Errorf("expected 0 rows for header-only input, got %d", len(result.Rows))
+	}
+}
+
+func TestParseCoinbaseCSV_DollarSignParsing(t *testing.T) {
+	// Verify $ prefixed amounts parse correctly on a Buy (which uses Total and Fees)
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"abc1,2023-08-01 19:50:07 UTC,Buy,BTC,0.001,USD,$29244.04,$29.24,$30.24,$1.00,Bought BTC\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if math.Abs(r.CostBasisUSD-30.24) > 0.001 {
+		t.Errorf("expected CostBasisUSD 30.24 (parsed from $30.24), got %f", r.CostBasisUSD)
+	}
+	if math.Abs(r.FeeUSD-1.00) > 0.001 {
+		t.Errorf("expected FeeUSD 1.00 (parsed from $1.00), got %f", r.FeeUSD)
+	}
+}
+
+func TestParseCoinbaseCSV_AdvancedTradeBuy(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"atb1,2023-08-01 19:50:07 UTC,Advanced Trade Buy,BTC,0.001,USD,$29244.04,$29.24,$30.24,$1.00,Advanced trade\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+	if result.Rows[0].Type != "buy" {
+		t.Errorf("expected type 'buy' for Advanced Trade Buy, got %q", result.Rows[0].Type)
+	}
+}
+
+func TestParseCoinbaseCSV_AdvancedTradeSell(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"ats1,2023-08-01 19:50:07 UTC,Advanced Trade Sell,BTC,-0.001,USD,$29244.04,-$29.24,-$30.24,$1.00,Advanced trade sell\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+	if result.Rows[0].Type != "sale" {
+		t.Errorf("expected type 'sale' for Advanced Trade Sell, got %q", result.Rows[0].Type)
+	}
+}
+
+func TestParseCoinbaseCSV_RawLinePopulated(t *testing.T) {
+	dataLine := "abc123,2023-08-01 19:50:07 UTC,Buy,BTC,0.001,USD,$29244.04,$29.24,$30.24,$1.00,Bought 0.001 BTC"
+	input := coinbasePreamble(coinbaseHeader + "\n" + dataLine + "\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+	if result.Rows[0].RawLine == "" {
+		t.Error("expected RawLine to be populated, got empty string")
+	}
+}
+
+func TestParseCoinbaseCSV_BTCSell(t *testing.T) {
+	input := coinbasePreamble(coinbaseHeader + "\n" +
+		"sell1,2023-06-14 10:57:37 UTC,Sell,BTC,-0.001,USD,$25955.565,$25.96,$25.46,$0.50,Sold BTC\n")
+
+	result, err := ParseCoinbaseCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(result.Rows))
+	}
+
+	r := result.Rows[0]
+	if r.Type != "sale" {
+		t.Errorf("expected type 'sale', got %q", r.Type)
+	}
+	if r.AmountBTC >= 0 {
+		t.Errorf("expected negative AmountBTC for sell, got %f", r.AmountBTC)
+	}
+	if math.Abs(r.AmountUSD-25.96) > 0.001 {
+		t.Errorf("expected AmountUSD 25.96 (abs of Subtotal), got %f", r.AmountUSD)
+	}
+	if math.Abs(r.FeeUSD-0.50) > 0.001 {
+		t.Errorf("expected FeeUSD 0.50, got %f", r.FeeUSD)
+	}
+}
+
+func TestCoinbaseRow_IsPurchase(t *testing.T) {
+	tests := []struct {
+		typ  string
+		want bool
+	}{
+		{"buy", true},
+		{"sale", false},
+		{"send", false},
+		{"receive", false},
+	}
+
+	for _, tt := range tests {
+		r := CoinbaseRow{Type: tt.typ}
+		if got := r.IsPurchase(); got != tt.want {
+			t.Errorf("IsPurchase() for type %q = %v, want %v", tt.typ, got, tt.want)
+		}
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -41,6 +41,7 @@ type PriceProvider interface {
 type ImportStore interface {
 	ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
 	ImportRiverCSV(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error)
+	ImportCoinbaseCSV(ctx context.Context, rows []exchange.CoinbaseRow) (*db.ImportSummary, error)
 }
 
 // Handler serves dashboard API and HTML endpoints.
@@ -472,6 +473,65 @@ func (h *Handler) HandleRiverImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// HTMX request — render partial
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := h.renderer.Render(w, "import_result", resp); err != nil {
+			h.logger.Printf("failed to render import result: %v", err)
+		}
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleCoinbaseImport serves POST /api/import/coinbase.
+func (h *Handler) HandleCoinbaseImport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		h.logger.Printf("coinbase import: failed to parse multipart form: %v", err)
+		h.writeError(w, http.StatusBadRequest, "failed to parse upload: file may be too large (10MB max)")
+		return
+	}
+
+	file, fh, err := r.FormFile("file")
+	if err != nil {
+		h.logger.Printf("coinbase import: missing file field: %v", err)
+		h.writeError(w, http.StatusBadRequest, "missing 'file' field in upload")
+		return
+	}
+	defer file.Close()
+	h.logger.Printf("coinbase import: received file %q (%d bytes)", fh.Filename, fh.Size)
+
+	result, err := exchange.ParseCoinbaseCSV(file)
+	if err != nil {
+		h.logger.Printf("coinbase import: CSV parse error: %v", err)
+		h.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if len(result.Rows) == 0 {
+		h.writeError(w, http.StatusBadRequest, "CSV contains no BTC transactions")
+		return
+	}
+
+	summary, err := h.importStore.ImportCoinbaseCSV(r.Context(), result.Rows)
+	if err != nil {
+		h.logger.Printf("coinbase import failed: %v", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to import transactions")
+		return
+	}
+
+	resp := importResponse{
+		Total:        summary.Total,
+		NewPurchases: summary.NewPurchases,
+		Duplicates:   summary.Duplicates,
+		ParseErrors:  result.Errors,
+	}
+
 	if r.Header.Get("HX-Request") == "true" {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if err := h.renderer.Render(w, "import_result", resp); err != nil {

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -37,10 +37,12 @@ type DashboardData struct {
 	// Exchange balances
 	StrikeBalanceSats   int64
 	StrikeBalanceUSD    float64
-	RiverBalanceSats    int64
-	RiverBalanceUSD     float64
-	ExchangeBalanceSats int64
-	ExchangeBalanceUSD  float64
+	RiverBalanceSats      int64
+	RiverBalanceUSD       float64
+	CoinbaseBalanceSats   int64
+	CoinbaseBalanceUSD    float64
+	ExchangeBalanceSats   int64
+	ExchangeBalanceUSD    float64
 
 	// Price
 	BTCPriceUSD    float64
@@ -108,6 +110,7 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		priceFetched           time.Time
 		strikeBalance          int64
 		riverBalance           int64
+		coinbaseBalance        int64
 	}
 	var res result
 
@@ -231,6 +234,15 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	})
 
+	fetch(func() {
+		bal, err := h.store.ExchangeBalance(ctx, "coinbase")
+		if err == nil {
+			mu.Lock()
+			res.coinbaseBalance = bal
+			mu.Unlock()
+		}
+	})
+
 	wg.Wait()
 
 	// Assemble template data
@@ -259,7 +271,8 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	data.StrikeBalanceSats = res.strikeBalance
 	data.RiverBalanceSats = res.riverBalance
-	data.ExchangeBalanceSats = res.strikeBalance + res.riverBalance
+	data.CoinbaseBalanceSats = res.coinbaseBalance
+	data.ExchangeBalanceSats = res.strikeBalance + res.riverBalance + res.coinbaseBalance
 
 	if res.btcPrice > 0 {
 		data.BTCPriceUSD = res.btcPrice
@@ -268,6 +281,7 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		data.WalletBalanceUSD = float64(data.WalletBalanceSats) / 100_000_000.0 * res.btcPrice
 		data.StrikeBalanceUSD = float64(res.strikeBalance) / 100_000_000.0 * res.btcPrice
 		data.RiverBalanceUSD = float64(res.riverBalance) / 100_000_000.0 * res.btcPrice
+		data.CoinbaseBalanceUSD = float64(res.coinbaseBalance) / 100_000_000.0 * res.btcPrice
 		data.ExchangeBalanceUSD = float64(data.ExchangeBalanceSats) / 100_000_000.0 * res.btcPrice
 	}
 
@@ -392,6 +406,7 @@ type PLPageData struct {
 	FeesPaidUSD          float64
 	StrikeFeesPaidUSD    float64
 	RiverFeesPaidUSD     float64
+	CoinbaseFeesPaidUSD  float64
 
 	// Net position
 	NetBTCSats int64
@@ -438,8 +453,9 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 		feesMsat       int64
 		routedCount    int64
 		strikeSummary  *db.ExchangeSummaryResult
-		riverSummary   *db.ExchangeSummaryResult
-		nodeInfo       *lnd.NodeInfo
+		riverSummary    *db.ExchangeSummaryResult
+		coinbaseSummary *db.ExchangeSummaryResult
+		nodeInfo        *lnd.NodeInfo
 		lastSynced     time.Time
 		btcPrice       float64
 		priceFetched   time.Time
@@ -478,6 +494,15 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			mu.Lock()
 			res.riverSummary = summary
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		summary, err := h.store.ExchangeSummary(ctx, "coinbase", since)
+		if err == nil {
+			mu.Lock()
+			res.coinbaseSummary = summary
 			mu.Unlock()
 		}
 	})
@@ -526,7 +551,7 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 	data.RoutedCount = res.routedCount
 
 	// Aggregate exchange summaries across all sources
-	for _, s := range []*db.ExchangeSummaryResult{res.strikeSummary, res.riverSummary} {
+	for _, s := range []*db.ExchangeSummaryResult{res.strikeSummary, res.riverSummary, res.coinbaseSummary} {
 		if s != nil {
 			data.PurchasedSats += s.PurchasedSats
 			data.ReceivedSats += s.ReceivedSats
@@ -542,6 +567,9 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 	}
 	if res.riverSummary != nil {
 		data.RiverFeesPaidUSD = res.riverSummary.FeesPaidUSD
+	}
+	if res.coinbaseSummary != nil {
+		data.CoinbaseFeesPaidUSD = res.coinbaseSummary.FeesPaidUSD
 	}
 
 	// Net BTC = routing fees + purchased + received - sold - sent

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -96,8 +96,9 @@ func (m *mockPrice) FetchedAt() time.Time {
 }
 
 type mockImportStore struct {
-	importStrikeFn func(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
-	importRiverFn  func(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error)
+	importStrikeFn   func(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
+	importRiverFn    func(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error)
+	importCoinbaseFn func(ctx context.Context, rows []exchange.CoinbaseRow) (*db.ImportSummary, error)
 }
 
 func (m *mockImportStore) ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error) {
@@ -110,6 +111,13 @@ func (m *mockImportStore) ImportStrikeCSV(ctx context.Context, rows []exchange.S
 func (m *mockImportStore) ImportRiverCSV(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error) {
 	if m.importRiverFn != nil {
 		return m.importRiverFn(ctx, rows)
+	}
+	return &db.ImportSummary{}, nil
+}
+
+func (m *mockImportStore) ImportCoinbaseCSV(ctx context.Context, rows []exchange.CoinbaseRow) (*db.ImportSummary, error) {
+	if m.importCoinbaseFn != nil {
+		return m.importCoinbaseFn(ctx, rows)
 	}
 	return &db.ImportSummary{}, nil
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -36,6 +36,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
 	mux.HandleFunc("/api/node", handler.HandleNode)
 	mux.HandleFunc("/api/import/strike", handler.HandleStrikeImport)
 	mux.HandleFunc("/api/import/river", handler.HandleRiverImport)
+	mux.HandleFunc("/api/import/coinbase", handler.HandleCoinbaseImport)
 
 	return &Server{
 		httpServer: &http.Server{

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -31,7 +31,7 @@
     {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .WalletBalanceUSD}}</div>{{end}}
   </div>
 
-  {{if or .StrikeBalanceSats .RiverBalanceSats}}
+  {{if or .StrikeBalanceSats .RiverBalanceSats .CoinbaseBalanceSats}}
   <div class="card">
     <div class="card-label">Exchange Balance <span style="font-size:0.75em;color:var(--text-muted);">(from CSV import)</span></div>
     <div class="card-value">{{formatSats .ExchangeBalanceSats}} <small>sats</small></div>
@@ -39,6 +39,7 @@
     <div style="margin-top: 8px; font-size: 0.8em; color: var(--text-muted);">
       {{if .StrikeBalanceSats}}<div>Strike: {{formatSats .StrikeBalanceSats}} sats</div>{{end}}
       {{if .RiverBalanceSats}}<div>River: {{formatSats .RiverBalanceSats}} sats</div>{{end}}
+      {{if .CoinbaseBalanceSats}}<div>Coinbase: {{formatSats .CoinbaseBalanceSats}} sats</div>{{end}}
     </div>
   </div>
   {{end}}

--- a/internal/web/templates/import.html
+++ b/internal/web/templates/import.html
@@ -4,6 +4,7 @@
 <div style="display: flex; gap: 16px; margin-bottom: 16px;">
   <button class="filter-form" id="tab-strike" onclick="showTab('strike')" style="display: inline-block;">Strike</button>
   <button class="filter-form" id="tab-river" onclick="showTab('river')" style="display: inline-block; opacity: 0.6;">River</button>
+  <button class="filter-form" id="tab-coinbase" onclick="showTab('coinbase')" style="display: inline-block; opacity: 0.6;">Coinbase</button>
 </div>
 
 <div id="panel-strike" class="card" style="max-width: 600px;">
@@ -50,14 +51,38 @@
   </form>
 </div>
 
+<div id="panel-coinbase" class="card" style="max-width: 600px; display: none;">
+  <div class="card-label">Upload Coinbase CSV</div>
+  <p class="card-sub" style="margin-bottom: 16px;">
+    Import your Coinbase transaction history (BTC only). Export from Coinbase: Reports &gt; Generate Report &gt; Transaction History &gt; Download CSV.
+  </p>
+
+  <form hx-post="/api/import/coinbase"
+        hx-target="#import-result"
+        hx-swap="innerHTML"
+        hx-encoding="multipart/form-data"
+        hx-indicator="#import-loading-coinbase">
+    <div style="margin-bottom: 12px;">
+      <input type="file" name="file" accept=".csv" required
+             style="background: var(--bg); border: 1px solid var(--border); border-radius: 4px; color: var(--text); padding: 8px; width: 100%;">
+    </div>
+    <button type="submit" class="filter-form" style="display: inline-block;">
+      Upload
+    </button>
+    <span id="import-loading-coinbase" class="htmx-indicator">Importing...</span>
+  </form>
+</div>
+
 <div id="import-result" style="margin-top: 20px;"></div>
 
 <script>
 function showTab(name) {
   document.getElementById('panel-strike').style.display = name === 'strike' ? 'block' : 'none';
   document.getElementById('panel-river').style.display = name === 'river' ? 'block' : 'none';
+  document.getElementById('panel-coinbase').style.display = name === 'coinbase' ? 'block' : 'none';
   document.getElementById('tab-strike').style.opacity = name === 'strike' ? '1' : '0.6';
   document.getElementById('tab-river').style.opacity = name === 'river' ? '1' : '0.6';
+  document.getElementById('tab-coinbase').style.opacity = name === 'coinbase' ? '1' : '0.6';
 }
 </script>
 {{end}}

--- a/internal/web/templates/import.html
+++ b/internal/web/templates/import.html
@@ -54,7 +54,7 @@
 <div id="panel-coinbase" class="card" style="max-width: 600px; display: none;">
   <div class="card-label">Upload Coinbase CSV</div>
   <p class="card-sub" style="margin-bottom: 16px;">
-    Import your Coinbase transaction history (BTC only). Export from Coinbase: Reports &gt; Generate Report &gt; Transaction History &gt; Download CSV.
+    Import your Coinbase transaction history (BTC only). Export from Coinbase: Manage Account &gt; Statements &gt; Generate Statement.
   </p>
 
   <form hx-post="/api/import/coinbase"

--- a/internal/web/templates/pl.html
+++ b/internal/web/templates/pl.html
@@ -56,10 +56,11 @@
   <div class="card">
     <div class="card-label">Fees Paid</div>
     <div class="card-value">{{formatUSD .FeesPaidUSD}}</div>
-    {{if or .StrikeFeesPaidUSD .RiverFeesPaidUSD}}
+    {{if or .StrikeFeesPaidUSD .RiverFeesPaidUSD .CoinbaseFeesPaidUSD}}
     <div style="margin-top: 8px; font-size: 0.8em; color: var(--text-muted);">
       {{if .StrikeFeesPaidUSD}}<div>Strike: {{formatUSD .StrikeFeesPaidUSD}}</div>{{end}}
       {{if .RiverFeesPaidUSD}}<div>River: {{formatUSD .RiverFeesPaidUSD}}</div>{{end}}
+      {{if .CoinbaseFeesPaidUSD}}<div>Coinbase: {{formatUSD .CoinbaseFeesPaidUSD}}</div>{{end}}
     </div>
     {{end}}
   </div>


### PR DESCRIPTION
## Summary
- Coinbase retail CSV parser that filters to BTC-only transactions, skips preamble lines, and handles $-prefixed amounts
- Supports Buy, Sell, Send, Receive, Convert (from BTC), Advanced Trade Buy/Sell, and Staking Income transaction types
- Adds Coinbase tab to import UI, balance on dashboard, and fee breakdown on P&L page
- 14 parser unit tests + 6 DB-level tests, db coverage at 79.1%

Closes #50

## Test plan
- [x] Upload real Coinbase CSV — verify only BTC rows imported
- [x] Re-import same CSV — verify deduplication (all duplicates)
- [x] Check dashboard shows Coinbase balance in Exchange Balance card
- [x] Check P&L page shows Coinbase fees in per-source breakdown
- [x] Verify `go test ./...` passes
- [x] Verify db coverage >= 75%