### PR TITLE
feat: shared nav bar on all pages

### DIFF
--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -38,6 +38,9 @@ header {
   justify-content: space-between;
 }
 .logo { font-size: 1.25rem; font-weight: 700; color: var(--accent); text-decoration: none; }
+.nav-link { color: var(--text-muted); text-decoration: none; margin-right: 16px; }
+.nav-link:last-child { margin-right: 0; }
+.nav-link.nav-active { color: var(--text); font-weight: 600; }
 .node-info-bar { font-size: 0.8rem; color: var(--text-muted); }
 .node-info-bar .synced { color: var(--green); }
 .node-info-bar .not-synced { color: var(--red); }

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -71,6 +71,7 @@ func NewRenderer() *Renderer {
 			"templates/partials/import_result.html",
 			"templates/partials/clear_import_result.html",
 			"templates/partials/danger_zone.html",
+			"templates/partials/nav.html",
 			"templates/pl_layout.html",
 			"templates/pl.html",
 			"templates/wallets_layout.html",

--- a/internal/web/templates/import_layout.html
+++ b/internal/web/templates/import_layout.html
@@ -10,13 +10,10 @@
 <body>
   <header>
     <div class="container header-inner">
-      <a class="logo" href="/">Satsbook</a>
-      <nav style="font-size: 0.85rem;">
-        <a href="/" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Dashboard</a>
-        <a href="/import" style="color: var(--text); text-decoration: none; margin-right: 16px;">Import</a>
-        <a href="/wallets" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Wallets</a>
-        <a href="/pl" style="color: var(--text-muted); text-decoration: none;">P&L</a>
-      </nav>
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <a class="logo" href="/">Satsbook</a>
+        {{template "nav" "import"}}
+      </div>
     </div>
   </header>
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -12,12 +12,7 @@
     <div class="container header-inner">
       <div style="display: flex; align-items: center; gap: 24px;">
         <a class="logo" href="/">Satsbook</a>
-        <nav style="font-size: 0.85rem;">
-          <a href="/" style="color: var(--text); text-decoration: none; margin-right: 16px;">Dashboard</a>
-          <a href="/import" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Import</a>
-          <a href="/wallets" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Wallets</a>
-          <a href="/pl" style="color: var(--text-muted); text-decoration: none;">P&L</a>
-        </nav>
+        {{template "nav" "dashboard"}}
       </div>
       <div class="node-info-bar">
         {{if .NodeAlias}}

--- a/internal/web/templates/partials/nav.html
+++ b/internal/web/templates/partials/nav.html
@@ -1,0 +1,8 @@
+{{define "nav"}}
+<nav style="font-size: 0.85rem;">
+  <a href="/" class="nav-link{{if eq . "dashboard"}} nav-active{{end}}">Dashboard</a>
+  <a href="/import" class="nav-link{{if eq . "import"}} nav-active{{end}}">Import</a>
+  <a href="/wallets" class="nav-link{{if eq . "wallets"}} nav-active{{end}}">Wallets</a>
+  <a href="/pl" class="nav-link{{if eq . "pl"}} nav-active{{end}}">P&L</a>
+</nav>
+{{end}}

--- a/internal/web/templates/pl_layout.html
+++ b/internal/web/templates/pl_layout.html
@@ -12,12 +12,7 @@
     <div class="container header-inner">
       <div style="display: flex; align-items: center; gap: 24px;">
         <a class="logo" href="/">Satsbook</a>
-        <nav style="font-size: 0.85rem;">
-          <a href="/" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Dashboard</a>
-          <a href="/import" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Import</a>
-          <a href="/wallets" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Wallets</a>
-          <a href="/pl" style="color: var(--text); text-decoration: none;">P&L</a>
-        </nav>
+        {{template "nav" "pl"}}
       </div>
       <div class="node-info-bar">
         {{if .NodeAlias}}

--- a/internal/web/templates/wallets_layout.html
+++ b/internal/web/templates/wallets_layout.html
@@ -10,13 +10,10 @@
 <body>
   <header>
     <div class="container header-inner">
-      <a class="logo" href="/">Satsbook</a>
-      <nav style="font-size: 0.85rem;">
-        <a href="/" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Dashboard</a>
-        <a href="/import" style="color: var(--text-muted); text-decoration: none; margin-right: 16px;">Import</a>
-        <a href="/wallets" style="color: var(--text); text-decoration: none; margin-right: 16px;">Wallets</a>
-        <a href="/pl" style="color: var(--text-muted); text-decoration: none;">P&L</a>
-      </nav>
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <a class="logo" href="/">Satsbook</a>
+        {{template "nav" "wallets"}}
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary

- Extract duplicated nav markup from 4 layout templates into a shared `nav.html` partial
- Active page is visually highlighted (bold text via `nav-active` CSS class)
- Nav bar now appears consistently on Dashboard, Import, Wallets, and P&L pages

## Changes
- **New**: `templates/partials/nav.html` — shared nav partial, accepts page name string
- **New**: `.nav-link` / `.nav-active` CSS classes in `style.css`
- **Updated**: `layout.html`, `import_layout.html`, `wallets_layout.html`, `pl_layout.html` — replaced inline nav with `{{template "nav" "pagename"}}`
- **Updated**: `template.go` — registered new partial

## Test plan
- [x] `go build ./...` — compiles
- [x] `go test ./...` — all tests pass
- [x] Nav renders on all 4 pages with correct active highlighting

Closes #72