### PR TITLE
feat(import): multi-file CSV upload for Strike, River, Coinbase

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -405,28 +406,41 @@ func (h *Handler) HandleStrikeImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file, fh, err := r.FormFile("file")
-	if err != nil {
-		h.logger.Printf("strike import: missing file field: %v", err)
-		h.writeError(w, http.StatusBadRequest, "missing 'file' field in upload")
-		return
-	}
-	defer file.Close()
-	h.logger.Printf("strike import: received file %q (%d bytes)", fh.Filename, fh.Size)
-
-	result, err := exchange.ParseStrikeCSV(file)
-	if err != nil {
-		h.logger.Printf("strike import: CSV parse error: %v", err)
-		h.writeError(w, http.StatusBadRequest, err.Error())
+	files := r.MultipartForm.File["file"]
+	if len(files) == 0 {
+		h.writeError(w, http.StatusBadRequest, "no files uploaded")
 		return
 	}
 
-	if len(result.Rows) == 0 {
-		h.writeError(w, http.StatusBadRequest, "CSV contains no valid data rows")
+	var allRows []exchange.StrikeRow
+	var allErrors []string
+	for _, fh := range files {
+		file, err := fh.Open()
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("%s: failed to open: %v", fh.Filename, err))
+			continue
+		}
+		h.logger.Printf("strike import: received file %q (%d bytes)", fh.Filename, fh.Size)
+		result, err := exchange.ParseStrikeCSV(file)
+		file.Close()
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("%s: %v", fh.Filename, err))
+			continue
+		}
+		allRows = append(allRows, result.Rows...)
+		allErrors = append(allErrors, result.Errors...)
+	}
+
+	if len(allRows) == 0 {
+		msg := "no valid data rows found"
+		if len(allErrors) > 0 {
+			msg = allErrors[0]
+		}
+		h.writeError(w, http.StatusBadRequest, msg)
 		return
 	}
 
-	summary, err := h.importStore.ImportStrikeCSV(r.Context(), result.Rows)
+	summary, err := h.importStore.ImportStrikeCSV(r.Context(), allRows)
 	if err != nil {
 		h.logger.Printf("strike import failed: %v", err)
 		h.writeError(w, http.StatusInternalServerError, "failed to import transactions")
@@ -434,10 +448,11 @@ func (h *Handler) HandleStrikeImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := importResponse{
-		Total:        summary.Total,
-		NewPurchases: summary.NewPurchases,
-		Duplicates:   summary.Duplicates,
-		ParseErrors:  result.Errors,
+		Total:          summary.Total,
+		NewPurchases:   summary.NewPurchases,
+		Duplicates:     summary.Duplicates,
+		FilesProcessed: len(files),
+		ParseErrors:    allErrors,
 	}
 
 	// HTMX request — render partial
@@ -453,10 +468,11 @@ func (h *Handler) HandleStrikeImport(w http.ResponseWriter, r *http.Request) {
 }
 
 type importResponse struct {
-	Total        int      `json:"total"`
-	NewPurchases int      `json:"new_purchases"`
-	Duplicates   int      `json:"duplicates"`
-	ParseErrors  []string `json:"parse_errors,omitempty"`
+	Total          int      `json:"total"`
+	NewPurchases   int      `json:"new_purchases"`
+	Duplicates     int      `json:"duplicates"`
+	FilesProcessed int      `json:"files_processed,omitempty"`
+	ParseErrors    []string `json:"parse_errors,omitempty"`
 }
 
 // HandleRiverImport serves POST /api/import/river.
@@ -473,28 +489,41 @@ func (h *Handler) HandleRiverImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file, fh, err := r.FormFile("file")
-	if err != nil {
-		h.logger.Printf("river import: missing file field: %v", err)
-		h.writeError(w, http.StatusBadRequest, "missing 'file' field in upload")
-		return
-	}
-	defer file.Close()
-	h.logger.Printf("river import: received file %q (%d bytes)", fh.Filename, fh.Size)
-
-	result, err := exchange.ParseRiverCSV(file)
-	if err != nil {
-		h.logger.Printf("river import: CSV parse error: %v", err)
-		h.writeError(w, http.StatusBadRequest, err.Error())
+	files := r.MultipartForm.File["file"]
+	if len(files) == 0 {
+		h.writeError(w, http.StatusBadRequest, "no files uploaded")
 		return
 	}
 
-	if len(result.Rows) == 0 {
-		h.writeError(w, http.StatusBadRequest, "CSV contains no valid data rows")
+	var allRows []exchange.RiverRow
+	var allErrors []string
+	for _, fh := range files {
+		file, err := fh.Open()
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("%s: failed to open: %v", fh.Filename, err))
+			continue
+		}
+		h.logger.Printf("river import: received file %q (%d bytes)", fh.Filename, fh.Size)
+		result, err := exchange.ParseRiverCSV(file)
+		file.Close()
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("%s: %v", fh.Filename, err))
+			continue
+		}
+		allRows = append(allRows, result.Rows...)
+		allErrors = append(allErrors, result.Errors...)
+	}
+
+	if len(allRows) == 0 {
+		msg := "no valid data rows found"
+		if len(allErrors) > 0 {
+			msg = allErrors[0]
+		}
+		h.writeError(w, http.StatusBadRequest, msg)
 		return
 	}
 
