### PR TITLE
feat(web): transaction history detail views

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -875,6 +875,81 @@ func (d *DB) TotalWatchedBalance(ctx context.Context) (int64, error) {
 	return total, nil
 }
 
+// ExchangeTransaction represents a single exchange import row for display.
+type ExchangeTransaction struct {
+	ID           int64
+	Source       string
+	TxType       string
+	Date         time.Time
+	AmountBTC    float64
+	AmountSats   int64
+	AmountUSD    float64
+	FeeUSD       float64
+	CostBasisUSD float64
+}
+
+// ExchangeTransactionPage holds paginated exchange transaction results.
+type ExchangeTransactionPage struct {
+	Transactions []ExchangeTransaction
+	Total        int
+	Page         int
+	Limit        int
+}
+
+// ListExchangeTransactions returns paginated exchange import rows for a source.
+func (d *DB) ListExchangeTransactions(ctx context.Context, source string, limit, offset int) (*ExchangeTransactionPage, error) {
+	// Count total
+	var total int
+	err := d.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM exchange_imports WHERE source = ?`, source,
+	).Scan(&total)
+	if err != nil {
+		return nil, fmt.Errorf("count exchange transactions for %s: %w", source, err)
+	}
+
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT id, source, tx_type,
+			COALESCE(json_extract(raw_data, '$.Date'), imported_at) as tx_date,
+			COALESCE(json_extract(raw_data, '$.AmountBTC'), 0),
+			COALESCE(json_extract(raw_data, '$.AmountUSD'), 0),
+			COALESCE(json_extract(raw_data, '$.FeeUSD'), 0),
+			COALESCE(json_extract(raw_data, '$.CostBasisUSD'), 0)
+		FROM exchange_imports
+		WHERE source = ?
+		ORDER BY COALESCE(json_extract(raw_data, '$.Date'), imported_at) DESC
+		LIMIT ? OFFSET ?`, source, limit, offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list exchange transactions for %s: %w", source, err)
+	}
+	defer rows.Close()
+
+	var txns []ExchangeTransaction
+	for rows.Next() {
+		var t ExchangeTransaction
+		var dateStr string
+		if err := rows.Scan(&t.ID, &t.Source, &t.TxType, &dateStr, &t.AmountBTC, &t.AmountUSD, &t.FeeUSD, &t.CostBasisUSD); err != nil {
+			return nil, fmt.Errorf("scan exchange transaction: %w", err)
+		}
+		t.Date, _ = time.Parse(time.RFC3339, dateStr)
+		if t.Date.IsZero() {
+			t.Date, _ = time.Parse("2006-01-02T15:04:05Z", dateStr)
+		}
+		t.AmountSats = int64(math.Round(t.AmountBTC * 1e8))
+		txns = append(txns, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate exchange transactions: %w", err)
+	}
+
+	return &ExchangeTransactionPage{
+		Transactions: txns,
+		Total:        total,
+		Page:         offset/limit + 1,
+		Limit:        limit,
+	}, nil
+}
+
 // ExchangeBalance returns the net BTC balance (in sats) for a given exchange source
 // by summing AmountBTC only from rows that actually move BTC (non-zero AmountBTC).
 // USD-only transactions (e.g. cash withdrawals) are excluded.

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1957,3 +1957,70 @@ func TestExchangeBalance_Swan(t *testing.T) {
 		t.Errorf("swan balance = %d, want 34705", bal)
 	}
 }
