### PR TITLE
feat(ci): automated release pipeline (task 1.7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,144 @@
+name: Release
+
+# Triggered by pushing a semver tag (e.g. v0.2.0). The full pipeline:
+#   1. Build & push multi-arch Docker image to ghcr.io
+#   2. Cross-compile linux/amd64 + linux/arm64 binaries
+#   3. Create a GitHub Release with auto-generated notes + binaries
+#   4. Update satsbook/umbrel-app-store with the new version
+#
+# Required secrets:
+#   GITHUB_TOKEN     — automatic, used for ghcr.io push and release creation
+#   UMBREL_STORE_PAT — fine-grained PAT with contents:write on
+#                      satsbook/umbrel-app-store, added as a repo secret
+#
+# Required one-time setup after the first push:
+#   - Make the ghcr.io/satsbook/satsbook package public in package settings.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # create releases
+  packages: write   # push to ghcr.io
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  release:
+    name: Build, publish, release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so release notes can diff against previous tag
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Cross-compile release binaries
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          mkdir -p dist
+          LDFLAGS="-s -w -X main.version=${VERSION}"
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+            go build -ldflags "$LDFLAGS" -o dist/satsbook-linux-amd64 ./cmd/satsbook
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+            go build -ldflags "$LDFLAGS" -o dist/satsbook-linux-arm64 ./cmd/satsbook
+          ls -lh dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/satsbook-linux-amd64
+            dist/satsbook-linux-arm64
+
+      - name: Update Umbrel app store
+        env:
+          UMBREL_STORE_PAT: ${{ secrets.UMBREL_STORE_PAT }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${UMBREL_STORE_PAT}" ]; then
+            echo "::error::UMBREL_STORE_PAT secret is not set — skipping app store update"
+            exit 1
+          fi
+
+          git config --global user.name  "satsbook-release-bot"
+          git config --global user.email "release-bot@satsbook.invalid"
+
+          REPO_DIR="$(mktemp -d)"
+          git clone --depth 1 \
+            "https://x-access-token:${UMBREL_STORE_PAT}@github.com/satsbook/umbrel-app-store.git" \
+            "$REPO_DIR"
+
+          cd "$REPO_DIR"
+
+          APP_FILE="satsbook-satsbook/umbrel-app.yml"
+          COMPOSE_FILE="satsbook-satsbook/docker-compose.yml"
+
+          # Bump the `version:` line in umbrel-app.yml (anchored at line start).
+          sed -i -E "s|^version:.*|version: \"${VERSION}\"|" "$APP_FILE"
+
+          # Bump the image tag in docker-compose.yml.
+          sed -i -E \
+            "s|image: ghcr.io/satsbook/satsbook:[^[:space:]]+|image: ghcr.io/satsbook/satsbook:${VERSION}|" \
+            "$COMPOSE_FILE"
+
+          echo "--- updated $APP_FILE ---"
+          grep '^version:' "$APP_FILE"
+          echo "--- updated $COMPOSE_FILE ---"
+          grep 'image: ghcr.io/satsbook/satsbook:' "$COMPOSE_FILE"
+
+          if git diff --quiet; then
+            echo "No changes to umbrel-app-store — already at v${VERSION}?"
+            exit 0
+          fi
+
+          git add "$APP_FILE" "$COMPOSE_FILE"
+          git commit -m "chore: bump satsbook to v${VERSION}"
+          git push origin main

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,18 @@ FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git
 
+# VERSION is injected by the release pipeline (or by `make`) so the running
+# binary can report its own version. Defaults to "dev" for local builds.
+ARG VERSION=dev
+
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /satsbook ./cmd/satsbook
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w -X main.version=${VERSION}" \
+    -o /satsbook ./cmd/satsbook
 
 # Stage 2: Minimal runtime image
 FROM alpine:3.21

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing Satsbook
+
+Releases are fully automated by `.github/workflows/release.yml`, triggered when a
+semver tag matching `v*` is pushed to `main`.
+
+## What a release does
+
+1. Builds and pushes a multi-arch Docker image (`linux/amd64`, `linux/arm64`) to
+   `ghcr.io/satsbook/satsbook:<version>` and `:latest`.
+2. Cross-compiles `satsbook-linux-amd64` and `satsbook-linux-arm64` binaries.
+3. Creates a GitHub Release with auto-generated notes and the binaries attached.
+4. Clones `satsbook/umbrel-app-store`, bumps the version in
+   `satsbook-satsbook/umbrel-app.yml` and the image tag in
+   `satsbook-satsbook/docker-compose.yml`, and pushes the change to `main`.
+
+## Cutting a release
+
+```bash
+# From an up-to-date main:
+git checkout main
+git pull --ff-only
+git tag -a v0.2.0 -m "v0.2.0"
+git push origin v0.2.0
+```
+
+Then watch the workflow at:
+https://github.com/satsbook/satsbook/actions/workflows/release.yml
+
+## One-time setup
+
+### `UMBREL_STORE_PAT` secret (required)
+
+The workflow needs a fine-grained Personal Access Token to push to the app store
+repo. Create one at https://github.com/settings/personal-access-tokens/new with:
+
+- **Resource owner**: `satsbook`
+- **Repository access**: only `satsbook/umbrel-app-store`
+- **Permissions**: Repository → **Contents: Read and write**
+
+Add it as a repo secret on `satsbook/satsbook` named `UMBREL_STORE_PAT`.
+
+### Make the GHCR package public (after first release)
+
+After the first successful release, the container image will be private by
+default. Make it public:
+
+1. https://github.com/orgs/satsbook/packages
+2. Select `satsbook` → Package settings → Change visibility → Public.
+
+## Version reporting
+
+The running binary prints its version on startup:
+
+```
+satsbook 0.2.0 - Bitcoin node analytics and accounting
+```
+
+This is injected at build time via `-ldflags "-X main.version=<tag>"` in both
+the Dockerfile and the release workflow. Local `make build` produces a binary
+that reports `dev`.

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -17,8 +17,12 @@ import (
 	"github.com/satsbook/satsbook/internal/web"
 )
 
+// version is set at build time via -ldflags "-X main.version=<tag>".
+// Defaults to "dev" for local builds.
+var version = "dev"
+
 func main() {
-	fmt.Println("satsbook - Bitcoin node analytics and accounting")
+	fmt.Printf("satsbook %s - Bitcoin node analytics and accounting\n", version)
 
 	// Load configuration
 	cfg, err := config.Load()


### PR DESCRIPTION
## Summary
- Tag-triggered (`v*`) GitHub Actions workflow that builds multi-arch Docker images (`linux/amd64`, `linux/arm64`), pushes to `ghcr.io/satsbook/satsbook`, and creates a GitHub Release with cross-compiled binaries
- Workflow also clones `satsbook/umbrel-app-store` and bumps the version + image tag in `satsbook-satsbook/umbrel-app.yml` and `docker-compose.yml`
- Binary now reports its build version via `-ldflags -X main.version=<tag>` (defaults to `dev`)
- Adds `RELEASING.md` documenting the cut-a-release flow and one-time setup

## Required user action before first release
- [ ] Create fine-grained PAT with `contents:write` on `satsbook/umbrel-app-store`, add as repo secret `UMBREL_STORE_PAT` on `satsbook/satsbook`
- [ ] After the first successful release, make `ghcr.io/satsbook/satsbook` package public

## Test plan
- [ ] Push a `v0.0.0-test` tag from a throwaway branch and verify the workflow succeeds end-to-end
- [ ] Confirm `ghcr.io/satsbook/satsbook:<version>` exists for both arches
- [ ] Confirm a GitHub Release was created with both binaries attached
- [ ] Confirm `satsbook/umbrel-app-store` received the version bump commit
- [ ] Run `docker run ghcr.io/satsbook/satsbook:<version>` and confirm it prints the correct version on startup

Closes #48