-	summary, err := h.importStore.ImportRiverCSV(r.Context(), result.Rows)
+	summary, err := h.importStore.ImportRiverCSV(r.Context(), allRows)
 	if err != nil {
 		h.logger.Printf("river import failed: %v", err)
 		h.writeError(w, http.StatusInternalServerError, "failed to import transactions")
@@ -502,10 +531,11 @@ func (h *Handler) HandleRiverImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := importResponse{
-		Total:        summary.Total,
-		NewPurchases: summary.NewPurchases,
-		Duplicates:   summary.Duplicates,
-		ParseErrors:  result.Errors,
+		Total:          summary.Total,
+		NewPurchases:   summary.NewPurchases,
+		Duplicates:     summary.Duplicates,
+		FilesProcessed: len(files),
+		ParseErrors:    allErrors,
 	}
 
 	// HTMX request — render partial
@@ -533,28 +563,41 @@ func (h *Handler) HandleCoinbaseImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file, fh, err := r.FormFile("file")
-	if err != nil {
-		h.logger.Printf("coinbase import: missing file field: %v", err)
-		h.writeError(w, http.StatusBadRequest, "missing 'file' field in upload")
-		return
-	}
-	defer file.Close()
-	h.logger.Printf("coinbase import: received file %q (%d bytes)", fh.Filename, fh.Size)
-
-	result, err := exchange.ParseCoinbaseCSV(file)
-	if err != nil {
-		h.logger.Printf("coinbase import: CSV parse error: %v", err)
-		h.writeError(w, http.StatusBadRequest, err.Error())
+	files := r.MultipartForm.File["file"]
+	if len(files) == 0 {
+		h.writeError(w, http.StatusBadRequest, "no files uploaded")
 		return
 	}
 
-	if len(result.Rows) == 0 {
-		h.writeError(w, http.StatusBadRequest, "CSV contains no BTC transactions")
+	var allRows []exchange.CoinbaseRow
+	var allErrors []string
+	for _, fh := range files {
+		file, err := fh.Open()
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("%s: failed to open: %v", fh.Filename, err))
+			continue
+		}
+		h.logger.Printf("coinbase import: received file %q (%d bytes)", fh.Filename, fh.Size)
+		result, err := exchange.ParseCoinbaseCSV(file)
+		file.Close()
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("%s: %v", fh.Filename, err))
+			continue
+		}
+		allRows = append(allRows, result.Rows...)
+		allErrors = append(allErrors, result.Errors...)
+	}
+
+	if len(allRows) == 0 {
+		msg := "no valid BTC transactions found"
+		if len(allErrors) > 0 {
+			msg = allErrors[0]
+		}
+		h.writeError(w, http.StatusBadRequest, msg)
 		return
 	}
 
