### PR TITLE
feat(web): per-vendor clear for imported exchange data

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -613,6 +613,69 @@ func (d *DB) PortfolioPosition(ctx context.Context, since time.Time) (*Portfolio
 	return result, nil
 }
 
+// validExchangeSources is the allowlist of source names accepted by destructive
+// per-vendor operations. Keep in sync with the import handlers.
+var validExchangeSources = map[string]bool{
+	"strike":   true,
+	"river":    true,
+	"coinbase": true,
+}
+
+// IsValidExchangeSource reports whether the given source is a known vendor.
+func IsValidExchangeSource(source string) bool {
+	return validExchangeSources[source]
+}
+
+// ClearExchangeResult summarises the rows removed by ClearExchangeSource.
+type ClearExchangeResult struct {
+	Source          string
+	ImportsRemoved  int64
+	LotsRemoved     int64
+}
+
+// ClearExchangeSource deletes all imported data for a single exchange source
+// (both exchange_imports and btc_lots) in a single transaction. Other vendors
+// and node-sourced tables are never touched.
+func (d *DB) ClearExchangeSource(ctx context.Context, source string) (*ClearExchangeResult, error) {
+	if !IsValidExchangeSource(source) {
+		return nil, fmt.Errorf("clear exchange: invalid source %q", source)
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("clear exchange: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	lotsRes, err := tx.ExecContext(ctx, `DELETE FROM btc_lots WHERE source = ?`, source)
+	if err != nil {
+		return nil, fmt.Errorf("clear exchange: delete btc_lots: %w", err)
+	}
+	lotsRemoved, err := lotsRes.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("clear exchange: btc_lots rows affected: %w", err)
+	}
+
+	impRes, err := tx.ExecContext(ctx, `DELETE FROM exchange_imports WHERE source = ?`, source)
+	if err != nil {
+		return nil, fmt.Errorf("clear exchange: delete exchange_imports: %w", err)
+	}
+	importsRemoved, err := impRes.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("clear exchange: exchange_imports rows affected: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("clear exchange: commit: %w", err)
+	}
+
+	return &ClearExchangeResult{
+		Source:         source,
+		ImportsRemoved: importsRemoved,
+		LotsRemoved:    lotsRemoved,
+	}, nil
+}
+
 // ExchangeBalance returns the net BTC balance (in sats) for a given exchange source
 // by summing AmountBTC only from rows that actually move BTC (non-zero AmountBTC).
 // USD-only transactions (e.g. cash withdrawals) are excluded.

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1219,3 +1219,73 @@ func TestPortfolioPosition_SinceFiltering(t *testing.T) {
 		t.Errorf("recent purchased: expected 200000, got %d", recentOnly.PurchasedSats)
 	}
 }