+
+func TestListExchangeTransactions(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	// Empty source returns empty page
+	page, err := d.ListExchangeTransactions(context.Background(), "strike", 10, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Total != 0 || len(page.Transactions) != 0 {
+		t.Errorf("expected empty page, got total=%d txns=%d", page.Total, len(page.Transactions))
+	}
+
+	// Import some rows
+	rows := testStrikeRows()
+	_, err = d.ImportStrikeCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("import error: %v", err)
+	}
+
+	// Fetch all
+	page, err = d.ListExchangeTransactions(context.Background(), "strike", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Total != len(rows) {
+		t.Errorf("total = %d, want %d", page.Total, len(rows))
+	}
+	if len(page.Transactions) != len(rows) {
+		t.Errorf("txns = %d, want %d", len(page.Transactions), len(rows))
+	}
+
+	// Verify fields on first transaction (sorted by date desc)
+	for _, tx := range page.Transactions {
+		if tx.Source != "strike" {
+			t.Errorf("source = %q, want %q", tx.Source, "strike")
+		}
+		if tx.TxType == "" {
+			t.Error("tx_type should not be empty")
+		}
+	}
+
+	// Pagination: limit 1
+	page, err = d.ListExchangeTransactions(context.Background(), "strike", 1, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Total != len(rows) {
+		t.Errorf("total = %d, want %d", page.Total, len(rows))
+	}
+	if len(page.Transactions) != 1 {
+		t.Errorf("txns = %d, want 1", len(page.Transactions))
+	}
+	if page.Page != 1 {
+		t.Errorf("page = %d, want 1", page.Page)
+	}
+
+	// Different source returns 0
+	page, err = d.ListExchangeTransactions(context.Background(), "river", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Total != 0 {
+		t.Errorf("river total = %d, want 0", page.Total)
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -25,6 +25,7 @@ type DashboardStore interface {
 	LastSyncedAt(ctx context.Context) (time.Time, error)
 	ExchangeBalance(ctx context.Context, source string) (int64, error)
 	ExchangeSummary(ctx context.Context, source string, since time.Time) (*db.ExchangeSummaryResult, error)
+	ListExchangeTransactions(ctx context.Context, source string, limit, offset int) (*db.ExchangeTransactionPage, error)
 	PortfolioPosition(ctx context.Context, since time.Time) (*db.PortfolioPositionResult, error)
 }
 

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -993,6 +993,141 @@ func (h *Handler) scanWallet(id int64, label, walletType, value, derivationType 
 	h.logger.Printf("scan %q: %d sats", label, balance)
 }
 
+// ExchangeDetailData holds data for the exchange transaction detail page.
+type ExchangeDetailData struct {
+	Source      string
+	SourceLabel string
+
+	// Summary stats
+	Summary *db.ExchangeSummaryResult
+
+	// Transaction list
+	Transactions []db.ExchangeTransaction
+	Total        int
+	Page         int
+	Limit        int
+	TotalPages   int
+
+	// Price
+	BTCPriceUSD    float64
+	PriceFetchedAt time.Time
+}
+
+// HandleExchangeDetail serves GET /exchange/{source}.
+func (h *Handler) HandleExchangeDetail(w http.ResponseWriter, r *http.Request) {
+	source := strings.TrimPrefix(r.URL.Path, "/exchange/")
+	if source == "" || (source != "strike" && source != "river" && source != "coinbase" && source != "swan") {
+		http.NotFound(w, r)
+		return
+	}
+
+	labels := map[string]string{"strike": "Strike", "river": "River", "coinbase": "Coinbase", "swan": "Swan"}
+	ctx := r.Context()
+
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	if page < 1 {
+		page = 1
+	}
+	limit := 50
+	offset := (page - 1) * limit
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	data := ExchangeDetailData{
+		Source:      source,
+		SourceLabel: labels[source],
+		Page:        page,
+		Limit:       limit,
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		summary, err := h.store.ExchangeSummary(ctx, source, time.Time{})
+		if err == nil {
+			mu.Lock()
+			data.Summary = summary
+			mu.Unlock()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		result, err := h.store.ListExchangeTransactions(ctx, source, limit, offset)
+		if err == nil {
+			mu.Lock()
+			data.Transactions = result.Transactions
+			data.Total = result.Total
+			mu.Unlock()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		price, err := h.price.GetBTCPrice(ctx)
+		if err == nil {
+			mu.Lock()
+			data.BTCPriceUSD = price
+			data.PriceFetchedAt = h.price.FetchedAt()
+			mu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+
+	if data.Total > 0 {
+		data.TotalPages = (data.Total + limit - 1) / limit
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "exchange_detail_layout", data); err != nil {
+		h.logger.Printf("failed to render exchange detail: %v", err)
+	}
+}
+
+// WalletDetailData holds data for the wallet detail page.
+type WalletDetailData struct {
+	Wallet      *db.WatchedWallet
+	BTCPriceUSD float64
+	BalanceUSD  float64
+}
+
+// HandleWalletDetail serves GET /wallets/{id}.
+func (h *Handler) HandleWalletDetail(w http.ResponseWriter, r *http.Request) {
+	idStr := strings.TrimPrefix(r.URL.Path, "/wallets/")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id < 1 {
+		http.NotFound(w, r)
+		return
+	}
+
+	if h.walletStore == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	ctx := r.Context()
+	wallet, err := h.walletStore.GetWallet(ctx, id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := WalletDetailData{Wallet: wallet}
+	price, err := h.price.GetBTCPrice(ctx)
+	if err == nil && price > 0 {
+		data.BTCPriceUSD = price
+		data.BalanceUSD = float64(wallet.BalanceSats) / 1e8 * price
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "wallet_detail_layout", data); err != nil {
+		h.logger.Printf("failed to render wallet detail: %v", err)
+	}
+}
+
 // isDescriptor returns true if the value looks like a Bitcoin output descriptor.
 func isDescriptor(v string) bool {
 	prefixes := []string{

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -999,7 +999,8 @@ type ExchangeDetailData struct {
 	SourceLabel string
 
 	// Summary stats
-	Summary *db.ExchangeSummaryResult
+	Summary    *db.ExchangeSummaryResult
+	BalanceSats int64
 
 	// Transaction list
 	Transactions []db.ExchangeTransaction
@@ -1047,6 +1048,17 @@ func (h *Handler) HandleExchangeDetail(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			mu.Lock()
 			data.Summary = summary
+			mu.Unlock()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		bal, err := h.store.ExchangeBalance(ctx, source)
+		if err == nil {
+			mu.Lock()
+			data.BalanceSats = bal
 			mu.Unlock()
 		}
 	}()

--- a/internal/web/handler_html_test.go
+++ b/internal/web/handler_html_test.go
@@ -1,17 +1,45 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/exchange"
 	"github.com/satsbook/satsbook/internal/lnd"
 )
+
+type mockWalletStore struct {
+	wallets []db.WatchedWallet
+	wallet  *db.WatchedWallet
+}
+
+func (m *mockWalletStore) AddWallet(_ context.Context, label, wType, value, derivationType string) (int64, error) {
+	return 1, nil
+}
+func (m *mockWalletStore) RemoveWallet(_ context.Context, id int64) error { return nil }
+func (m *mockWalletStore) ListWallets(_ context.Context) ([]db.WatchedWallet, error) {
+	return m.wallets, nil
+}
+func (m *mockWalletStore) GetWallet(_ context.Context, id int64) (*db.WatchedWallet, error) {
+	if m.wallet != nil {
+		return m.wallet, nil
+	}
+	return nil, errors.New("not found")
+}
+func (m *mockWalletStore) UpdateWalletBalance(_ context.Context, id int64, sats int64) error {
+	return nil
+}
+func (m *mockWalletStore) TotalWatchedBalance(_ context.Context) (int64, error) { return 0, nil }
 
 func fullMockStore() *mockStore {
 	now := time.Now().UTC()
@@ -444,5 +472,557 @@ func TestHandlePLPage_NodeDown(t *testing.T) {
 	}
 	if !strings.Contains(body, "price unavailable") {
 		t.Error("expected 'price unavailable' when price fails")
+	}
+}
+
+// --- mockWalletScanner ---
+
+type mockWalletScanner struct {
+	balance int64
+}
+
+func (m *mockWalletScanner) ScanAddress(_ context.Context, _ string) (int64, error) {
+	return m.balance, nil
+}
+func (m *mockWalletScanner) ScanXpub(_ context.Context, _ string, _ string) (int64, error) {
+	return m.balance, nil
+}
+func (m *mockWalletScanner) ScanDescriptor(_ context.Context, _ string) (int64, error) {
+	return m.balance, nil
+}
+
+// --- HandleImportPage tests ---
+
+func TestHandleImportPage(t *testing.T) {
+	store := fullMockStore()
+	h := newTestHandler(store, &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/import", nil)
+	w := httptest.NewRecorder()
+	h.HandleImportPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Import Transactions") {
+		t.Error("expected import page content")
+	}
+}
+
+// --- HandleWalletsPage tests ---
+
+func TestHandleWalletsPage(t *testing.T) {
+	store := fullMockStore()
+	h := newTestHandler(store, &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{price: 67000.0})
+	h.SetWalletStore(&mockWalletStore{
+		wallets: []db.WatchedWallet{
+			{ID: 1, Label: "TestWallet", Type: "address", Value: "bc1qtest", BalanceSats: 50000},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/wallets", nil)
+	w := httptest.NewRecorder()
+	h.HandleWalletsPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "TestWallet") {
+		t.Error("expected wallet label in page")
+	}
+}
+
+func TestHandleWalletsPage_NoWalletStore(t *testing.T) {
+	store := fullMockStore()
+	h := newTestHandler(store, &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/wallets", nil)
+	w := httptest.NewRecorder()
+	h.HandleWalletsPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+// --- HandleExchangeDetail tests ---
+
+func TestHandleExchangeDetail(t *testing.T) {
+	store := fullMockStore()
+	store.listExchangeTransactionsFn = func(_ context.Context, source string, limit, offset int) (*db.ExchangeTransactionPage, error) {
+		return &db.ExchangeTransactionPage{
+			Transactions: []db.ExchangeTransaction{
+				{ID: 1, Source: source, TxType: "purchase", Date: time.Now(), AmountBTC: 0.001, AmountSats: 100000, AmountUSD: 67.00, CostBasisUSD: 67.00},
+			},
+			Total: 1,
+			Page:  1,
+			Limit: 50,
+		}, nil
+	}
+	h := newTestHandler(store, &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{price: 67000.0})
+
+	req := httptest.NewRequest(http.MethodGet, "/exchange/strike", nil)
+	w := httptest.NewRecorder()
+	h.HandleExchangeDetail(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Strike Transactions") {
+		t.Error("expected 'Strike Transactions' heading")
+	}
+	if !strings.Contains(body, "purchase") {
+		t.Error("expected transaction type in table")
+	}
+}
+
+func TestHandleExchangeDetail_InvalidSource(t *testing.T) {
+	h := newTestHandler(fullMockStore(), &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/exchange/kraken", nil)
+	w := httptest.NewRecorder()
+	h.HandleExchangeDetail(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleExchangeDetail_EmptySource(t *testing.T) {
+	h := newTestHandler(fullMockStore(), &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/exchange/", nil)
+	w := httptest.NewRecorder()
+	h.HandleExchangeDetail(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleExchangeDetail_Pagination(t *testing.T) {
+	store := fullMockStore()
+	store.listExchangeTransactionsFn = func(_ context.Context, source string, limit, offset int) (*db.ExchangeTransactionPage, error) {
+		// Return a non-empty list so the table (and pagination) renders
+		txns := make([]db.ExchangeTransaction, 1)
+		txns[0] = db.ExchangeTransaction{ID: 1, Source: source, TxType: "purchase", AmountSats: 100}
+		return &db.ExchangeTransactionPage{
+			Transactions: txns,
+			Total:        100,
+			Page:         2,
+			Limit:        50,
+		}, nil
+	}
+	h := newTestHandler(store, &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/exchange/strike?page=2", nil)
+	w := httptest.NewRecorder()
+	h.HandleExchangeDetail(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Page 2 of 2") {
+		t.Error("expected pagination info")
+	}
+}
+
+func TestHandleExchangeDetail_AllSources(t *testing.T) {
+	for _, source := range []string{"strike", "river", "coinbase", "swan"} {
+		store := fullMockStore()
+		h := newTestHandler(store, &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+
+		req := httptest.NewRequest(http.MethodGet, "/exchange/"+source, nil)
+		w := httptest.NewRecorder()
+		h.HandleExchangeDetail(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("source=%s: expected 200, got %d", source, w.Code)
+		}
+	}
+}
+
+// --- HandleWalletDetail tests ---
+
+func TestHandleWalletDetail(t *testing.T) {
+	store := fullMockStore()
+	h := newTestHandler(store, &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{price: 67000.0})
+	h.SetWalletStore(&mockWalletStore{
+		wallet: &db.WatchedWallet{
+			ID: 1, Label: "Coldcard", Type: "address", Value: "bc1qtest123", BalanceSats: 500000,
+			CreatedAt: time.Now(),
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/wallets/1", nil)
+	w := httptest.NewRecorder()
+	h.HandleWalletDetail(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Coldcard") {
+		t.Error("expected wallet label")
+	}
+	if !strings.Contains(body, "bc1qtest123") {
+		t.Error("expected wallet value")
+	}
+}
+
+func TestHandleWalletDetail_NotFound(t *testing.T) {
+	store := fullMockStore()
+	h := newTestHandler(store, &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+	h.SetWalletStore(&mockWalletStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/wallets/999", nil)
+	w := httptest.NewRecorder()
+	h.HandleWalletDetail(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleWalletDetail_InvalidID(t *testing.T) {
+	h := newTestHandler(fullMockStore(), &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+	h.SetWalletStore(&mockWalletStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/wallets/abc", nil)
+	w := httptest.NewRecorder()
+	h.HandleWalletDetail(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleWalletDetail_NoWalletStore(t *testing.T) {
+	h := newTestHandler(fullMockStore(), &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/wallets/1", nil)
+	w := httptest.NewRecorder()
+	h.HandleWalletDetail(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 without wallet store, got %d", w.Code)
+	}
+}
+
+// --- HandleAddWallet tests ---
+
+func TestHandleAddWallet_Success(t *testing.T) {
+	h := newTestHandler(fullMockStore(), &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+	ws := &mockWalletStore{}
+	h.SetWalletStore(ws)
+	h.SetWalletScanner(&mockWalletScanner{balance: 100000})
+
+	body := strings.NewReader("label=TestWallet&value=bc1qtest123")
+	req := httptest.NewRequest(http.MethodPost, "/api/wallets", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleAddWallet(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", w.Code)
+	}
+}
+
+func TestHandleAddWallet_MissingFields(t *testing.T) {
+	h := newTestHandler(fullMockStore(), &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+	h.SetWalletStore(&mockWalletStore{})
+
+	body := strings.NewReader("label=&value=")
+	req := httptest.NewRequest(http.MethodPost, "/api/wallets", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleAddWallet(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- HandleRemoveWallet tests ---
+
+func TestHandleRemoveWallet(t *testing.T) {
+	h := newTestHandler(fullMockStore(), &mockNodeInfo{info: &lnd.NodeInfo{}}, &mockPrice{})
+	h.SetWalletStore(&mockWalletStore{})
+
+	body := strings.NewReader("id=1")
+	req := httptest.NewRequest(http.MethodPost, "/api/wallets/delete", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleRemoveWallet(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", w.Code)
+	}
+}
+
+// --- isDescriptor tests ---
+
+func TestIsDescriptor(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"wsh(sortedmulti(2,xpub...))", true},
+		{"wpkh(xpub...)", true},
+		{"sh(wpkh(xpub...))", true},
+		{"tr(xpub...)", true},
+		{"bc1qtest", false},
+		{"zpub6rFR7y4Q2AijBEqTUqmBQ5kWnViJaSBhg", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := isDescriptor(tt.input)
+		if got != tt.want {
+			t.Errorf("isDescriptor(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+// --- River/Coinbase import handler tests ---
+
+func TestHandleRiverImport_Success(t *testing.T) {
+	importStore := &mockImportStore{
+		importRiverFn: func(_ context.Context, rows []exchange.RiverRow) (*db.ImportSummary, error) {
+			return &db.ImportSummary{Total: len(rows), NewPurchases: 1}, nil
+		},
+	}
+	h := NewHandler(fullMockStore(), nil, &mockPrice{}, importStore, log.New(os.Stderr, "[test] ", 0))
+
+	csv := "Date,Sent Amount,Sent Currency,Received Amount,Received Currency,Fee Amount,Fee Currency,Tag\n2024-09-26 19:59:41,3.96,USD,0.00006093,BTC,0.04,USD,Buy\n"
+	req, w := createMultipartCSV(t, csv)
+	req.URL.Path = "/api/import/river"
+	h.HandleRiverImport(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleRiverImport_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	req := httptest.NewRequest(http.MethodGet, "/api/import/river", nil)
+	w := httptest.NewRecorder()
+	h.HandleRiverImport(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleCoinbaseImport_Success(t *testing.T) {
+	importStore := &mockImportStore{
+		importCoinbaseFn: func(_ context.Context, rows []exchange.CoinbaseRow) (*db.ImportSummary, error) {
+			return &db.ImportSummary{Total: len(rows), NewPurchases: 1}, nil
+		},
+	}
+	h := NewHandler(fullMockStore(), nil, &mockPrice{}, importStore, log.New(os.Stderr, "[test] ", 0))
+
+	csv := "\nTransactions\nUser,Test User,test-uuid\nID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\nabc123,2023-08-01 19:50:07 UTC,Buy,BTC,0.001,USD,$29244.04,$29.24,$30.24,$1.00,Bought 0.001 BTC\n"
+	req, w := createMultipartCSV(t, csv)
+	req.URL.Path = "/api/import/coinbase"
+	h.HandleCoinbaseImport(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleCoinbaseImport_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	req := httptest.NewRequest(http.MethodGet, "/api/import/coinbase", nil)
+	w := httptest.NewRecorder()
+	h.HandleCoinbaseImport(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+// --- HandleSwanImport tests ---
+
+func TestHandleSwanImport_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	req := httptest.NewRequest(http.MethodGet, "/api/import/swan", nil)
+	w := httptest.NewRecorder()
+	h.HandleSwanImport(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleSwanImport_NoFiles(t *testing.T) {
+	h := NewHandler(fullMockStore(), nil, &mockPrice{}, &mockImportStore{}, log.New(os.Stderr, "[test] ", 0))
+
+	// Empty multipart form with no files
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/import/swan", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+	h.HandleSwanImport(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleSwanImport_WithTradesFile(t *testing.T) {
+	h := NewHandler(fullMockStore(), nil, &mockPrice{}, &mockImportStore{}, log.New(os.Stderr, "[test] ", 0))
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("trades", "trades.csv")
+	part.Write([]byte("Date,Received Quantity,Received Currency,Sent Quantity,Sent Currency,Fee Amount,Fee Currency,Tag\n11/16/2024 17:36:30,0.00010975,BTC,10.00,USD,0.00,USD,\"\"\n"))
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/import/swan", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+	h.HandleSwanImport(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- HandleRefreshWallet tests ---
+
+func TestHandleRefreshWallet_Success(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	h.SetWalletStore(&mockWalletStore{
+		wallet: &db.WatchedWallet{ID: 1, Label: "Test", Type: "address", Value: "bc1q123"},
+	})
+	h.SetWalletScanner(&mockWalletScanner{balance: 50000})
+
+	body := strings.NewReader("id=1")
+	req := httptest.NewRequest(http.MethodPost, "/api/wallets/refresh", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleRefreshWallet(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", w.Code)
+	}
+}
+
+func TestHandleRefreshWallet_NoScanner(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	h.SetWalletStore(&mockWalletStore{})
+
+	body := strings.NewReader("id=1")
+	req := httptest.NewRequest(http.MethodPost, "/api/wallets/refresh", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleRefreshWallet(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestHandleRefreshWallet_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	req := httptest.NewRequest(http.MethodGet, "/api/wallets/refresh", nil)
+	w := httptest.NewRecorder()
+	h.HandleRefreshWallet(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+// --- HandleRefreshAll tests ---
+
+func TestHandleRefreshAll_Success(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	h.SetWalletStore(&mockWalletStore{
+		wallets: []db.WatchedWallet{{ID: 1, Label: "Test", Type: "address", Value: "bc1q123"}},
+	})
+	h.SetWalletScanner(&mockWalletScanner{balance: 50000})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/wallets/refresh-all", nil)
+	w := httptest.NewRecorder()
+	h.HandleRefreshAll(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", w.Code)
+	}
+}
+
+func TestHandleRefreshAll_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	req := httptest.NewRequest(http.MethodGet, "/api/wallets/refresh-all", nil)
+	w := httptest.NewRecorder()
+	h.HandleRefreshAll(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+// --- HandleAddWallet edge cases ---
+
+func TestHandleAddWallet_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	req := httptest.NewRequest(http.MethodGet, "/api/wallets", nil)
+	w := httptest.NewRecorder()
+	h.HandleAddWallet(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleAddWallet_NoWalletStore(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+
+	body := strings.NewReader("label=Test&value=bc1q123")
+	req := httptest.NewRequest(http.MethodPost, "/api/wallets", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleAddWallet(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+// --- HandleRemoveWallet edge cases ---
+
+func TestHandleRemoveWallet_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	req := httptest.NewRequest(http.MethodGet, "/api/wallets/delete", nil)
+	w := httptest.NewRecorder()
+	h.HandleRemoveWallet(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleRemoveWallet_InvalidID(t *testing.T) {
+	h := newTestHandler(fullMockStore(), nil, &mockPrice{})
+	h.SetWalletStore(&mockWalletStore{})
+
+	body := strings.NewReader("id=abc")
+	req := httptest.NewRequest(http.MethodPost, "/api/wallets/delete", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleRemoveWallet(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -30,8 +30,9 @@ type mockStore struct {
 	dailyFeesFn         func(ctx context.Context, since time.Time) ([]db.DailyFeeStat, error)
 	lastSyncedAtFn      func(ctx context.Context) (time.Time, error)
 	exchangeBalanceFn   func(ctx context.Context, source string) (int64, error)
-	exchangeSummaryFn   func(ctx context.Context, source string, since time.Time) (*db.ExchangeSummaryResult, error)
-	portfolioPositionFn func(ctx context.Context, since time.Time) (*db.PortfolioPositionResult, error)
+	exchangeSummaryFn          func(ctx context.Context, source string, since time.Time) (*db.ExchangeSummaryResult, error)
+	listExchangeTransactionsFn func(ctx context.Context, source string, limit, offset int) (*db.ExchangeTransactionPage, error)
+	portfolioPositionFn        func(ctx context.Context, since time.Time) (*db.PortfolioPositionResult, error)
 }
 
 func (m *mockStore) FeeSummary(ctx context.Context, since time.Time) (int64, int64, error) {
@@ -72,6 +73,12 @@ func (m *mockStore) ExchangeSummary(ctx context.Context, source string, since ti
 		return m.exchangeSummaryFn(ctx, source, since)
 	}
 	return &db.ExchangeSummaryResult{}, nil
+}
+func (m *mockStore) ListExchangeTransactions(ctx context.Context, source string, limit, offset int) (*db.ExchangeTransactionPage, error) {
+	if m.listExchangeTransactionsFn != nil {
+		return m.listExchangeTransactionsFn(ctx, source, limit, offset)
+	}
+	return &db.ExchangeTransactionPage{}, nil
 }
 func (m *mockStore) PortfolioPosition(ctx context.Context, since time.Time) (*db.PortfolioPositionResult, error) {
 	if m.portfolioPositionFn != nil {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -24,6 +24,8 @@ func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
 	mux.HandleFunc("/import", handler.HandleImportPage)
 	mux.HandleFunc("/pl", handler.HandlePLPage)
 	mux.HandleFunc("/wallets", handler.HandleWalletsPage)
+	mux.HandleFunc("/exchange/", handler.HandleExchangeDetail)
+	mux.HandleFunc("/wallets/", handler.HandleWalletDetail)
 	mux.HandleFunc("/partials/forwarding", handler.HandleForwardingPartial)
 
 	// Static assets (embedded)

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -75,6 +75,8 @@ func NewRenderer() *Renderer {
 			"templates/pl_layout.html",
 			"templates/pl.html",
 			"templates/wallets_layout.html",
+			"templates/exchange_detail.html",
+			"templates/wallet_detail.html",
 		),
 	)
 

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -44,6 +44,18 @@ func NewRenderer() *Renderer {
 		"add": func(a, b int) int { return a + b },
 		"add64":       func(a, b int64) int64 { return a + b },
 		"seq":         seq,
+		"netSats": func(s *db.ExchangeSummaryResult) int64 {
+			if s == nil {
+				return 0
+			}
+			return s.PurchasedSats + s.ReceivedSats - s.SoldSats - s.SentSats
+		},
+		"costPerBTC": func(costUSD float64, sats int64) float64 {
+			if sats <= 0 {
+				return 0
+			}
+			return costUSD / (float64(sats) / 1e8)
+		},
 		"dict": func(kv ...interface{}) (map[string]interface{}, error) {
 			if len(kv)%2 != 0 {
 				return nil, fmt.Errorf("dict requires even number of args")

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -126,10 +126,10 @@
     <div class="card-value">{{formatSats .ExchangeBalanceSats}} <small>sats</small></div>
     {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .ExchangeBalanceUSD}}</div>{{end}}
     <div style="margin-top: 8px; font-size: 0.8em; color: var(--text-muted);">
-      {{if .StrikeBalanceSats}}<div>Strike: {{formatSats .StrikeBalanceSats}} sats</div>{{end}}
-      {{if .RiverBalanceSats}}<div>River: {{formatSats .RiverBalanceSats}} sats</div>{{end}}
-      {{if .CoinbaseBalanceSats}}<div>Coinbase: {{formatSats .CoinbaseBalanceSats}} sats</div>{{end}}
-      {{if .SwanBalanceSats}}<div>Swan: {{formatSats .SwanBalanceSats}} sats</div>{{end}}
+      {{if .StrikeBalanceSats}}<div><a href="/exchange/strike" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">Strike</a>: {{formatSats .StrikeBalanceSats}} sats</div>{{end}}
+      {{if .RiverBalanceSats}}<div><a href="/exchange/river" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">River</a>: {{formatSats .RiverBalanceSats}} sats</div>{{end}}
+      {{if .CoinbaseBalanceSats}}<div><a href="/exchange/coinbase" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">Coinbase</a>: {{formatSats .CoinbaseBalanceSats}} sats</div>{{end}}
+      {{if .SwanBalanceSats}}<div><a href="/exchange/swan" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">Swan</a>: {{formatSats .SwanBalanceSats}} sats</div>{{end}}
     </div>
   </div>
   {{end}}

--- a/internal/web/templates/exchange_detail.html
+++ b/internal/web/templates/exchange_detail.html
@@ -1,0 +1,121 @@
+{{define "exchange_detail_layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Satsbook — {{.SourceLabel}} Transactions</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <a class="logo" href="/">Satsbook</a>
+        {{template "nav" "exchange"}}
+      </div>
+    </div>
+  </header>
+
+  <main class="container" style="padding: 24px 16px;">
+    <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 24px;">
+      <a href="/" style="color: var(--text-muted); text-decoration: none; font-size: 0.85rem;">&larr; Dashboard</a>
+      <h1 style="margin: 0; font-size: 1.25rem;">{{.SourceLabel}} Transactions</h1>
+    </div>
+
+    {{if .Summary}}
+    <div style="display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 24px;">
+      <div class="card" style="flex: 1; min-width: 140px;">
+        <div class="card-label">Total Rows</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{.Total}}</div>
+      </div>
+      <div class="card" style="flex: 1; min-width: 140px;">
+        <div class="card-label">Purchased</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{formatSats .Summary.PurchasedSats}} <small>sats</small></div>
+      </div>
+      {{if .Summary.ReceivedSats}}
+      <div class="card" style="flex: 1; min-width: 140px;">
+        <div class="card-label">Received</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{formatSats .Summary.ReceivedSats}} <small>sats</small></div>
+      </div>
+      {{end}}
+      {{if .Summary.SoldSats}}
+      <div class="card" style="flex: 1; min-width: 140px;">
+        <div class="card-label">Sold</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{formatSats .Summary.SoldSats}} <small>sats</small></div>
+      </div>
+      {{end}}
+      {{if .Summary.SentSats}}
+      <div class="card" style="flex: 1; min-width: 140px;">
+        <div class="card-label">Sent</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{formatSats .Summary.SentSats}} <small>sats</small></div>
+      </div>
+      {{end}}
+      <div class="card" style="flex: 1; min-width: 140px;">
+        <div class="card-label">Cost Basis</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{formatUSD .Summary.TotalCostBasisUSD}}</div>
+      </div>
+      {{if gt .Summary.FeesPaidUSD 0.0}}
+      <div class="card" style="flex: 1; min-width: 140px;">
+        <div class="card-label">Fees Paid</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{formatUSD .Summary.FeesPaidUSD}}</div>
+      </div>
+      {{end}}
+    </div>
+    {{end}}
+
+    {{if .Transactions}}
+    <div style="overflow-x: auto;">
+      <table class="data-table" style="width: 100%; border-collapse: collapse; font-size: 0.85rem;">
+        <thead>
+          <tr style="border-bottom: 2px solid var(--border); text-align: left;">
+            <th style="padding: 8px 12px;">Date</th>
+            <th style="padding: 8px 12px;">Type</th>
+            <th style="padding: 8px 12px; text-align: right;">Amount (sats)</th>
+            <th style="padding: 8px 12px; text-align: right;">Amount (USD)</th>
+            <th style="padding: 8px 12px; text-align: right;">Fee (USD)</th>
+            <th style="padding: 8px 12px; text-align: right;">Cost Basis</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range .Transactions}}
+          <tr style="border-bottom: 1px solid var(--border);">
+            <td style="padding: 8px 12px; white-space: nowrap;">{{formatDate .Date}}</td>
+            <td style="padding: 8px 12px;">
+              <span style="background: var(--border); border-radius: 4px; padding: 1px 6px; font-size: 0.75rem;">{{.TxType}}</span>
+            </td>
+            <td style="padding: 8px 12px; text-align: right; font-family: monospace;">{{formatSats .AmountSats}}</td>
+            <td style="padding: 8px 12px; text-align: right;">{{if .AmountUSD}}{{formatUSD .AmountUSD}}{{else}}-{{end}}</td>
+            <td style="padding: 8px 12px; text-align: right;">{{if .FeeUSD}}{{formatUSD .FeeUSD}}{{else}}-{{end}}</td>
+            <td style="padding: 8px 12px; text-align: right;">{{if .CostBasisUSD}}{{formatUSD .CostBasisUSD}}{{else}}-{{end}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+
+    {{if gt .TotalPages 1}}
+    <div style="display: flex; justify-content: center; gap: 8px; margin-top: 16px; font-size: 0.85rem;">
+      {{if gt .Page 1}}
+      <a href="/exchange/{{.Source}}?page={{subtract .Page 1}}" style="color: var(--text-muted); text-decoration: none;">&larr; Prev</a>
+      {{end}}
+      <span style="color: var(--text-muted);">Page {{.Page}} of {{.TotalPages}}</span>
+      {{if lt .Page .TotalPages}}
+      <a href="/exchange/{{.Source}}?page={{add .Page 1}}" style="color: var(--text-muted); text-decoration: none;">Next &rarr;</a>
+      {{end}}
+    </div>
+    {{end}}
+
+    {{else}}
+    <div style="text-align: center; padding: 40px 16px; color: var(--text-muted);">
+      No transactions imported yet. <a href="/import" style="color: var(--accent);">Import CSV</a>
+    </div>
+    {{end}}
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Satsbook</span>
+    </div>
+  </footer>
+</body>
+</html>{{end}}

--- a/internal/web/templates/exchange_detail.html
+++ b/internal/web/templates/exchange_detail.html
@@ -25,6 +25,11 @@
     {{if .Summary}}
     <div style="display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 24px;">
       <div class="card" style="flex: 1; min-width: 140px;">
+        <div class="card-label">Net Balance</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{formatSats (netSats .Summary)}} <small>sats</small></div>
+        <div class="card-sub">{{satsToBTC (netSats .Summary)}} BTC</div>
+      </div>
+      <div class="card" style="flex: 1; min-width: 140px;">
         <div class="card-label">Total Rows</div>
         <div class="card-value" style="font-size: 1.1rem;">{{.Total}}</div>
       </div>
@@ -51,8 +56,15 @@
       </div>
       {{end}}
       <div class="card" style="flex: 1; min-width: 140px;">
-        <div class="card-label">Cost Basis</div>
+        <div class="card-label" style="display: flex; align-items: center; gap: 6px;">
+          Cost Basis
+          <span title="Total USD spent on purchases as reported by {{.SourceLabel}}. Per-BTC price is calculated by dividing total cost basis by total purchased BTC. Some exchanges allow you to edit your cost basis — if yours does, re-export your CSV and re-import to update."
+                style="display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px; border-radius: 50%; border: 1px solid var(--text-muted); color: var(--text-muted); font-size: 0.65rem; cursor: help; font-style: italic; flex-shrink: 0;">i</span>
+        </div>
         <div class="card-value" style="font-size: 1.1rem;">{{formatUSD .Summary.TotalCostBasisUSD}}</div>
+        {{if .Summary.PurchasedSats}}
+        <div class="card-sub">{{formatUSD (costPerBTC .Summary.TotalCostBasisUSD .Summary.PurchasedSats)}} / BTC</div>
+        {{end}}
       </div>
       {{if gt .Summary.FeesPaidUSD 0.0}}
       <div class="card" style="flex: 1; min-width: 140px;">

--- a/internal/web/templates/exchange_detail.html
+++ b/internal/web/templates/exchange_detail.html
@@ -26,12 +26,8 @@
     <div style="display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 24px;">
       <div class="card" style="flex: 1; min-width: 140px;">
         <div class="card-label">Net Balance</div>
-        <div class="card-value" style="font-size: 1.1rem;">{{formatSats (netSats .Summary)}} <small>sats</small></div>
-        <div class="card-sub">{{satsToBTC (netSats .Summary)}} BTC</div>
-      </div>
-      <div class="card" style="flex: 1; min-width: 140px;">
-        <div class="card-label">Total Rows</div>
-        <div class="card-value" style="font-size: 1.1rem;">{{.Total}}</div>
+        <div class="card-value" style="font-size: 1.1rem;">{{formatSats .BalanceSats}} <small>sats</small></div>
+        <div class="card-sub">{{satsToBTC .BalanceSats}} BTC</div>
       </div>
       <div class="card" style="flex: 1; min-width: 140px;">
         <div class="card-label">Purchased</div>

--- a/internal/web/templates/wallet_detail.html
+++ b/internal/web/templates/wallet_detail.html
@@ -24,9 +24,11 @@
 
     <div class="card" style="max-width: 600px;">
       <div class="card-label">Wallet Details</div>
-      <table style="width: 100%; font-size: 0.85rem; margin-top: 12px;">
+      <table style="width: 100%; table-layout: fixed; font-size: 0.85rem; margin-top: 12px;">
+        <col style="width: 130px;">
+        <col>
         <tr>
-          <td style="padding: 6px 0; color: var(--text-muted); width: 120px;">Type</td>
+          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Type</td>
           <td style="padding: 6px 0;">
             <span style="background: var(--border); border-radius: 4px; padding: 1px 6px; font-size: 0.75rem;">{{.Wallet.Type}}</span>
             {{if eq .Wallet.Type "xpub"}}
@@ -35,11 +37,11 @@
           </td>
         </tr>
         <tr>
-          <td style="padding: 6px 0; color: var(--text-muted);">Value</td>
-          <td style="padding: 6px 0; font-family: monospace; word-break: break-all; font-size: 0.8rem;">{{.Wallet.Value}}</td>
+          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Value</td>
+          <td style="padding: 6px 0; font-family: monospace; overflow-wrap: break-word; word-break: break-all; font-size: 0.8rem;">{{.Wallet.Value}}</td>
         </tr>
         <tr>
-          <td style="padding: 6px 0; color: var(--text-muted);">Balance</td>
+          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Balance</td>
           <td style="padding: 6px 0; font-weight: 600;">
             {{formatSats .Wallet.BalanceSats}} <span style="font-size: 0.75rem; color: var(--text-muted);">sats</span>
             {{if gt .BTCPriceUSD 0.0}}
@@ -48,11 +50,11 @@
           </td>
         </tr>
         <tr>
-          <td style="padding: 6px 0; color: var(--text-muted);">Last Checked</td>
+          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Last Checked</td>
           <td style="padding: 6px 0;">{{timeAgoPtr .Wallet.LastCheckedAt}}</td>
         </tr>
         <tr>
-          <td style="padding: 6px 0; color: var(--text-muted);">Added</td>
+          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Added</td>
           <td style="padding: 6px 0;">{{formatDate .Wallet.CreatedAt}}</td>
         </tr>
       </table>

--- a/internal/web/templates/wallet_detail.html
+++ b/internal/web/templates/wallet_detail.html
@@ -22,42 +22,40 @@
       <h1 style="margin: 0; font-size: 1.25rem;">{{.Wallet.Label}}</h1>
     </div>
 
-    <div class="card">
+    <div class="card" style="overflow: hidden;">
       <div class="card-label">Wallet Details</div>
-      <table style="width: 100%; table-layout: fixed; font-size: 0.85rem; margin-top: 12px;">
-        <col style="width: 130px;">
-        <col style="width: calc(100% - 130px);">
-        <tr>
-          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Type</td>
-          <td style="padding: 6px 0;">
+      <div style="font-size: 0.85rem; margin-top: 12px;">
+        <div style="padding: 8px 0; border-bottom: 1px solid var(--border);">
+          <div style="color: var(--text-muted); margin-bottom: 4px;">Type</div>
+          <div>
             <span style="background: var(--border); border-radius: 4px; padding: 1px 6px; font-size: 0.75rem;">{{.Wallet.Type}}</span>
             {{if eq .Wallet.Type "xpub"}}
             <span style="background: var(--border); border-radius: 4px; padding: 1px 6px; font-size: 0.75rem; margin-left: 4px;">{{.Wallet.DerivationType}}</span>
             {{end}}
-          </td>
-        </tr>
-        <tr>
-          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Value</td>
-          <td style="padding: 6px 0; font-family: monospace; overflow-wrap: break-word; word-break: break-all; font-size: 0.8rem;">{{.Wallet.Value}}</td>
-        </tr>
-        <tr>
-          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Balance</td>
-          <td style="padding: 6px 0; font-weight: 600;">
+          </div>
+        </div>
+        <div style="padding: 8px 0; border-bottom: 1px solid var(--border);">
+          <div style="color: var(--text-muted); margin-bottom: 4px;">Value</div>
+          <div style="font-family: monospace; font-size: 0.8rem; word-break: break-all; overflow-wrap: break-word;">{{.Wallet.Value}}</div>
+        </div>
+        <div style="padding: 8px 0; border-bottom: 1px solid var(--border);">
+          <div style="color: var(--text-muted); margin-bottom: 4px;">Balance</div>
+          <div style="font-weight: 600;">
             {{formatSats .Wallet.BalanceSats}} <span style="font-size: 0.75rem; color: var(--text-muted);">sats</span>
             {{if gt .BTCPriceUSD 0.0}}
             <span style="color: var(--text-muted); font-weight: 400; font-size: 0.85rem; margin-left: 8px;">{{formatUSD .BalanceUSD}}</span>
             {{end}}
-          </td>
-        </tr>
-        <tr>
-          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Last Checked</td>
-          <td style="padding: 6px 0;">{{timeAgoPtr .Wallet.LastCheckedAt}}</td>
-        </tr>
-        <tr>
-          <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Added</td>
-          <td style="padding: 6px 0;">{{formatDate .Wallet.CreatedAt}}</td>
-        </tr>
-      </table>
+          </div>
+        </div>
+        <div style="padding: 8px 0; border-bottom: 1px solid var(--border);">
+          <div style="color: var(--text-muted); margin-bottom: 4px;">Last Checked</div>
+          <div>{{timeAgoPtr .Wallet.LastCheckedAt}}</div>
+        </div>
+        <div style="padding: 8px 0;">
+          <div style="color: var(--text-muted); margin-bottom: 4px;">Added</div>
+          <div>{{formatDate .Wallet.CreatedAt}}</div>
+        </div>
+      </div>
     </div>
   </main>
 

--- a/internal/web/templates/wallet_detail.html
+++ b/internal/web/templates/wallet_detail.html
@@ -22,11 +22,11 @@
       <h1 style="margin: 0; font-size: 1.25rem;">{{.Wallet.Label}}</h1>
     </div>
 
-    <div class="card" style="max-width: 600px;">
+    <div class="card">
       <div class="card-label">Wallet Details</div>
       <table style="width: 100%; table-layout: fixed; font-size: 0.85rem; margin-top: 12px;">
         <col style="width: 130px;">
-        <col>
+        <col style="width: calc(100% - 130px);">
         <tr>
           <td style="padding: 6px 12px 6px 0; color: var(--text-muted); vertical-align: top;">Type</td>
           <td style="padding: 6px 0;">

--- a/internal/web/templates/wallet_detail.html
+++ b/internal/web/templates/wallet_detail.html
@@ -1,0 +1,68 @@
+{{define "wallet_detail_layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Satsbook — {{.Wallet.Label}}</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <a class="logo" href="/">Satsbook</a>
+        {{template "nav" "wallets"}}
+      </div>
+    </div>
+  </header>
+
+  <main class="container" style="padding: 24px 16px;">
+    <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 24px;">
+      <a href="/wallets" style="color: var(--text-muted); text-decoration: none; font-size: 0.85rem;">&larr; Wallets</a>
+      <h1 style="margin: 0; font-size: 1.25rem;">{{.Wallet.Label}}</h1>
+    </div>
+
+    <div class="card" style="max-width: 600px;">
+      <div class="card-label">Wallet Details</div>
+      <table style="width: 100%; font-size: 0.85rem; margin-top: 12px;">
+        <tr>
+          <td style="padding: 6px 0; color: var(--text-muted); width: 120px;">Type</td>
+          <td style="padding: 6px 0;">
+            <span style="background: var(--border); border-radius: 4px; padding: 1px 6px; font-size: 0.75rem;">{{.Wallet.Type}}</span>
+            {{if eq .Wallet.Type "xpub"}}
+            <span style="background: var(--border); border-radius: 4px; padding: 1px 6px; font-size: 0.75rem; margin-left: 4px;">{{.Wallet.DerivationType}}</span>
+            {{end}}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding: 6px 0; color: var(--text-muted);">Value</td>
+          <td style="padding: 6px 0; font-family: monospace; word-break: break-all; font-size: 0.8rem;">{{.Wallet.Value}}</td>
+        </tr>
+        <tr>
+          <td style="padding: 6px 0; color: var(--text-muted);">Balance</td>
+          <td style="padding: 6px 0; font-weight: 600;">
+            {{formatSats .Wallet.BalanceSats}} <span style="font-size: 0.75rem; color: var(--text-muted);">sats</span>
+            {{if gt .BTCPriceUSD 0.0}}
+            <span style="color: var(--text-muted); font-weight: 400; font-size: 0.85rem; margin-left: 8px;">{{formatUSD .BalanceUSD}}</span>
+            {{end}}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding: 6px 0; color: var(--text-muted);">Last Checked</td>
+          <td style="padding: 6px 0;">{{timeAgoPtr .Wallet.LastCheckedAt}}</td>
+        </tr>
+        <tr>
+          <td style="padding: 6px 0; color: var(--text-muted);">Added</td>
+          <td style="padding: 6px 0;">{{formatDate .Wallet.CreatedAt}}</td>
+        </tr>
+      </table>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Satsbook</span>
+    </div>
+  </footer>
+</body>
+</html>{{end}}

--- a/internal/web/templates/wallets_layout.html
+++ b/internal/web/templates/wallets_layout.html
@@ -63,7 +63,7 @@
       {{range .Wallets}}
       <div style="background: var(--card-bg); border: 1px solid var(--border); border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
         <div>
-          <div style="font-weight: 600;">{{.Label}}</div>
+          <div style="font-weight: 600;"><a href="/wallets/{{.ID}}" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">{{.Label}}</a></div>
           <div style="color: var(--text-muted); font-size: 0.75rem; font-family: monospace; word-break: break-all; max-width: 400px;">
             {{if or (eq .Type "xpub") (eq .Type "descriptor")}}{{truncate .Value 40}}...{{else}}{{.Value}}{{end}}
           </div>


### PR DESCRIPTION
## Summary
- Exchange detail page at `/exchange/{source}` — paginated table of all imported transactions with summary stats (purchased, received, sold, sent, cost basis, fees paid)
- Wallet detail page at `/wallets/{id}` — full wallet info (type, value, balance, last checked, created)
- Dashboard exchange names now link to their detail pages
- Wallet names on wallets page now link to their detail pages
- New `ListExchangeTransactions` DB query with count + pagination

## Test plan
- [x] Click Strike/River/Coinbase/Swan on dashboard → see transaction table
- [x] Pagination works (next/prev links, page X of Y)
- [x] Empty exchange shows "No transactions imported yet" with link to import
- [x] Click wallet label on wallets page → see wallet detail with full address/xpub
- [x] Invalid exchange source returns 404
- [x] Invalid wallet ID returns 404
- [x] Works on mobile viewport

Closes #71