-	summary, err := h.importStore.ImportCoinbaseCSV(r.Context(), result.Rows)
+	summary, err := h.importStore.ImportCoinbaseCSV(r.Context(), allRows)
 	if err != nil {
 		h.logger.Printf("coinbase import failed: %v", err)
 		h.writeError(w, http.StatusInternalServerError, "failed to import transactions")
@@ -562,10 +605,11 @@ func (h *Handler) HandleCoinbaseImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := importResponse{
-		Total:        summary.Total,
-		NewPurchases: summary.NewPurchases,
-		Duplicates:   summary.Duplicates,
-		ParseErrors:  result.Errors,
+		Total:          summary.Total,
+		NewPurchases:   summary.NewPurchases,
+		Duplicates:     summary.Duplicates,
+		FilesProcessed: len(files),
+		ParseErrors:    allErrors,
 	}
 
 	if r.Header.Get("HX-Request") == "true" {

--- a/internal/web/templates/import.html
+++ b/internal/web/templates/import.html
@@ -11,7 +11,7 @@
 <div id="panel-strike" class="card" style="max-width: 600px;">
   <div class="card-label">Upload Strike CSV</div>
   <p class="card-sub" style="margin-bottom: 16px;">
-    Import your Strike transaction history. Export from Strike app: Profile &gt; Account &gt; Transaction History &gt; Download CSV.
+    Import your Strike transaction history. You can select multiple files at once (e.g. quarterly exports). Export from Strike app: Profile &gt; Account &gt; Transaction History &gt; Download CSV.
   </p>
 
   <form hx-post="/api/import/strike"
@@ -20,7 +20,7 @@
         hx-encoding="multipart/form-data"
         hx-indicator="#import-loading">
     <div style="margin-bottom: 12px;">
-      <input type="file" name="file" accept=".csv" required
+      <input type="file" name="file" accept=".csv" required multiple
              style="background: var(--bg); border: 1px solid var(--border); border-radius: 4px; color: var(--text); padding: 8px; width: 100%;">
     </div>
     <button type="submit" class="filter-form" style="display: inline-block;">
@@ -37,7 +37,7 @@
 <div id="panel-river" class="card" style="max-width: 600px; display: none;">
   <div class="card-label">Upload River CSV</div>
   <p class="card-sub" style="margin-bottom: 16px;">
-    Import your River Financial transaction history. Export from River app: Settings &gt; Account &gt; Download Activity.
+    Import your River Financial transaction history. You can select multiple files at once. Export from River app: Settings &gt; Account &gt; Download Activity.
   </p>
 
   <form hx-post="/api/import/river"
@@ -46,7 +46,7 @@
         hx-encoding="multipart/form-data"
         hx-indicator="#import-loading-river">
     <div style="margin-bottom: 12px;">
-      <input type="file" name="file" accept=".csv" required
+      <input type="file" name="file" accept=".csv" required multiple
              style="background: var(--bg); border: 1px solid var(--border); border-radius: 4px; color: var(--text); padding: 8px; width: 100%;">
     </div>
     <button type="submit" class="filter-form" style="display: inline-block;">
@@ -63,7 +63,7 @@
 <div id="panel-coinbase" class="card" style="max-width: 600px; display: none;">
   <div class="card-label">Upload Coinbase CSV</div>
   <p class="card-sub" style="margin-bottom: 16px;">
-    Import your Coinbase transaction history (BTC only). Export from Coinbase: Manage Account &gt; Statements &gt; Generate Statement.
+    Import your Coinbase transaction history (BTC only). You can select multiple files at once. Export from Coinbase: Manage Account &gt; Statements &gt; Generate Statement.
   </p>
 
   <form hx-post="/api/import/coinbase"
@@ -72,7 +72,7 @@
         hx-encoding="multipart/form-data"
         hx-indicator="#import-loading-coinbase">
     <div style="margin-bottom: 12px;">
-      <input type="file" name="file" accept=".csv" required
+      <input type="file" name="file" accept=".csv" required multiple
              style="background: var(--bg); border: 1px solid var(--border); border-radius: 4px; color: var(--text); padding: 8px; width: 100%;">
     </div>
     <button type="submit" class="filter-form" style="display: inline-block;">

--- a/internal/web/templates/partials/import_result.html
+++ b/internal/web/templates/partials/import_result.html
@@ -2,7 +2,7 @@
 <div class="card">
   <div class="card-label" style="color: var(--green);">Import Complete</div>
   <p style="margin-top: 8px;">
-    Imported <strong>{{.Total}}</strong> transaction{{if ne .Total 1}}s{{end}},
+    {{if gt .FilesProcessed 1}}Processed <strong>{{.FilesProcessed}}</strong> files — {{end}}Imported <strong>{{.Total}}</strong> transaction{{if ne .Total 1}}s{{end}},
     <strong>{{.NewPurchases}}</strong> new purchase{{if ne .NewPurchases 1}}s{{end}},
     <strong>{{.Duplicates}}</strong> duplicate{{if ne .Duplicates 1}}s{{end}} skipped.
   </p>


### PR DESCRIPTION
## Summary
- Strike, River, and Coinbase import forms now accept multiple CSV files at once via `<input multiple>`
- Backend loops over all uploaded files, parses each individually, merges rows, and imports in one batch
- Per-file error reporting surfaces which file had issues
- Import result partial shows file count when >1 file processed
- Content-hash dedup prevents duplicates across overlapping files

## Test plan
- [x] Upload a single Strike CSV — works as before
- [x] Upload 2+ Strike CSVs at once — all rows imported, result shows "Processed N files"
- [x] Upload overlapping files — duplicates correctly skipped
- [x] Upload an invalid file alongside a valid one — valid file imports, error reported for invalid
- [x] Repeat for River and Coinbase
- [x] Swan import unchanged (uses separate file inputs)

Closes #70