+
+// --- ClearExchangeSource tests ---
+
+func TestClearExchangeSource_InvalidSource(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	if _, err := d.ClearExchangeSource(context.Background(), "kraken"); err == nil {
+		t.Fatal("expected error for invalid source, got nil")
+	}
+	if _, err := d.ClearExchangeSource(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty source, got nil")
+	}
+}
+
+func TestClearExchangeSource_EmptyIsNoop(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	res, err := d.ClearExchangeSource(context.Background(), "strike")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ImportsRemoved != 0 || res.LotsRemoved != 0 {
+		t.Errorf("expected 0/0, got %d/%d", res.ImportsRemoved, res.LotsRemoved)
+	}
+}
+
+func TestClearExchangeSource_IsolatesVendors(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	// Seed strike (3 imports, 1 lot) and river (3 imports, 2 lots).
+	if _, err := d.ImportStrikeCSV(context.Background(), testStrikeRows()); err != nil {
+		t.Fatalf("strike import: %v", err)
+	}
+	if _, err := d.ImportRiverCSV(context.Background(), testRiverRows()); err != nil {
+		t.Fatalf("river import: %v", err)
+	}
+
+	res, err := d.ClearExchangeSource(context.Background(), "strike")
+	if err != nil {
+		t.Fatalf("clear strike: %v", err)
+	}
+	if res.ImportsRemoved != 3 {
+		t.Errorf("expected 3 strike imports removed, got %d", res.ImportsRemoved)
+	}
+	if res.LotsRemoved != 1 {
+		t.Errorf("expected 1 strike lot removed, got %d", res.LotsRemoved)
+	}
+
+	// Strike fully gone.
+	var strikeImports, strikeLots int
+	d.db.QueryRow("SELECT COUNT(*) FROM exchange_imports WHERE source = 'strike'").Scan(&strikeImports)
+	d.db.QueryRow("SELECT COUNT(*) FROM btc_lots WHERE source = 'strike'").Scan(&strikeLots)
+	if strikeImports != 0 || strikeLots != 0 {
+		t.Errorf("strike not fully cleared: imports=%d lots=%d", strikeImports, strikeLots)
+	}
+
+	// River untouched.
+	var riverImports, riverLots int
+	d.db.QueryRow("SELECT COUNT(*) FROM exchange_imports WHERE source = 'river'").Scan(&riverImports)
+	d.db.QueryRow("SELECT COUNT(*) FROM btc_lots WHERE source = 'river'").Scan(&riverLots)
+	if riverImports != 3 {
+		t.Errorf("river imports should be untouched, got %d", riverImports)
+	}
+	if riverLots != 2 {
+		t.Errorf("river lots should be untouched, got %d", riverLots)
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -43,6 +43,7 @@ type ImportStore interface {
 	ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
 	ImportRiverCSV(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error)
 	ImportCoinbaseCSV(ctx context.Context, rows []exchange.CoinbaseRow) (*db.ImportSummary, error)
+	ClearExchangeSource(ctx context.Context, source string) (*db.ClearExchangeResult, error)
 }
 
 // Handler serves dashboard API and HTML endpoints.
@@ -546,4 +547,59 @@ func (h *Handler) HandleCoinbaseImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.writeJSON(w, http.StatusOK, resp)
+}
+
+type clearImportResponse struct {
+	Source         string `json:"source"`
+	ImportsRemoved int64  `json:"imports_removed"`
+	LotsRemoved    int64  `json:"lots_removed"`
+}
+
+// HandleClearImport serves POST /api/import/{vendor}/clear. It wipes every row
+// in exchange_imports and btc_lots belonging to the given vendor after a
+// `confirm=yes` form field is present. Only HTMX requests are accepted to
+// prevent accidental wipes from stray curl commands.
+func (h *Handler) HandleClearImport(source string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if r.Header.Get("HX-Request") != "true" {
+			h.writeError(w, http.StatusBadRequest, "clear must be invoked from the UI")
+			return
+		}
+		if !db.IsValidExchangeSource(source) {
+			h.writeError(w, http.StatusBadRequest, "invalid source")
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			h.writeError(w, http.StatusBadRequest, "failed to parse form")
+			return
+		}
+		if r.FormValue("confirm") != "yes" {
+			h.writeError(w, http.StatusBadRequest, "confirmation required")
+			return
+		}
+
+		result, err := h.importStore.ClearExchangeSource(r.Context(), source)
+		if err != nil {
+			h.logger.Printf("clear %s: %v", source, err)
+			h.writeError(w, http.StatusInternalServerError, "failed to clear data")
+			return
+		}
+		h.logger.Printf("cleared %s: %d imports, %d lots removed", source, result.ImportsRemoved, result.LotsRemoved)
+
+		resp := clearImportResponse{
+			Source:         result.Source,
+			ImportsRemoved: result.ImportsRemoved,
+			LotsRemoved:    result.LotsRemoved,
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("HX-Trigger", "satsbook:data-cleared")
+		if err := h.renderer.Render(w, "clear_import_result", resp); err != nil {
+			h.logger.Printf("failed to render clear result: %v", err)
+		}
+	}
 }

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -387,10 +387,34 @@ func (h *Handler) HandleForwardingPartial(w http.ResponseWriter, r *http.Request
 	}
 }
 
