### PR TITLE
fix(umbrel): update packaging for app store submission

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,16 @@ services:
   app_proxy:
     environment:
       APP_HOST: satsbook_server_1
-      APP_PORT: 3000
+      APP_PORT: 3015
 
   server:
-    image: ghcr.io/satsbook/satsbook:${APP_SATSBOOK_VERSION:-latest}
+    image: ghcr.io/satsbook/satsbook:1.0.0@sha256:4a265925e6903da45a0aa82653e9f17be97b47d63422212680025bcf418a8cc5
     container_name: satsbook_server_1
     restart: on-failure
     stop_grace_period: 1m
     init: true
     volumes:
-      - satsbook_data:/data
+      - ${APP_DATA_DIR}/data:/data
       - ${APP_LIGHTNING_NODE_DATA_DIR:-/dev/null}:/lnd:ro
     environment:
       SATSBOOK_LND_HOST: ${APP_LIGHTNING_NODE_IP:-localhost}
@@ -21,11 +21,5 @@ services:
       SATSBOOK_LND_MACAROON_PATH: /lnd/data/chain/bitcoin/mainnet/readonly.macaroon
       SATSBOOK_LND_TLS_CERT_PATH: /lnd/tls.cert
       SATSBOOK_DATABASE_PATH: /data/satsbook.db
-      SATSBOOK_APP_PORT: 3000
+      SATSBOOK_APP_PORT: 3015
       SATSBOOK_LOG_LEVEL: info
-    networks:
-      default:
-        ipv4_address: ${APP_SATSBOOK_IP:-10.21.22.50}
-
-volumes:
-  satsbook_data:

--- a/umbrel-app.yml
+++ b/umbrel-app.yml
@@ -2,26 +2,24 @@ manifestVersion: 1
 id: satsbook
 category: bitcoin
 name: Satsbook
-version: "0.1.0"
+version: "1.0.0"
 tagline: Bitcoin node analytics and accounting for Lightning operators
 description: >-
   Track routing fees, manage cost basis from exchange imports, and view
   profit & loss — all on your own hardware. Satsbook connects to your
   LND node and provides a privacy-first dashboard with fee analytics,
   Strike CSV import, and a basic P&L view. No cloud services required.
-developer: satsbook
+developer: brewgator
 website: https://github.com/satsbook/satsbook
 repo: https://github.com/satsbook/satsbook
 support: https://github.com/satsbook/satsbook/issues
 dependencies:
   - lightning
-port: 3000
+port: 3015
 gallery: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: >-
-  Initial release. Fee analytics dashboard, Strike CSV import,
-  basic P&L view with period selectors.
+releaseNotes: ""
 submitter: brewgator
-submission: ""
+submission: https://github.com/getumbrel/umbrel-apps/pull/5451


### PR DESCRIPTION
## Summary

- Pin Docker image to `v1.0.0` with sha256 digest for reproducibility
- Change port from 3000 to 3015 to avoid conflict with ThunderHub
- Use Umbrel `APP_DATA_DIR` volume instead of named volume
- Remove static IP network block (not needed with app_proxy)
- Set developer to `brewgator`, version to `1.0.0`
- Link Umbrel app store submission PR

## Test plan

- [x] Verify `docker-compose.yml` passes Umbrel linter
- [x] Confirm app installs correctly on Umbrel