### PR TITLE
feat: portfolio value chart (30-day history)

### DIFF
--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -63,6 +63,9 @@ func main() {
 	// Initialize price cache
 	priceCache := price.NewCache(price.WithAPIURL(cfg.PriceAPIURL))
 
+	// Enable portfolio snapshots after each sync
+	s.SetSnapshotStore(database, priceCache)
+
 	// Initialize HTTP server
 	httpLogger := log.New(os.Stdout, "[http] ", log.LstdFlags)
 	handler := web.NewHandler(database, lndClient, priceCache, database, httpLogger)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -177,6 +177,17 @@ var migrations = []string{
 	DROP TABLE watched_wallets;
 	ALTER TABLE watched_wallets_new RENAME TO watched_wallets;
 	`,
+
+	// Migration 6: Portfolio snapshots for 30-day value chart.
+	`
+	CREATE TABLE IF NOT EXISTS portfolio_snapshots (
+		id            INTEGER PRIMARY KEY AUTOINCREMENT,
+		captured_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		total_sats    INTEGER NOT NULL DEFAULT 0,
+		btc_price_usd REAL NOT NULL DEFAULT 0
+	);
+	CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_captured ON portfolio_snapshots(captured_at);
+	`,
 }
 
 // NewDB opens a SQLite database at the given path, runs migrations, and returns a DB.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -969,3 +969,211 @@ func (d *DB) ExchangeBalance(ctx context.Context, source string) (int64, error) 
 	}
 	return int64(math.Round(totalBTC.Float64 * 1e8)), nil
 }
+
+// TotalPortfolioSats computes total BTC across on-chain wallet, channels, cold storage, and exchanges.
+func (d *DB) TotalPortfolioSats(ctx context.Context) (int64, error) {
+	var total int64
+
+	// On-chain wallet balance (latest snapshot)
+	var walletSats sql.NullInt64
+	_ = d.db.QueryRowContext(ctx,
+		`SELECT total_sat FROM wallet_balance_snapshots ORDER BY captured_at DESC LIMIT 1`,
+	).Scan(&walletSats)
+	if walletSats.Valid {
+		total += walletSats.Int64
+	}
+
+	// Channel local balances
+	var channelSats sql.NullInt64
+	_ = d.db.QueryRowContext(ctx,
+		`SELECT SUM(local_balance) FROM channels WHERE active = 1`,
+	).Scan(&channelSats)
+	if channelSats.Valid {
+		total += channelSats.Int64
+	}
+
+	// Cold storage wallets
+	var coldSats sql.NullInt64
+	_ = d.db.QueryRowContext(ctx,
+		`SELECT SUM(balance_sats) FROM watched_wallets`,
+	).Scan(&coldSats)
+	if coldSats.Valid {
+		total += coldSats.Int64
+	}
+
+	// Exchange balances (all sources)
+	for _, source := range []string{"strike", "river", "coinbase", "swan"} {
+		bal, err := d.ExchangeBalance(ctx, source)
+		if err == nil {
+			total += bal
+		}
+	}
+
+	return total, nil
+}
+
+// PortfolioSnapshot represents a point-in-time portfolio value.
+type PortfolioSnapshot struct {
+	CapturedAt  time.Time
+	TotalSats   int64
+	BTCPriceUSD float64
+}
+
+// InsertPortfolioSnapshot records the current total portfolio value.
+func (d *DB) InsertPortfolioSnapshot(ctx context.Context, totalSats int64, btcPriceUSD float64) error {
+	_, err := d.db.ExecContext(ctx,
+		`INSERT INTO portfolio_snapshots (total_sats, btc_price_usd) VALUES (?, ?)`,
+		totalSats, btcPriceUSD,
+	)
+	if err != nil {
+		return fmt.Errorf("insert portfolio snapshot: %w", err)
+	}
+	return nil
+}
+
+// PortfolioSnapshots returns up to `days` days of portfolio snapshots, one per day (latest per day).
+func (d *DB) PortfolioSnapshots(ctx context.Context, days int) ([]PortfolioSnapshot, error) {
+	since := time.Now().AddDate(0, 0, -days).UTC().Format(time.RFC3339)
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT DATE(p.captured_at) as day,
+			p.total_sats,
+			MAX(p.btc_price_usd, 0)
+		FROM portfolio_snapshots p
+		INNER JOIN (
+			SELECT MAX(id) as max_id
+			FROM portfolio_snapshots
+			WHERE captured_at >= ?
+			GROUP BY DATE(captured_at)
+		) g ON p.id = g.max_id
+		ORDER BY day ASC`, since,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("portfolio snapshots: %w", err)
+	}
+	defer rows.Close()
+
+	var snapshots []PortfolioSnapshot
+	for rows.Next() {
+		var s PortfolioSnapshot
+		var day string
+		if err := rows.Scan(&day, &s.TotalSats, &s.BTCPriceUSD); err != nil {
+			return nil, fmt.Errorf("scan portfolio snapshot: %w", err)
+		}
+		s.CapturedAt, _ = time.Parse("2006-01-02", day)
+		snapshots = append(snapshots, s)
+	}
+	return snapshots, rows.Err()
+}
+
+// BackfillPortfolioSnapshots reconstructs historical portfolio snapshots by replaying
+// exchange transactions and wallet balance snapshots. For each unique date found in
+// the data, it computes the cumulative exchange balance (from CSV imports) plus the
+// wallet balance (from the nearest prior wallet_balance_snapshot). Channel and cold
+// storage balances are not available historically and are excluded from backfill.
+// Only dates without an existing snapshot are filled. Price data is not available
+// historically and is set to 0.
+// BackfillPortfolioSnapshots reconstructs historical portfolio snapshots by replaying
+// exchange transactions and wallet balance snapshots. For each unique date found in
+// the data, it computes the cumulative exchange balance (from CSV imports) plus the
+// wallet balance (from the nearest prior wallet_balance_snapshot). Channel and cold
+// storage balances are not available historically and are excluded from backfill.
+//
+// Backfilled snapshots use btc_price_usd = -1 as a marker so they can be distinguished
+// from live snapshots and safely replaced on re-import. This function is idempotent:
+// calling it multiple times (e.g. after each CSV import) replaces stale backfill data
+// without affecting live syncer snapshots (which have btc_price_usd >= 0).
+func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
+	// Remove previous backfilled snapshots (marker: btc_price_usd = -1)
+	_, err := d.db.ExecContext(ctx,
+		`DELETE FROM portfolio_snapshots WHERE btc_price_usd = -1`)
+	if err != nil {
+		return 0, fmt.Errorf("backfill: clear old: %w", err)
+	}
+
+	// Collect all unique dates from exchange transactions and wallet snapshots.
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT DISTINCT DATE(d) as day FROM (
+			SELECT json_extract(raw_data, '$.Date') as d FROM exchange_imports
+			WHERE json_extract(raw_data, '$.Date') IS NOT NULL
+			UNION
+			SELECT captured_at as d FROM wallet_balance_snapshots
+		)
+		WHERE d IS NOT NULL AND DATE(d) IS NOT NULL
+		ORDER BY day ASC`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("backfill: collect dates: %w", err)
+	}
+	defer rows.Close()
+
+	var dates []string
+	for rows.Next() {
+		var day string
+		if err := rows.Scan(&day); err != nil {
+			return 0, fmt.Errorf("backfill: scan date: %w", err)
+		}
+		dates = append(dates, day)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("backfill: iterate dates: %w", err)
+	}
+
+	if len(dates) == 0 {
+		return 0, nil
+	}
+
+	// For each date, compute the portfolio total and insert.
+	// Skip days that already have a live snapshot (btc_price_usd >= 0).
+	inserted := 0
+	for _, day := range dates {
+		var liveExists int
+		err := d.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM portfolio_snapshots
+			 WHERE DATE(captured_at) = ? AND btc_price_usd >= 0`, day,
+		).Scan(&liveExists)
+		if err != nil {
+			return inserted, fmt.Errorf("backfill: check existing for %s: %w", day, err)
+		}
+		if liveExists > 0 {
+			continue
+		}
+
+		var total int64
+
+		// Exchange balance: sum of all AmountBTC where Date <= this day
+		var exchBTC sql.NullFloat64
+		_ = d.db.QueryRowContext(ctx,
+			`SELECT SUM(json_extract(raw_data, '$.AmountBTC'))
+			 FROM exchange_imports
+			 WHERE COALESCE(json_extract(raw_data, '$.AmountBTC'), 0) != 0
+			   AND DATE(json_extract(raw_data, '$.Date')) <= ?`, day,
+		).Scan(&exchBTC)
+		if exchBTC.Valid {
+			total += int64(math.Round(exchBTC.Float64 * 1e8))
+		}
+
+		// Wallet balance: latest snapshot on or before this day
+		var walletSats sql.NullInt64
+		_ = d.db.QueryRowContext(ctx,
+			`SELECT total_sat FROM wallet_balance_snapshots
+			 WHERE DATE(captured_at) <= ?
+			 ORDER BY captured_at DESC LIMIT 1`, day,
+		).Scan(&walletSats)
+		if walletSats.Valid {
+			total += walletSats.Int64
+		}
+
+		// Insert with marker btc_price_usd = -1
+		capturedAt := day + " 12:00:00"
+		_, err = d.db.ExecContext(ctx,
+			`INSERT INTO portfolio_snapshots (captured_at, total_sats, btc_price_usd) VALUES (?, ?, -1)`,
+			capturedAt, total,
+		)
+		if err != nil {
+			return inserted, fmt.Errorf("backfill: insert for %s: %w", day, err)
+		}
+		inserted++
+	}
+
+	return inserted, nil
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1083,15 +1083,21 @@ func (d *DB) PortfolioSnapshots(ctx context.Context, days int) ([]PortfolioSnaps
 // calling it multiple times (e.g. after each CSV import) replaces stale backfill data
 // without affecting live syncer snapshots (which have btc_price_usd >= 0).
 func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("backfill: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
 	// Remove previous backfilled snapshots (marker: btc_price_usd = -1)
-	_, err := d.db.ExecContext(ctx,
+	_, err = tx.ExecContext(ctx,
 		`DELETE FROM portfolio_snapshots WHERE btc_price_usd = -1`)
 	if err != nil {
 		return 0, fmt.Errorf("backfill: clear old: %w", err)
 	}
 
 	// Collect all unique dates from exchange transactions and wallet snapshots.
-	rows, err := d.db.QueryContext(ctx,
+	rows, err := tx.QueryContext(ctx,
 		`SELECT DISTINCT DATE(d) as day FROM (
 			SELECT json_extract(raw_data, '$.Date') as d FROM exchange_imports
 			WHERE json_extract(raw_data, '$.Date') IS NOT NULL
@@ -1104,22 +1110,24 @@ func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("backfill: collect dates: %w", err)
 	}
-	defer rows.Close()
 
 	var dates []string
 	for rows.Next() {
 		var day string
 		if err := rows.Scan(&day); err != nil {
+			rows.Close()
 			return 0, fmt.Errorf("backfill: scan date: %w", err)
 		}
 		dates = append(dates, day)
 	}
+	rows.Close()
 	if err := rows.Err(); err != nil {
 		return 0, fmt.Errorf("backfill: iterate dates: %w", err)
 	}
 
 	if len(dates) == 0 {
-		return 0, nil
+		// Still commit to apply the delete (clears stale backfill).
+		return 0, tx.Commit()
 	}
 
 	// For each date, compute the portfolio total and insert.
@@ -1127,7 +1135,7 @@ func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
 	inserted := 0
 	for _, day := range dates {
 		var liveExists int
-		err := d.db.QueryRowContext(ctx,
+		err := tx.QueryRowContext(ctx,
 			`SELECT COUNT(*) FROM portfolio_snapshots
 			 WHERE DATE(captured_at) = ? AND btc_price_usd >= 0`, day,
 		).Scan(&liveExists)
@@ -1142,7 +1150,7 @@ func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
 
 		// Exchange balance: sum of all AmountBTC where Date <= this day
 		var exchBTC sql.NullFloat64
-		_ = d.db.QueryRowContext(ctx,
+		_ = tx.QueryRowContext(ctx,
 			`SELECT SUM(json_extract(raw_data, '$.AmountBTC'))
 			 FROM exchange_imports
 			 WHERE COALESCE(json_extract(raw_data, '$.AmountBTC'), 0) != 0
@@ -1154,7 +1162,7 @@ func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
 
 		// Wallet balance: latest snapshot on or before this day
 		var walletSats sql.NullInt64
-		_ = d.db.QueryRowContext(ctx,
+		_ = tx.QueryRowContext(ctx,
 			`SELECT total_sat FROM wallet_balance_snapshots
 			 WHERE DATE(captured_at) <= ?
 			 ORDER BY captured_at DESC LIMIT 1`, day,
@@ -1165,7 +1173,7 @@ func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
 
 		// Insert with marker btc_price_usd = -1
 		capturedAt := day + " 12:00:00"
-		_, err = d.db.ExecContext(ctx,
+		_, err = tx.ExecContext(ctx,
 			`INSERT INTO portfolio_snapshots (captured_at, total_sats, btc_price_usd) VALUES (?, ?, -1)`,
 			capturedAt, total,
 		)
@@ -1175,5 +1183,8 @@ func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
 		inserted++
 	}
 
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("backfill: commit: %w", err)
+	}
 	return inserted, nil
 }

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -2022,5 +2023,220 @@ func TestListExchangeTransactions(t *testing.T) {
 	}
 	if page.Total != 0 {
 		t.Errorf("river total = %d, want 0", page.Total)
+	}
+}
+
+func TestInsertPortfolioSnapshot(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	err := d.InsertPortfolioSnapshot(context.Background(), 5_000_000, 65000.0)
+	if err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+
+	// Insert another
+	err = d.InsertPortfolioSnapshot(context.Background(), 5_100_000, 66000.0)
+	if err != nil {
+		t.Fatalf("insert second snapshot: %v", err)
+	}
+
+	snaps, err := d.PortfolioSnapshots(context.Background(), 30)
+	if err != nil {
+		t.Fatalf("fetch snapshots: %v", err)
+	}
+	// Both inserted today, so grouped into 1 day
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 day of snapshots, got %d", len(snaps))
+	}
+	// Should pick the latest values (second insert)
+	if snaps[0].TotalSats != 5_100_000 {
+		t.Errorf("expected 5100000 sats, got %d", snaps[0].TotalSats)
+	}
+}
+
+func TestPortfolioSnapshots_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	snaps, err := d.PortfolioSnapshots(context.Background(), 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(snaps) != 0 {
+		t.Errorf("expected 0 snapshots, got %d", len(snaps))
+	}
+}
+
+func TestBackfillPortfolioSnapshots(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	ctx := context.Background()
+
+	// Backfill with no data should insert 0
+	n, err := d.BackfillPortfolioSnapshots(ctx)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 inserted with no data, got %d", n)
+	}
+
+	// Insert some exchange transactions with dates
+	now := time.Now()
+	day1 := now.AddDate(0, 0, -20).Format("2006-01-02")
+	day2 := now.AddDate(0, 0, -10).Format("2006-01-02")
+	day3 := now.AddDate(0, 0, -5).Format("2006-01-02")
+
+	for _, row := range []struct {
+		date      string
+		amountBTC float64
+	}{
+		{day1, 0.01},
+		{day2, 0.02},
+		{day3, -0.005},
+	} {
+		rawData := fmt.Sprintf(`{"Date":"%s","AmountBTC":%f,"Type":"purchase"}`, row.date, row.amountBTC)
+		_, err := d.db.ExecContext(ctx,
+			`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data)
+			 VALUES ('strike', ?, 'purchase', ?)`,
+			row.date, rawData)
+		if err != nil {
+			t.Fatalf("seed exchange: %v", err)
+		}
+	}
+
+	// Backfill should create 3 snapshots
+	n, err = d.BackfillPortfolioSnapshots(ctx)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("expected 3 inserted, got %d", n)
+	}
+
+	// Verify snapshots
+	snaps, err := d.PortfolioSnapshots(ctx, 365)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(snaps) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(snaps))
+	}
+
+	// Jan 15: 0.01 BTC = 1,000,000 sats
+	if snaps[0].TotalSats != 1_000_000 {
+		t.Errorf("jan snapshot: expected 1000000 sats, got %d", snaps[0].TotalSats)
+	}
+	// Feb 1: 0.01 + 0.02 = 0.03 BTC = 3,000,000 sats
+	if snaps[1].TotalSats != 3_000_000 {
+		t.Errorf("feb snapshot: expected 3000000 sats, got %d", snaps[1].TotalSats)
+	}
+	// Mar 1: 0.03 - 0.005 = 0.025 BTC = 2,500,000 sats
+	if snaps[2].TotalSats != 2_500_000 {
+		t.Errorf("mar snapshot: expected 2500000 sats, got %d", snaps[2].TotalSats)
+	}
+
+	// Price should be 0 (backfilled, marker -1 converted to 0)
+	if snaps[0].BTCPriceUSD != 0 {
+		t.Errorf("expected price 0 for backfilled, got %f", snaps[0].BTCPriceUSD)
+	}
+
+	// Re-running backfill is idempotent (deletes old backfill, re-inserts)
+	n, err = d.BackfillPortfolioSnapshots(ctx)
+	if err != nil {
+		t.Fatalf("re-backfill: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("re-backfill: expected 3, got %d", n)
+	}
+
+	// Should still have exactly 3 snapshots
+	snaps, err = d.PortfolioSnapshots(ctx, 365)
+	if err != nil {
+		t.Fatalf("fetch after re-backfill: %v", err)
+	}
+	if len(snaps) != 3 {
+		t.Fatalf("expected 3 snapshots after re-backfill, got %d", len(snaps))
+	}
+}
+
+func TestBackfillPortfolioSnapshots_PreservesLiveSnapshots(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	ctx := context.Background()
+
+	// Insert a live snapshot (btc_price_usd >= 0)
+	err := d.InsertPortfolioSnapshot(ctx, 5_000_000, 65000.0)
+	if err != nil {
+		t.Fatalf("insert live: %v", err)
+	}
+
+	// Insert exchange data for today
+	today := time.Now().Format("2006-01-02")
+	rawData := fmt.Sprintf(`{"Date":"%s","AmountBTC":0.01,"Type":"purchase"}`, today)
+	_, err = d.db.ExecContext(ctx,
+		`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data)
+		 VALUES ('strike', 'today-tx', 'purchase', ?)`, rawData)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Backfill should skip today (live snapshot exists)
+	n, err := d.BackfillPortfolioSnapshots(ctx)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 (live snapshot exists), got %d", n)
+	}
+
+	// Live snapshot should be preserved
+	snaps, err := d.PortfolioSnapshots(ctx, 1)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+	if snaps[0].TotalSats != 5_000_000 {
+		t.Errorf("live snapshot should be preserved, got %d sats", snaps[0].TotalSats)
+	}
+}
+
+func TestTotalPortfolioSats(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	// With no data, total should be 0
+	total, err := d.TotalPortfolioSats(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("expected 0, got %d", total)
+	}
+
+	// Add a wallet balance
+	err = d.RunSync(context.Background(), func(tx SyncTx) error {
+		return tx.InsertWalletBalanceSnapshot(WalletBalanceSnapshot{
+			CapturedAt:     time.Now(),
+			TotalSat:       100_000,
+			ConfirmedSat:   90_000,
+			UnconfirmedSat: 10_000,
+		})
+	})
+	if err != nil {
+		t.Fatalf("seed wallet balance: %v", err)
+	}
+
+	total, err = d.TotalPortfolioSats(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 100_000 {
+		t.Errorf("expected 100000, got %d", total)
 	}
 }

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -24,10 +24,23 @@ type Store interface {
 	RunSync(ctx context.Context, fn func(db.SyncTx) error) error
 }
 
+// SnapshotStore captures portfolio snapshots after each sync cycle.
+type SnapshotStore interface {
+	TotalPortfolioSats(ctx context.Context) (int64, error)
+	InsertPortfolioSnapshot(ctx context.Context, totalSats int64, btcPriceUSD float64) error
+}
+
+// PriceProvider fetches the current BTC/USD price for snapshots.
+type PriceProvider interface {
+	GetBTCPrice(ctx context.Context) (float64, error)
+}
+
 // Syncer orchestrates LND data synchronization.
 type Syncer struct {
 	lnd            LNDClient
 	store          Store
+	snapshot       SnapshotStore
+	price          PriceProvider
 	logger         *log.Logger
 	syncInterval   time.Duration
 	maxHistoryDays int
@@ -42,6 +55,12 @@ func New(lnd LNDClient, store Store, logger *log.Logger, syncInterval time.Durat
 		syncInterval:   syncInterval,
 		maxHistoryDays: maxHistoryDays,
 	}
+}
+
+// SetSnapshotStore sets the snapshot store and price provider for portfolio snapshots.
+func (s *Syncer) SetSnapshotStore(ss SnapshotStore, pp PriceProvider) {
+	s.snapshot = ss
+	s.price = pp
 }
 
 // Run blocks until ctx is cancelled, syncing on startup and then on the configured interval.
@@ -68,9 +87,38 @@ func (s *Syncer) Run(ctx context.Context) {
 
 // Sync performs one full synchronization cycle.
 func (s *Syncer) Sync(ctx context.Context) error {
-	return s.store.RunSync(ctx, func(tx db.SyncTx) error {
+	err := s.store.RunSync(ctx, func(tx db.SyncTx) error {
 		return s.syncCycle(ctx, tx)
 	})
+	if err != nil {
+		return err
+	}
+
+	// Capture portfolio snapshot after successful sync
+	if s.snapshot != nil && s.price != nil {
+		s.captureSnapshot(ctx)
+	}
+
+	return nil
+}
+
+// captureSnapshot records the current total portfolio value.
+func (s *Syncer) captureSnapshot(ctx context.Context) {
+	totalSats, err := s.snapshot.TotalPortfolioSats(ctx)
+	if err != nil {
+		s.logger.Printf("snapshot: failed to compute total sats: %v", err)
+		return
+	}
+
+	var btcPrice float64
+	price, err := s.price.GetBTCPrice(ctx)
+	if err == nil {
+		btcPrice = price
+	}
+
+	if err := s.snapshot.InsertPortfolioSnapshot(ctx, totalSats, btcPrice); err != nil {
+		s.logger.Printf("snapshot: failed to insert: %v", err)
+	}
 }
 
 // syncCycle is the core sync logic, executed within a transaction.

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -457,6 +457,121 @@ func TestSync_WithForwardingEvents(t *testing.T) {
 	}
 }
 
+// mockSnapshotStore mocks the SnapshotStore interface.
+type mockSnapshotStore struct {
+	totalSats int64
+	totalErr  error
+	inserted  []struct {
+		totalSats   int64
+		btcPriceUSD float64
+	}
+	insertErr error
+}
+
+func (m *mockSnapshotStore) TotalPortfolioSats(ctx context.Context) (int64, error) {
+	return m.totalSats, m.totalErr
+}
+
+func (m *mockSnapshotStore) InsertPortfolioSnapshot(ctx context.Context, totalSats int64, btcPriceUSD float64) error {
+	m.inserted = append(m.inserted, struct {
+		totalSats   int64
+		btcPriceUSD float64
+	}{totalSats, btcPriceUSD})
+	return m.insertErr
+}
+
+// mockPriceProvider mocks the PriceProvider interface.
+type mockPriceProvider struct {
+	price float64
+	err   error
+}
+
+func (m *mockPriceProvider) GetBTCPrice(ctx context.Context) (float64, error) {
+	return m.price, m.err
+}
+
+func TestSync_CapturesSnapshot(t *testing.T) {
+	store := newMockStore()
+	mockLND := &mockLNDClient{
+		channels:          []lnd.Channel{},
+		forwardingHistory: []lnd.ForwardingEvent{},
+		invoices:          []lnd.Invoice{},
+		payments:          []lnd.Payment{},
+		walletBalance:     defaultMockBalance(),
+	}
+
+	ss := &mockSnapshotStore{totalSats: 5_000_000}
+	pp := &mockPriceProvider{price: 65000.0}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetSnapshotStore(ss, pp)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	if len(ss.inserted) != 1 {
+		t.Fatalf("expected 1 snapshot inserted, got %d", len(ss.inserted))
+	}
+	if ss.inserted[0].totalSats != 5_000_000 {
+		t.Errorf("expected 5000000 sats, got %d", ss.inserted[0].totalSats)
+	}
+	if ss.inserted[0].btcPriceUSD != 65000.0 {
+		t.Errorf("expected price 65000, got %f", ss.inserted[0].btcPriceUSD)
+	}
+}
+
+func TestSync_SnapshotPriceError(t *testing.T) {
+	store := newMockStore()
+	mockLND := &mockLNDClient{
+		channels:          []lnd.Channel{},
+		forwardingHistory: []lnd.ForwardingEvent{},
+		invoices:          []lnd.Invoice{},
+		payments:          []lnd.Payment{},
+		walletBalance:     defaultMockBalance(),
+	}
+
+	ss := &mockSnapshotStore{totalSats: 1_000_000}
+	pp := &mockPriceProvider{err: errors.New("price unavailable")}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetSnapshotStore(ss, pp)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	// Snapshot should still be inserted with price=0
+	if len(ss.inserted) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(ss.inserted))
+	}
+	if ss.inserted[0].btcPriceUSD != 0 {
+		t.Errorf("expected price 0 on error, got %f", ss.inserted[0].btcPriceUSD)
+	}
+}
+
+func TestSync_NoSnapshotWithoutStore(t *testing.T) {
+	store := newMockStore()
+	mockLND := &mockLNDClient{
+		channels:          []lnd.Channel{},
+		forwardingHistory: []lnd.ForwardingEvent{},
+		invoices:          []lnd.Invoice{},
+		payments:          []lnd.Payment{},
+		walletBalance:     defaultMockBalance(),
+	}
+
+	s := newTestSyncer(mockLND, store)
+	// No SetSnapshotStore call
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	// No panic, no snapshot — just passes
+}
+
 func TestRun_StopsOnCancel(t *testing.T) {
 	store := newMockStore()
 	mockLND := &mockLNDClient{

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -132,7 +132,7 @@ func (h *Handler) HandlePortfolioBackfill(w http.ResponseWriter, r *http.Request
 		h.logger.Printf("portfolio backfill error: %v", err)
 		if r.Header.Get("HX-Request") == "true" {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			fmt.Fprintf(w, `<span style="color:var(--danger,#ef4444);font-size:0.85rem;">Backfill failed: %s</span>`, err.Error())
+			fmt.Fprintf(w, `<span style="color:var(--danger,#ef4444);">Backfill failed: %s</span>`, err.Error())
 			return
 		}
 		h.writeError(w, http.StatusInternalServerError, "backfill failed: "+err.Error())
@@ -143,13 +143,11 @@ func (h *Handler) HandlePortfolioBackfill(w http.ResponseWriter, r *http.Request
 
 	if r.Header.Get("HX-Request") == "true" {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		msg := "No new data to backfill"
+		msg := "No new data to backfill."
 		if n > 0 {
-			msg = fmt.Sprintf("Rebuilt %d days of history. Reloading…", n)
+			msg = fmt.Sprintf("Done — rebuilt %d days of portfolio history.", n)
 		}
-		// Return a success message, then trigger a page reload after a short delay
-		fmt.Fprintf(w, `<span style="color:var(--success,#4ade80);font-size:0.85rem;">%s</span>
-<script>setTimeout(function(){window.location.reload()},1500)</script>`, msg)
+		fmt.Fprintf(w, `<span style="color:var(--success,#4ade80);">%s</span>`, msg)
 		return
 	}
 

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -27,6 +27,8 @@ type DashboardStore interface {
 	ExchangeSummary(ctx context.Context, source string, since time.Time) (*db.ExchangeSummaryResult, error)
 	ListExchangeTransactions(ctx context.Context, source string, limit, offset int) (*db.ExchangeTransactionPage, error)
 	PortfolioPosition(ctx context.Context, since time.Time) (*db.PortfolioPositionResult, error)
+	PortfolioSnapshots(ctx context.Context, days int) ([]db.PortfolioSnapshot, error)
+	BackfillPortfolioSnapshots(ctx context.Context) (int, error)
 }
 
 // NodeInfoProvider fetches node info from LND.
@@ -98,6 +100,44 @@ func (h *Handler) SetWalletStore(ws WalletStore) {
 // SetWalletScanner sets the wallet scanner (optional, requires Electrum).
 func (h *Handler) SetWalletScanner(ws WalletScanner) {
 	h.walletScanner = ws
+}
+
+// backfillSnapshots runs portfolio snapshot backfill in the background after imports.
+func (h *Handler) backfillSnapshots(ctx context.Context) {
+	go func() {
+		n, err := h.store.BackfillPortfolioSnapshots(ctx)
+		if err != nil {
+			h.logger.Printf("portfolio backfill error: %v", err)
+		} else if n > 0 {
+			h.logger.Printf("portfolio backfill: inserted %d historical snapshots", n)
+		}
+	}()
+}
+
+// HandlePortfolioBackfill serves POST /api/portfolio/backfill.
+// Reconstructs historical portfolio snapshots from exchange CSVs and wallet data.
+func (h *Handler) HandlePortfolioBackfill(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	n, err := h.store.BackfillPortfolioSnapshots(r.Context())
+	if err != nil {
+		h.logger.Printf("portfolio backfill error: %v", err)
+		h.writeError(w, http.StatusInternalServerError, "backfill failed: "+err.Error())
+		return
+	}
+
+	h.logger.Printf("portfolio backfill: inserted %d historical snapshots", n)
+
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, map[string]int{"inserted": n})
 }
 
 // --- JSON response types ---
@@ -448,6 +488,8 @@ func (h *Handler) HandleStrikeImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.backfillSnapshots(r.Context())
+
 	resp := importResponse{
 		Total:          summary.Total,
 		NewPurchases:   summary.NewPurchases,
@@ -531,6 +573,8 @@ func (h *Handler) HandleRiverImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.backfillSnapshots(r.Context())
+
 	resp := importResponse{
 		Total:          summary.Total,
 		NewPurchases:   summary.NewPurchases,
@@ -604,6 +648,8 @@ func (h *Handler) HandleCoinbaseImport(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, http.StatusInternalServerError, "failed to import transactions")
 		return
 	}
+
+	h.backfillSnapshots(r.Context())
 
 	resp := importResponse{
 		Total:          summary.Total,
@@ -701,6 +747,8 @@ func (h *Handler) HandleSwanImport(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, http.StatusInternalServerError, "failed to import transactions")
 		return
 	}
+
+	h.backfillSnapshots(r.Context())
 
 	resp := importResponse{
 		Total:        summary.Total,

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -116,15 +116,25 @@ func (h *Handler) backfillSnapshots(ctx context.Context) {
 
 // HandlePortfolioBackfill serves POST /api/portfolio/backfill.
 // Reconstructs historical portfolio snapshots from exchange CSVs and wallet data.
+// Uses a detached context so the operation completes even if the user navigates away.
 func (h *Handler) HandlePortfolioBackfill(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
-	n, err := h.store.BackfillPortfolioSnapshots(r.Context())
+	// Use background context — this can take 30s+ and we don't want a
+	// cancelled HTTP request to abort the DB writes mid-transaction.
+	ctx := context.Background()
+
+	n, err := h.store.BackfillPortfolioSnapshots(ctx)
 	if err != nil {
 		h.logger.Printf("portfolio backfill error: %v", err)
+		if r.Header.Get("HX-Request") == "true" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprintf(w, `<span style="color:var(--danger,#ef4444);font-size:0.85rem;">Backfill failed: %s</span>`, err.Error())
+			return
+		}
 		h.writeError(w, http.StatusInternalServerError, "backfill failed: "+err.Error())
 		return
 	}
@@ -132,8 +142,14 @@ func (h *Handler) HandlePortfolioBackfill(w http.ResponseWriter, r *http.Request
 	h.logger.Printf("portfolio backfill: inserted %d historical snapshots", n)
 
 	if r.Header.Get("HX-Request") == "true" {
-		w.Header().Set("HX-Redirect", "/")
-		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		msg := "No new data to backfill"
+		if n > 0 {
+			msg = fmt.Sprintf("Rebuilt %d days of history. Reloading…", n)
+		}
+		// Return a success message, then trigger a page reload after a short delay
+		fmt.Fprintf(w, `<span style="color:var(--success,#4ade80);font-size:0.85rem;">%s</span>
+<script>setTimeout(function(){window.location.reload()},1500)</script>`, msg)
 		return
 	}
 

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -83,7 +83,8 @@ type DashboardData struct {
 	LastSyncedAt time.Time
 
 	// Chart data
-	DailyFees []db.DailyFeeStat
+	DailyFees          []db.DailyFeeStat
+	PortfolioSnapshots []db.PortfolioSnapshot
 
 	// Channel list
 	Channels []db.ChannelStat
@@ -140,7 +141,8 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		priceFetched       time.Time
 		portfolioAll       *db.PortfolioPositionResult
 		portfolioYTD       *db.PortfolioPositionResult
-		coldStorageSats    int64
+		coldStorageSats       int64
+		portfolioSnapshots []db.PortfolioSnapshot
 	}
 	var res result
 
@@ -229,6 +231,15 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	})
 
 	fetch(func() {
+		snaps, err := h.store.PortfolioSnapshots(ctx, 30)
+		if err == nil {
+			mu.Lock()
+			res.portfolioSnapshots = snaps
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
 		info, err := h.node.GetInfo(ctx)
 		if err == nil {
 			mu.Lock()
@@ -298,6 +309,7 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	data.ActiveChannels = res.activeChannels
 	data.LastSyncedAt = res.lastSynced
 	data.DailyFees = res.dailyFees
+	data.PortfolioSnapshots = res.portfolioSnapshots
 	data.Channels = res.channels
 
 	if res.balance != nil {

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -141,8 +141,7 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		priceFetched       time.Time
 		portfolioAll       *db.PortfolioPositionResult
 		portfolioYTD       *db.PortfolioPositionResult
-		coldStorageSats       int64
-		portfolioSnapshots []db.PortfolioSnapshot
+		coldStorageSats int64
 	}
 	var res result
 
@@ -231,15 +230,6 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	})
 
 	fetch(func() {
-		snaps, err := h.store.PortfolioSnapshots(ctx, 30)
-		if err == nil {
-			mu.Lock()
-			res.portfolioSnapshots = snaps
-			mu.Unlock()
-		}
-	})
-
-	fetch(func() {
 		info, err := h.node.GetInfo(ctx)
 		if err == nil {
 			mu.Lock()
@@ -309,7 +299,6 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	data.ActiveChannels = res.activeChannels
 	data.LastSyncedAt = res.lastSynced
 	data.DailyFees = res.dailyFees
-	data.PortfolioSnapshots = res.portfolioSnapshots
 	data.Channels = res.channels
 
 	if res.balance != nil {
@@ -362,6 +351,24 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	if err := h.renderer.Render(w, "layout", data); err != nil {
 		h.logger.Printf("failed to render dashboard: %v", err)
 	}
+}
+
+// HandlePortfolioChartPartial serves GET /partials/portfolio-chart (HTMX partial).
+func (h *Handler) HandlePortfolioChartPartial(w http.ResponseWriter, r *http.Request) {
+	days := parseIntParam(r, "days", 30)
+	if days <= 0 {
+		days = 3650 // "All" — 10 years
+	}
+
+	snaps, err := h.store.PortfolioSnapshots(r.Context(), days)
+	if err != nil {
+		h.logger.Printf("portfolio chart partial error: %v", err)
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// portfolioChart returns template.HTML, write it directly
+	html := portfolioChart(snaps)
+	w.Write([]byte(html))
 }
 
 // HandleForwardingPartial serves GET /partials/forwarding (HTMX partial).

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -33,6 +33,7 @@ type mockStore struct {
 	exchangeSummaryFn          func(ctx context.Context, source string, since time.Time) (*db.ExchangeSummaryResult, error)
 	listExchangeTransactionsFn func(ctx context.Context, source string, limit, offset int) (*db.ExchangeTransactionPage, error)
 	portfolioPositionFn        func(ctx context.Context, since time.Time) (*db.PortfolioPositionResult, error)
+	portfolioSnapshotsFn       func(ctx context.Context, days int) ([]db.PortfolioSnapshot, error)
 }
 
 func (m *mockStore) FeeSummary(ctx context.Context, since time.Time) (int64, int64, error) {
@@ -85,6 +86,15 @@ func (m *mockStore) PortfolioPosition(ctx context.Context, since time.Time) (*db
 		return m.portfolioPositionFn(ctx, since)
 	}
 	return &db.PortfolioPositionResult{BySource: map[string]db.SourceBalance{}}, nil
+}
+func (m *mockStore) PortfolioSnapshots(ctx context.Context, days int) ([]db.PortfolioSnapshot, error) {
+	if m.portfolioSnapshotsFn != nil {
+		return m.portfolioSnapshotsFn(ctx, days)
+	}
+	return nil, nil
+}
+func (m *mockStore) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
+	return 0, nil
 }
 
 type mockNodeInfo struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -45,6 +45,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
 	mux.HandleFunc("/api/wallets/delete", handler.HandleRemoveWallet)
 	mux.HandleFunc("/api/wallets/refresh", handler.HandleRefreshWallet)
 	mux.HandleFunc("/api/wallets/refresh-all", handler.HandleRefreshAll)
+	mux.HandleFunc("/api/portfolio/backfill", handler.HandlePortfolioBackfill)
 	mux.Handle("/api/import/strike/clear", handler.HandleClearImport("strike"))
 	mux.Handle("/api/import/river/clear", handler.HandleClearImport("river"))
 	mux.Handle("/api/import/coinbase/clear", handler.HandleClearImport("coinbase"))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -27,6 +27,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
 	mux.HandleFunc("/exchange/", handler.HandleExchangeDetail)
 	mux.HandleFunc("/wallets/", handler.HandleWalletDetail)
 	mux.HandleFunc("/partials/forwarding", handler.HandleForwardingPartial)
+	mux.HandleFunc("/partials/portfolio-chart", handler.HandlePortfolioChartPartial)
 
 	// Static assets (embedded)
 	staticSub, _ := fs.Sub(staticFS, "static")

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -56,6 +56,7 @@ func NewRenderer() *Renderer {
 			}
 			return costUSD / (float64(sats) / 1e8)
 		},
+		"portfolioChart": portfolioChart,
 		"dict": func(kv ...interface{}) (map[string]interface{}, error) {
 			if len(kv)%2 != 0 {
 				return nil, fmt.Errorf("dict requires even number of args")
@@ -208,6 +209,108 @@ func seq(n int) []int {
 		s[i] = i
 	}
 	return s
+}
+
+// portfolioChart generates an inline SVG line chart from portfolio snapshots.
+func portfolioChart(snapshots []db.PortfolioSnapshot) template.HTML {
+	if len(snapshots) == 0 {
+		return template.HTML(`<div class="chart-empty">No portfolio data yet — snapshots are recorded each sync cycle</div>`)
+	}
+
+	const (
+		width     = 800
+		height    = 200
+		padTop    = 10
+		padBottom = 30
+		padLeft   = 70
+		padRight  = 10
+		chartW    = width - padLeft - padRight
+		chartH    = height - padTop - padBottom
+	)
+
+	// Find min/max sats for scaling
+	var minSats, maxSats int64
+	minSats = snapshots[0].TotalSats
+	maxSats = snapshots[0].TotalSats
+	for _, s := range snapshots {
+		if s.TotalSats < minSats {
+			minSats = s.TotalSats
+		}
+		if s.TotalSats > maxSats {
+			maxSats = s.TotalSats
+		}
+	}
+
+	// Add 5% padding to range
+	rangeVal := maxSats - minSats
+	if rangeVal == 0 {
+		rangeVal = 1
+	}
+	pad := rangeVal / 20
+	if pad == 0 {
+		pad = 1
+	}
+	scaleMin := minSats - pad
+	if scaleMin < 0 {
+		scaleMin = 0
+	}
+	scaleMax := maxSats + pad
+	scaleRange := scaleMax - scaleMin
+	if scaleRange == 0 {
+		scaleRange = 1
+	}
+
+	n := len(snapshots)
+	xStep := float64(chartW) / float64(n-1)
+	if n == 1 {
+		xStep = float64(chartW)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, `<svg viewBox="0 0 %d %d" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">`, width, height)
+
+	// Y-axis and X-axis
+	fmt.Fprintf(&sb, `<line x1="%d" y1="%d" x2="%d" y2="%d" class="chart-axis"/>`, padLeft, padTop, padLeft, padTop+chartH)
+	fmt.Fprintf(&sb, `<line x1="%d" y1="%d" x2="%d" y2="%d" class="chart-axis"/>`, padLeft, padTop+chartH, padLeft+chartW, padTop+chartH)
+
+	// Y-axis labels
+	fmt.Fprintf(&sb, `<text x="%d" y="%d" class="chart-label" text-anchor="end">%s</text>`, padLeft-5, padTop+10, formatSats(scaleMax))
+	fmt.Fprintf(&sb, `<text x="%d" y="%d" class="chart-label" text-anchor="end">%s</text>`, padLeft-5, padTop+chartH, formatSats(scaleMin))
+
+	// Build polyline points and circles
+	var points strings.Builder
+	for i, s := range snapshots {
+		var x float64
+		if n == 1 {
+			x = float64(padLeft) + float64(chartW)/2
+		} else {
+			x = float64(padLeft) + float64(i)*xStep
+		}
+		y := float64(padTop) + float64(chartH) - (float64(s.TotalSats-scaleMin)/float64(scaleRange))*float64(chartH)
+		fmt.Fprintf(&points, "%.1f,%.1f ", x, y)
+
+		// Tooltip circle for each point
+		usdLabel := ""
+		if s.BTCPriceUSD > 0 {
+			usdVal := float64(s.TotalSats) / 1e8 * s.BTCPriceUSD
+			usdLabel = fmt.Sprintf(" ($%.0f)", usdVal)
+		}
+		fmt.Fprintf(&sb, `<circle cx="%.1f" cy="%.1f" r="3" class="chart-dot"><title>%s: %s sats%s</title></circle>`,
+			x, y, s.CapturedAt.Format("Jan 02"), formatSats(s.TotalSats), usdLabel)
+
+		// X-axis labels
+		if i == 0 || i == n-1 || (n > 7 && i%(n/5) == 0) {
+			fmt.Fprintf(&sb, `<text x="%.1f" y="%d" class="chart-label" text-anchor="middle">%s</text>`,
+				x, padTop+chartH+15, s.CapturedAt.Format("01-02"))
+		}
+	}
+
+	// Draw the line
+	fmt.Fprintf(&sb, `<polyline points="%s" class="chart-line" fill="none" stroke="var(--accent, #f7931a)" stroke-width="2"/>`,
+		strings.TrimSpace(points.String()))
+
+	sb.WriteString(`</svg>`)
+	return template.HTML(sb.String())
 }
 
 // feeChart generates an inline SVG bar chart from daily fee data.

--- a/internal/web/template_test.go
+++ b/internal/web/template_test.go
@@ -151,6 +151,70 @@ func TestSeq(t *testing.T) {
 	}
 }
 
+func TestPortfolioChart_Empty(t *testing.T) {
+	html := portfolioChart(nil)
+	if !contains(string(html), "No portfolio data yet") {
+		t.Errorf("unexpected empty chart output: %s", html)
+	}
+}
+
+func TestPortfolioChart_WithData(t *testing.T) {
+	now := time.Now()
+	data := []db.PortfolioSnapshot{
+		{CapturedAt: now.AddDate(0, 0, -2), TotalSats: 1000000, BTCPriceUSD: 60000},
+		{CapturedAt: now.AddDate(0, 0, -1), TotalSats: 1100000, BTCPriceUSD: 61000},
+		{CapturedAt: now, TotalSats: 1050000, BTCPriceUSD: 59000},
+	}
+	html := portfolioChart(data)
+	s := string(html)
+
+	if !contains(s, "<svg") {
+		t.Error("expected SVG element")
+	}
+	if !contains(s, "chart-line") {
+		t.Error("expected chart-line class")
+	}
+	if !contains(s, "chart-dot") {
+		t.Error("expected chart-dot class")
+	}
+	// Should have 3 dots
+	count := countOccurrences(s, `class="chart-dot"`)
+	if count != 3 {
+		t.Errorf("expected 3 dots, found %d", count)
+	}
+	// Should include USD tooltip
+	if !contains(s, "$") {
+		t.Error("expected USD value in tooltip")
+	}
+}
+
+func TestPortfolioChart_SinglePoint(t *testing.T) {
+	data := []db.PortfolioSnapshot{
+		{CapturedAt: time.Now(), TotalSats: 500000, BTCPriceUSD: 0},
+	}
+	html := portfolioChart(data)
+	s := string(html)
+	if !contains(s, "<svg") {
+		t.Error("expected SVG for single point")
+	}
+	// No USD when price is 0
+	if contains(s, "$") {
+		t.Error("expected no USD value when price is 0")
+	}
+}
+
+func TestPortfolioChart_FlatLine(t *testing.T) {
+	now := time.Now()
+	data := []db.PortfolioSnapshot{
+		{CapturedAt: now.AddDate(0, 0, -1), TotalSats: 500000},
+		{CapturedAt: now, TotalSats: 500000},
+	}
+	html := portfolioChart(data)
+	if !contains(string(html), "<svg") {
+		t.Error("expected SVG for flat line (same values)")
+	}
+}
+
 // helpers
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && countOccurrences(s, substr) > 0

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -143,6 +143,22 @@
   </div>
 </div>
 
+<!-- Portfolio Value Chart -->
+<div class="chart-section">
+  <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;">
+    <h2 style="margin: 0;">Portfolio Value (last 30 days)</h2>
+    <button hx-post="/api/portfolio/backfill"
+            hx-swap="none"
+            style="font-size: 0.8rem; padding: 4px 12px; cursor: pointer;"
+            title="Reconstruct historical portfolio values from imported exchange CSVs and wallet data">
+      Rebuild History
+    </button>
+  </div>
+  <div class="chart-container">
+    {{portfolioChart .PortfolioSnapshots}}
+  </div>
+</div>
+
 <!-- Channel Table -->
 <div class="table-section">
   <h2>Channels</h2>

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -146,25 +146,30 @@
 <!-- Portfolio Value Chart -->
 <div class="chart-section">
   <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;">
-    <h2 style="margin: 0;">Portfolio Value (last 30 days)</h2>
-    <span id="backfill-area" style="display:inline-flex;align-items:center;gap:8px;">
-      <button hx-post="/api/portfolio/backfill"
-              hx-target="#backfill-result"
-              hx-swap="innerHTML"
-              hx-indicator="#backfill-spinner"
-              hx-disabled-elt="this"
-              style="font-size: 0.8rem; padding: 4px 12px; cursor: pointer;"
-              title="Reconstruct historical portfolio values from imported exchange CSVs and wallet data">
-        Rebuild History
-      </button>
-      <span id="backfill-spinner" class="htmx-indicator" style="font-size:0.8rem;color:var(--text-muted);">Rebuilding… this may take a moment</span>
-      <span id="backfill-result"></span>
-    </span>
+    <h2 style="margin: 0;">Portfolio Value</h2>
+    <div style="display: flex; gap: 4px; font-size: 0.8rem;">
+      <button class="filter-form portfolio-range-btn" data-days="30"
+              onclick="setPortfolioRange(30)" style="display:inline-block;padding:4px 10px;opacity:1;">30d</button>
+      <button class="filter-form portfolio-range-btn" data-days="90"
+              onclick="setPortfolioRange(90)" style="display:inline-block;padding:4px 10px;opacity:0.6;">90d</button>
+      <button class="filter-form portfolio-range-btn" data-days="0"
+              onclick="setPortfolioRange(0)" style="display:inline-block;padding:4px 10px;opacity:0.6;">All</button>
+    </div>
   </div>
-  <div class="chart-container">
-    {{portfolioChart .PortfolioSnapshots}}
+  <div id="portfolio-chart" class="chart-container"
+       hx-get="/partials/portfolio-chart?days=30"
+       hx-trigger="load"
+       hx-swap="innerHTML">
   </div>
 </div>
+<script>
+function setPortfolioRange(days) {
+  document.querySelectorAll('.portfolio-range-btn').forEach(function(b) {
+    b.style.opacity = parseInt(b.dataset.days) === days ? '1' : '0.6';
+  });
+  htmx.ajax('GET', '/partials/portfolio-chart?days=' + days, '#portfolio-chart');
+}
+</script>
 
 <!-- Channel Table -->
 <div class="table-section">

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -147,12 +147,19 @@
 <div class="chart-section">
   <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;">
     <h2 style="margin: 0;">Portfolio Value (last 30 days)</h2>
-    <button hx-post="/api/portfolio/backfill"
-            hx-swap="none"
-            style="font-size: 0.8rem; padding: 4px 12px; cursor: pointer;"
-            title="Reconstruct historical portfolio values from imported exchange CSVs and wallet data">
-      Rebuild History
-    </button>
+    <span id="backfill-area" style="display:inline-flex;align-items:center;gap:8px;">
+      <button hx-post="/api/portfolio/backfill"
+              hx-target="#backfill-result"
+              hx-swap="innerHTML"
+              hx-indicator="#backfill-spinner"
+              hx-disabled-elt="this"
+              style="font-size: 0.8rem; padding: 4px 12px; cursor: pointer;"
+              title="Reconstruct historical portfolio values from imported exchange CSVs and wallet data">
+        Rebuild History
+      </button>
+      <span id="backfill-spinner" class="htmx-indicator" style="font-size:0.8rem;color:var(--text-muted);">Rebuilding… this may take a moment</span>
+      <span id="backfill-result"></span>
+    </span>
   </div>
   <div class="chart-container">
     {{portfolioChart .PortfolioSnapshots}}

--- a/internal/web/templates/import.html
+++ b/internal/web/templates/import.html
@@ -125,6 +125,24 @@
 
 <div id="import-result" style="margin-top: 20px;"></div>
 
+<!-- Re-sync portfolio history -->
+<div class="card" style="max-width: 600px; margin-top: 24px;">
+  <div class="card-label">Portfolio History</div>
+  <p class="card-sub" style="margin-bottom: 12px;">
+    Reconstruct historical portfolio values from your imported exchange data and wallet balance history. Run this after importing or clearing CSV data.
+  </p>
+  <form hx-post="/api/portfolio/backfill"
+        hx-target="#backfill-result"
+        hx-swap="innerHTML"
+        hx-indicator="#backfill-btn">
+    <button type="submit" class="scan-btn filter-form" style="display:inline-block;min-width:180px;">
+      <span class="scan-label">Re-sync Portfolio History</span>
+      <span class="htmx-indicator scan-spinner"></span>
+    </button>
+  </form>
+  <div id="backfill-result" style="margin-top: 8px; font-size: 0.85rem;"></div>
+</div>
+
 <script>
 function showTab(name) {
   ['strike','river','coinbase','swan'].forEach(function(t) {


### PR DESCRIPTION
## Summary
- Adds `portfolio_snapshots` table (migration 6) to record total BTC position and BTC/USD price after each sync cycle
- Syncer captures live snapshots via `SnapshotStore`/`PriceProvider` interfaces after each successful sync
- **Historical backfill**: after each CSV import, replays exchange transactions chronologically to reconstruct portfolio value per day (cumulative exchange balance + wallet balance snapshots). Backfill is idempotent — uses `btc_price_usd = -1` as a marker so re-imports replace stale data without affecting live syncer snapshots.
- Dashboard renders an SVG line chart showing portfolio value over the last 30 days with date and value hover tooltips (sats + USD)
- Fixes `TotalPortfolioSats` wallet balance query column name (`ts` → `captured_at`)
- Fixes `PortfolioSnapshots` query to correctly pick the latest snapshot per day

## Test plan
- [x] DB tests: InsertPortfolioSnapshot, PortfolioSnapshots (empty, grouped by day), TotalPortfolioSats
- [x] DB tests: BackfillPortfolioSnapshots (empty, with exchange data, idempotent re-run, preserves live snapshots)
- [x] Syncer tests: snapshot capture after sync, price error fallback (price=0), no snapshot without store
- [x] Template tests: portfolioChart empty, with data, single point, flat line
- [x] All existing tests pass, coverage ≥80% on web/syncer/db

Closes #66