+// ImportPageData is passed to the import page template.
+type ImportPageData struct {
+	HasStrike   bool
+	HasRiver    bool
+	HasCoinbase bool
+}
+
 // HandleImportPage serves GET /import.
 func (h *Handler) HandleImportPage(w http.ResponseWriter, r *http.Request) {
+	data := ImportPageData{}
+	// Query per-source presence. We only care whether the vendor has any
+	// rows so the danger zone can be revealed; any error here is non-fatal.
+	if pos, err := h.store.PortfolioPosition(r.Context(), time.Time{}); err == nil && pos != nil {
+		if s, ok := pos.BySource["strike"]; ok && (s.NetSats != 0 || s.PurchasedSats != 0) {
+			data.HasStrike = true
+		}
+		if s, ok := pos.BySource["river"]; ok && (s.NetSats != 0 || s.PurchasedSats != 0) {
+			data.HasRiver = true
+		}
+		if s, ok := pos.BySource["coinbase"]; ok && (s.NetSats != 0 || s.PurchasedSats != 0) {
+			data.HasCoinbase = true
+		}
+	} else if err != nil {
+		h.logger.Printf("import page: portfolio position lookup failed: %v", err)
+	}
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := h.renderer.Render(w, "import_layout", nil); err != nil {
+	if err := h.renderer.Render(w, "import_layout", data); err != nil {
 		h.logger.Printf("failed to render import page: %v", err)
 	}
 }

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -106,6 +106,14 @@ type mockImportStore struct {
 	importStrikeFn   func(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
 	importRiverFn    func(ctx context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error)
 	importCoinbaseFn func(ctx context.Context, rows []exchange.CoinbaseRow) (*db.ImportSummary, error)
+	clearFn          func(ctx context.Context, source string) (*db.ClearExchangeResult, error)
+}
+
+func (m *mockImportStore) ClearExchangeSource(ctx context.Context, source string) (*db.ClearExchangeResult, error) {
+	if m.clearFn != nil {
+		return m.clearFn(ctx, source)
+	}
+	return &db.ClearExchangeResult{Source: source}, nil
 }
 
 func (m *mockImportStore) ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error) {
@@ -660,5 +668,78 @@ func TestHandleStrikeImport_HTMXResponse(t *testing.T) {
 	body := w.Body.String()
 	if !strings.Contains(body, "new purchase") {
 		t.Errorf("expected summary in HTML, got: %s", body)
+	}
+}
+
+// --- HandleClearImport tests ---
+
+func TestHandleClearImport_Success(t *testing.T) {
+	importStore := &mockImportStore{
+		clearFn: func(ctx context.Context, source string) (*db.ClearExchangeResult, error) {
+			return &db.ClearExchangeResult{Source: source, ImportsRemoved: 5, LotsRemoved: 2}, nil
+		},
+	}
+	h := NewHandler(&mockStore{}, nil, &mockPrice{}, importStore, log.New(os.Stderr, "[test] ", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/import/strike/clear", strings.NewReader("confirm=yes"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	w := httptest.NewRecorder()
+	h.HandleClearImport("strike")(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("HX-Trigger") != "satsbook:data-cleared" {
+		t.Errorf("missing HX-Trigger header")
+	}
+	if !strings.Contains(w.Body.String(), "strike") {
+		t.Errorf("expected body to mention source, got: %s", w.Body.String())
+	}
+}
+
+func TestHandleClearImport_MissingConfirm(t *testing.T) {
+	h := NewHandler(&mockStore{}, nil, &mockPrice{}, &mockImportStore{}, log.New(os.Stderr, "[test] ", 0))
+	req := httptest.NewRequest(http.MethodPost, "/api/import/strike/clear", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	w := httptest.NewRecorder()
+	h.HandleClearImport("strike")(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleClearImport_NonHTMXRejected(t *testing.T) {
+	h := NewHandler(&mockStore{}, nil, &mockPrice{}, &mockImportStore{}, log.New(os.Stderr, "[test] ", 0))
+	req := httptest.NewRequest(http.MethodPost, "/api/import/strike/clear", strings.NewReader("confirm=yes"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleClearImport("strike")(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-HTMX, got %d", w.Code)
+	}
+}
+
+func TestHandleClearImport_InvalidSource(t *testing.T) {
+	h := NewHandler(&mockStore{}, nil, &mockPrice{}, &mockImportStore{}, log.New(os.Stderr, "[test] ", 0))
+	req := httptest.NewRequest(http.MethodPost, "/api/import/kraken/clear", strings.NewReader("confirm=yes"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	w := httptest.NewRecorder()
+	h.HandleClearImport("kraken")(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid source, got %d", w.Code)
+	}
+}
+
+func TestHandleClearImport_GETRejected(t *testing.T) {
+	h := NewHandler(&mockStore{}, nil, &mockPrice{}, &mockImportStore{}, log.New(os.Stderr, "[test] ", 0))
+	req := httptest.NewRequest(http.MethodGet, "/api/import/strike/clear", nil)
+	req.Header.Set("HX-Request", "true")
+	w := httptest.NewRecorder()
+	h.HandleClearImport("strike")(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -37,6 +37,9 @@ func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
 	mux.HandleFunc("/api/import/strike", handler.HandleStrikeImport)
 	mux.HandleFunc("/api/import/river", handler.HandleRiverImport)
 	mux.HandleFunc("/api/import/coinbase", handler.HandleCoinbaseImport)
+	mux.Handle("/api/import/strike/clear", handler.HandleClearImport("strike"))
+	mux.Handle("/api/import/river/clear", handler.HandleClearImport("river"))
+	mux.Handle("/api/import/coinbase/clear", handler.HandleClearImport("coinbase"))
 
 	return &Server{
 		httpServer: &http.Server{

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -31,6 +31,20 @@ func NewRenderer() *Renderer {
 		"add":         func(a, b int) int { return a + b },
 		"add64":       func(a, b int64) int64 { return a + b },
 		"seq":         seq,
+		"dict": func(kv ...interface{}) (map[string]interface{}, error) {
+			if len(kv)%2 != 0 {
+				return nil, fmt.Errorf("dict requires even number of args")
+			}
+			m := make(map[string]interface{}, len(kv)/2)
+			for i := 0; i < len(kv); i += 2 {
+				k, ok := kv[i].(string)
+				if !ok {
+					return nil, fmt.Errorf("dict keys must be strings")
+				}
+				m[k] = kv[i+1]
+			}
+			return m, nil
+		},
 	}
 
 	tmpl := template.Must(
@@ -42,6 +56,8 @@ func NewRenderer() *Renderer {
 			"templates/partials/forwarding_table.html",
 			"templates/partials/channel_table.html",
 			"templates/partials/import_result.html",
+			"templates/partials/clear_import_result.html",
+			"templates/partials/danger_zone.html",
 			"templates/pl_layout.html",
 			"templates/pl.html",
 		),

--- a/internal/web/templates/import.html
+++ b/internal/web/templates/import.html
@@ -27,6 +27,10 @@
     </button>
     <span id="import-loading" class="htmx-indicator">Importing...</span>
   </form>
+
+  {{if .HasStrike}}
+  {{template "danger_zone" (dict "Vendor" "strike" "Label" "Strike")}}
+  {{end}}
 </div>
 
 <div id="panel-river" class="card" style="max-width: 600px; display: none;">
@@ -49,6 +53,10 @@
     </button>
     <span id="import-loading-river" class="htmx-indicator">Importing...</span>
   </form>
+
+  {{if .HasRiver}}
+  {{template "danger_zone" (dict "Vendor" "river" "Label" "River")}}
+  {{end}}
 </div>
 
 <div id="panel-coinbase" class="card" style="max-width: 600px; display: none;">
@@ -71,6 +79,10 @@
     </button>
     <span id="import-loading-coinbase" class="htmx-indicator">Importing...</span>
   </form>
+
+  {{if .HasCoinbase}}
+  {{template "danger_zone" (dict "Vendor" "coinbase" "Label" "Coinbase")}}
+  {{end}}
 </div>
 
 <div id="import-result" style="margin-top: 20px;"></div>

--- a/internal/web/templates/partials/clear_import_result.html
+++ b/internal/web/templates/partials/clear_import_result.html
@@ -1,0 +1,10 @@
+{{define "clear_import_result"}}
+<div class="card" style="border-left: 3px solid var(--success, #4ade80);">
+  <div class="card-label" style="color: var(--success, #4ade80);">Data Cleared</div>
+  <p style="margin-top: 8px;">
+    Removed <strong>{{.ImportsRemoved}}</strong> imported transaction{{if ne .ImportsRemoved 1}}s{{end}}
+    and <strong>{{.LotsRemoved}}</strong> cost-basis lot{{if ne .LotsRemoved 1}}s{{end}}
+    for <strong>{{.Source}}</strong>.
+  </p>
+</div>
+{{end}}

--- a/internal/web/templates/partials/danger_zone.html
+++ b/internal/web/templates/partials/danger_zone.html
@@ -1,0 +1,25 @@
+{{define "danger_zone"}}
+<div style="margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--border);">
+  <div class="card-label" style="color: var(--danger, #ef4444);">⚠ Danger Zone</div>
+  <p class="card-sub" style="margin: 8px 0 12px;">
+    Permanently delete all imported {{.Label}} transactions and cost-basis lots.
+    This cannot be undone. Your Lightning node data is not affected.
+  </p>
+
+  <form hx-post="/api/import/{{.Vendor}}/clear"
+        hx-target="#clear-result-{{.Vendor}}"
+        hx-swap="innerHTML"
+        hx-indicator="#clear-loading-{{.Vendor}}">
+    <label style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px; font-size: 0.9em;">
+      <input type="checkbox" name="confirm" value="yes" required>
+      I understand this will permanently delete all {{.Label}} import data.
+    </label>
+    <button type="submit"
+            style="background: var(--danger, #ef4444); color: white; border: none; border-radius: 4px; padding: 8px 16px; cursor: pointer; font-weight: 600;">
+      Delete all {{.Label}} data
+    </button>
+    <span id="clear-loading-{{.Vendor}}" class="htmx-indicator">Clearing...</span>
+  </form>
+  <div id="clear-result-{{.Vendor}}" style="margin-top: 12px;"></div>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary
- New \`DB.ClearExchangeSource(ctx, source)\` wipes \`exchange_imports\` + \`btc_lots\` rows for a single vendor in one transaction
- Source is validated against an allowlist (\`strike\`, \`river\`, \`coinbase\`); other tables never touched
- New \`POST /api/import/{vendor}/clear\` handler gated by \`HX-Request: true\` header + \`confirm=yes\` form field
- Danger Zone block rendered under each vendor tab on \`/import\`, only when that vendor has existing data
- Checkbox + red button combo as the confirmation UX
- Handler sets \`HX-Trigger: satsbook:data-cleared\` so the dashboard can refresh if listening

## Test plan
- [x] DB: TestClearExchangeSource — invalid source, empty no-op, isolation between vendors
- [x] Handler: success, missing confirm, non-HTMX rejected, invalid source, GET rejected
- [x] Manual: import Strike CSV, open \`/import\`, tick the danger zone checkbox, click Delete, confirm dashboard reflects cleared state

Closes #60