### PR TITLE
feat: cost basis verification and re-import support

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2,9 +2,7 @@ package db
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -310,6 +308,7 @@ type ImportSummary struct {
 	Total        int
 	NewPurchases int
 	Duplicates   int
+	Updated      int
 }
 
 // ImportStrikeCSV imports parsed Strike CSV rows into exchange_imports and btc_lots.
@@ -326,62 +325,80 @@ func (d *DB) ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*I
 	for _, row := range rows {
 		rawData, _ := json.Marshal(row)
 
-		// Use content hash for dedup — Strike reference IDs are not unique
-		// (same ref can appear for reversals, multi-part transactions, etc.)
-		h := sha256.Sum256([]byte(row.RawLine))
-		contentHash := hex.EncodeToString(h[:])
+		// Use TransactionID (Strike "Reference") as the key field.
+		// Same reference can appear with different tx_types (e.g. Sale + Withdrawal).
+		externalID := row.TransactionID
 
-		// Insert into exchange_imports (dedup via UNIQUE(source, external_id, tx_type))
-		// external_id is the content hash so re-importing the same CSV is idempotent
-		res, err := tx.ExecContext(ctx,
-			`INSERT OR IGNORE INTO exchange_imports (source, external_id, tx_type, raw_data)
-			 VALUES (?, ?, ?, ?)`,
-			"strike", contentHash, row.Type, string(rawData),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("insert exchange import %q: %w", row.TransactionID, err)
+		// Check if this row already exists
+		var existingRaw string
+		err := tx.QueryRowContext(ctx,
+			`SELECT raw_data FROM exchange_imports WHERE source = ? AND external_id = ? AND tx_type = ?`,
+			"strike", externalID, row.Type,
+		).Scan(&existingRaw)
+
+		isNew := errors.Is(err, sql.ErrNoRows)
+		if err != nil && !isNew {
+			return nil, fmt.Errorf("check exchange import %q: %w", row.TransactionID, err)
 		}
 
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return nil, fmt.Errorf("rows affected for %q: %w", row.TransactionID, err)
-		}
-
-		if affected == 0 {
+		rawStr := string(rawData)
+		if !isNew && existingRaw == rawStr {
 			summary.Duplicates++
 			continue
 		}
 
-		// Create btc_lot for completed purchases
+		if isNew {
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data) VALUES (?, ?, ?, ?)`,
+				"strike", externalID, row.Type, rawStr,
+			)
+		} else {
+			_, err = tx.ExecContext(ctx,
+				`UPDATE exchange_imports SET raw_data = ? WHERE source = ? AND external_id = ? AND tx_type = ?`,
+				rawStr, "strike", externalID, row.Type,
+			)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("upsert exchange import %q: %w", row.TransactionID, err)
+		}
+
+		// Create or update btc_lot for completed purchases
 		if row.IsPurchase() && row.AmountSat > 0 {
-			// Dedup check: don't create lot if one already exists for this content hash
-			var exists int
-			err := tx.QueryRowContext(ctx,
-				`SELECT 1 FROM btc_lots WHERE source = ? AND external_id = ?`,
-				"strike", contentHash,
-			).Scan(&exists)
-			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				return nil, fmt.Errorf("check btc_lot %q: %w", contentHash, err)
+			priceUSD := row.CostBasisUSD
+			if priceUSD == 0 {
+				priceUSD = row.AmountUSD
 			}
+			if priceUSD == 0 {
+				continue
+			}
+
+			var lotID int64
+			err := tx.QueryRowContext(ctx,
+				`SELECT id FROM btc_lots WHERE source = ? AND external_id = ?`,
+				"strike", externalID,
+			).Scan(&lotID)
 			if errors.Is(err, sql.ErrNoRows) {
-				// Prefer cost basis from Strike; fall back to amount USD
-				priceUSD := row.CostBasisUSD
-				if priceUSD == 0 {
-					priceUSD = row.AmountUSD
-				}
-				if priceUSD == 0 {
-					// No cost basis available, skip lot creation
-					continue
-				}
 				_, err = tx.ExecContext(ctx,
 					`INSERT INTO btc_lots (acquired_at, amount_sat, price_usd, source, external_id)
 					 VALUES (?, ?, ?, ?, ?)`,
-					row.Date, row.AmountSat, priceUSD, "strike", contentHash,
+					row.Date, row.AmountSat, priceUSD, "strike", externalID,
 				)
 				if err != nil {
-					return nil, fmt.Errorf("insert btc_lot %q: %w", contentHash, err)
+					return nil, fmt.Errorf("insert btc_lot %q: %w", externalID, err)
 				}
 				summary.NewPurchases++
+			} else if err != nil {
+				return nil, fmt.Errorf("check btc_lot %q: %w", externalID, err)
+			} else {
+				// Update cost basis if it changed
+				_, err = tx.ExecContext(ctx,
+					`UPDATE btc_lots SET price_usd = ? WHERE id = ?`,
+					priceUSD, lotID,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("update btc_lot %q: %w", externalID, err)
+				}
+				summary.Updated++
 			}
 		}
 	}
@@ -407,55 +424,77 @@ func (d *DB) ImportRiverCSV(ctx context.Context, rows []exchange.RiverRow) (*Imp
 	for _, row := range rows {
 		rawData, _ := json.Marshal(row)
 
-		h := sha256.Sum256([]byte(row.RawLine))
-		contentHash := hex.EncodeToString(h[:])
+		// River has no transaction ID; use composite key: date|type|amount_btc
+		externalID := fmt.Sprintf("%s|%s|%.8f", row.Date.Format("2006-01-02T15:04:05"), row.Type, row.AmountBTC)
 
-		res, err := tx.ExecContext(ctx,
-			`INSERT OR IGNORE INTO exchange_imports (source, external_id, tx_type, raw_data)
-			 VALUES (?, ?, ?, ?)`,
-			"river", contentHash, row.Type, string(rawData),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("insert exchange import: %w", err)
+		var existingRaw string
+		err := tx.QueryRowContext(ctx,
+			`SELECT raw_data FROM exchange_imports WHERE source = ? AND external_id = ? AND tx_type = ?`,
+			"river", externalID, row.Type,
+		).Scan(&existingRaw)
+
+		isNew := errors.Is(err, sql.ErrNoRows)
+		if err != nil && !isNew {
+			return nil, fmt.Errorf("check exchange import: %w", err)
 		}
 
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return nil, fmt.Errorf("rows affected: %w", err)
-		}
-
-		if affected == 0 {
+		rawStr := string(rawData)
+		if !isNew && existingRaw == rawStr {
 			summary.Duplicates++
 			continue
 		}
 
-		// Create btc_lot for completed purchases
+		if isNew {
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data) VALUES (?, ?, ?, ?)`,
+				"river", externalID, row.Type, rawStr,
+			)
+		} else {
+			_, err = tx.ExecContext(ctx,
+				`UPDATE exchange_imports SET raw_data = ? WHERE source = ? AND external_id = ? AND tx_type = ?`,
+				rawStr, "river", externalID, row.Type,
+			)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("upsert exchange import: %w", err)
+		}
+
+		// Create or update btc_lot for completed purchases
 		if row.IsPurchase() && row.AmountSat > 0 {
-			var exists int
-			err := tx.QueryRowContext(ctx,
-				`SELECT 1 FROM btc_lots WHERE source = ? AND external_id = ?`,
-				"river", contentHash,
-			).Scan(&exists)
-			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				return nil, fmt.Errorf("check btc_lot %q: %w", contentHash, err)
+			priceUSD := row.CostBasisUSD
+			if priceUSD == 0 {
+				priceUSD = row.AmountUSD
 			}
+			if priceUSD == 0 {
+				continue
+			}
+
+			var lotID int64
+			err := tx.QueryRowContext(ctx,
+				`SELECT id FROM btc_lots WHERE source = ? AND external_id = ?`,
+				"river", externalID,
+			).Scan(&lotID)
 			if errors.Is(err, sql.ErrNoRows) {
-				priceUSD := row.CostBasisUSD
-				if priceUSD == 0 {
-					priceUSD = row.AmountUSD
-				}
-				if priceUSD == 0 {
-					continue
-				}
 				_, err = tx.ExecContext(ctx,
 					`INSERT INTO btc_lots (acquired_at, amount_sat, price_usd, source, external_id)
 					 VALUES (?, ?, ?, ?, ?)`,
-					row.Date, row.AmountSat, priceUSD, "river", contentHash,
+					row.Date, row.AmountSat, priceUSD, "river", externalID,
 				)
 				if err != nil {
-					return nil, fmt.Errorf("insert btc_lot %q: %w", contentHash, err)
+					return nil, fmt.Errorf("insert btc_lot %q: %w", externalID, err)
 				}
 				summary.NewPurchases++
+			} else if err != nil {
+				return nil, fmt.Errorf("check btc_lot %q: %w", externalID, err)
+			} else {
+				_, err = tx.ExecContext(ctx,
+					`UPDATE btc_lots SET price_usd = ? WHERE id = ?`,
+					priceUSD, lotID,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("update btc_lot %q: %w", externalID, err)
+				}
+				summary.Updated++
 			}
 		}
 	}
@@ -481,55 +520,77 @@ func (d *DB) ImportCoinbaseCSV(ctx context.Context, rows []exchange.CoinbaseRow)
 	for _, row := range rows {
 		rawData, _ := json.Marshal(row)
 
-		h := sha256.Sum256([]byte(row.RawLine))
-		contentHash := hex.EncodeToString(h[:])
+		// Coinbase has no transaction ID in struct; use composite key
+		externalID := fmt.Sprintf("%s|%s|%.8f", row.Date.Format("2006-01-02T15:04:05"), row.Type, row.AmountBTC)
 
-		res, err := tx.ExecContext(ctx,
-			`INSERT OR IGNORE INTO exchange_imports (source, external_id, tx_type, raw_data)
-			 VALUES (?, ?, ?, ?)`,
-			"coinbase", contentHash, row.Type, string(rawData),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("insert exchange import: %w", err)
+		var existingRaw string
+		err := tx.QueryRowContext(ctx,
+			`SELECT raw_data FROM exchange_imports WHERE source = ? AND external_id = ? AND tx_type = ?`,
+			"coinbase", externalID, row.Type,
+		).Scan(&existingRaw)
+
+		isNew := errors.Is(err, sql.ErrNoRows)
+		if err != nil && !isNew {
+			return nil, fmt.Errorf("check exchange import: %w", err)
 		}
 
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return nil, fmt.Errorf("rows affected: %w", err)
-		}
-
-		if affected == 0 {
+		rawStr := string(rawData)
+		if !isNew && existingRaw == rawStr {
 			summary.Duplicates++
 			continue
 		}
 
-		// Create btc_lot for completed purchases
+		if isNew {
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data) VALUES (?, ?, ?, ?)`,
+				"coinbase", externalID, row.Type, rawStr,
+			)
+		} else {
+			_, err = tx.ExecContext(ctx,
+				`UPDATE exchange_imports SET raw_data = ? WHERE source = ? AND external_id = ? AND tx_type = ?`,
+				rawStr, "coinbase", externalID, row.Type,
+			)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("upsert exchange import: %w", err)
+		}
+
+		// Create or update btc_lot for completed purchases
 		if row.IsPurchase() && row.AmountSat > 0 {
-			var exists int
-			err := tx.QueryRowContext(ctx,
-				`SELECT 1 FROM btc_lots WHERE source = ? AND external_id = ?`,
-				"coinbase", contentHash,
-			).Scan(&exists)
-			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				return nil, fmt.Errorf("check btc_lot %q: %w", contentHash, err)
+			priceUSD := row.CostBasisUSD
+			if priceUSD == 0 {
+				priceUSD = row.AmountUSD
 			}
+			if priceUSD == 0 {
+				continue
+			}
+
+			var lotID int64
+			err := tx.QueryRowContext(ctx,
+				`SELECT id FROM btc_lots WHERE source = ? AND external_id = ?`,
+				"coinbase", externalID,
+			).Scan(&lotID)
 			if errors.Is(err, sql.ErrNoRows) {
-				priceUSD := row.CostBasisUSD
-				if priceUSD == 0 {
-					priceUSD = row.AmountUSD
-				}
-				if priceUSD == 0 {
-					continue
-				}
 				_, err = tx.ExecContext(ctx,
 					`INSERT INTO btc_lots (acquired_at, amount_sat, price_usd, source, external_id)
 					 VALUES (?, ?, ?, ?, ?)`,
-					row.Date, row.AmountSat, priceUSD, "coinbase", contentHash,
+					row.Date, row.AmountSat, priceUSD, "coinbase", externalID,
 				)
 				if err != nil {
-					return nil, fmt.Errorf("insert btc_lot %q: %w", contentHash, err)
+					return nil, fmt.Errorf("insert btc_lot %q: %w", externalID, err)
 				}
 				summary.NewPurchases++
+			} else if err != nil {
+				return nil, fmt.Errorf("check btc_lot %q: %w", externalID, err)
+			} else {
+				_, err = tx.ExecContext(ctx,
+					`UPDATE btc_lots SET price_usd = ? WHERE id = ?`,
+					priceUSD, lotID,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("update btc_lot %q: %w", externalID, err)
+				}
+				summary.Updated++
 			}
 		}
 	}
@@ -555,29 +616,45 @@ func (d *DB) ImportSwanCSV(ctx context.Context, rows []exchange.SwanRow) (*Impor
 	for _, row := range rows {
 		rawData, _ := json.Marshal(row)
 
-		h := sha256.Sum256([]byte(row.RawLine))
-		contentHash := hex.EncodeToString(h[:])
-
-		res, err := tx.ExecContext(ctx,
-			`INSERT OR IGNORE INTO exchange_imports (source, external_id, tx_type, raw_data)
-			 VALUES (?, ?, ?, ?)`,
-			"swan", contentHash, row.Type, string(rawData),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("insert exchange import: %w", err)
+		// Swan has TransactionID for transfers/withdrawals; use composite for trades
+		externalID := row.TransactionID
+		if externalID == "" {
+			externalID = fmt.Sprintf("%s|%s|%.8f", row.Date.Format("2006-01-02T15:04:05"), row.Type, row.AmountBTC)
 		}
 
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return nil, fmt.Errorf("rows affected: %w", err)
+		var existingRaw string
+		err := tx.QueryRowContext(ctx,
+			`SELECT raw_data FROM exchange_imports WHERE source = ? AND external_id = ? AND tx_type = ?`,
+			"swan", externalID, row.Type,
+		).Scan(&existingRaw)
+
+		isNew := errors.Is(err, sql.ErrNoRows)
+		if err != nil && !isNew {
+			return nil, fmt.Errorf("check exchange import: %w", err)
 		}
 
-		if affected == 0 {
+		rawStr := string(rawData)
+		if !isNew && existingRaw == rawStr {
 			summary.Duplicates++
 			continue
 		}
 
-		// Create btc_lot for purchases, BTC deposits, and withdrawals
+		if isNew {
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data) VALUES (?, ?, ?, ?)`,
+				"swan", externalID, row.Type, rawStr,
+			)
+		} else {
+			_, err = tx.ExecContext(ctx,
+				`UPDATE exchange_imports SET raw_data = ? WHERE source = ? AND external_id = ? AND tx_type = ?`,
+				rawStr, "swan", externalID, row.Type,
+			)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("upsert exchange import: %w", err)
+		}
+
+		// Create or update btc_lot for purchases, deposits, and withdrawals
 		shouldCreateLot := false
 		var lotAmount int64
 		var lotPrice float64
@@ -591,38 +668,44 @@ func (d *DB) ImportSwanCSV(ctx context.Context, rows []exchange.SwanRow) (*Impor
 				lotPrice = row.AmountUSD
 			}
 		case row.IsDeposit() && row.AmountSat > 0:
-			// BTC deposit (e.g. custodial transfer) — no cost basis
 			shouldCreateLot = true
 			lotAmount = row.AmountSat
 			lotPrice = 0
 		case row.IsWithdrawal() && row.AmountSat < 0:
-			// Withdrawal — negative lot to reduce balance
 			shouldCreateLot = true
-			lotAmount = row.AmountSat // already negative
+			lotAmount = row.AmountSat
 			lotPrice = 0
 		}
 
 		if shouldCreateLot && lotAmount != 0 {
-			var exists int
+			var lotID int64
 			err := tx.QueryRowContext(ctx,
-				`SELECT 1 FROM btc_lots WHERE source = ? AND external_id = ?`,
-				"swan", contentHash,
-			).Scan(&exists)
-			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				return nil, fmt.Errorf("check btc_lot %q: %w", contentHash, err)
-			}
+				`SELECT id FROM btc_lots WHERE source = ? AND external_id = ?`,
+				"swan", externalID,
+			).Scan(&lotID)
 			if errors.Is(err, sql.ErrNoRows) {
 				_, err = tx.ExecContext(ctx,
 					`INSERT INTO btc_lots (acquired_at, amount_sat, price_usd, source, external_id)
 					 VALUES (?, ?, ?, ?, ?)`,
-					row.Date, lotAmount, lotPrice, "swan", contentHash,
+					row.Date, lotAmount, lotPrice, "swan", externalID,
 				)
 				if err != nil {
-					return nil, fmt.Errorf("insert btc_lot %q: %w", contentHash, err)
+					return nil, fmt.Errorf("insert btc_lot %q: %w", externalID, err)
 				}
 				if row.IsPurchase() {
 					summary.NewPurchases++
 				}
+			} else if err != nil {
+				return nil, fmt.Errorf("check btc_lot %q: %w", externalID, err)
+			} else {
+				_, err = tx.ExecContext(ctx,
+					`UPDATE btc_lots SET price_usd = ? WHERE id = ?`,
+					lotPrice, lotID,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("update btc_lot %q: %w", externalID, err)
+				}
+				summary.Updated++
 			}
 		}
 	}
@@ -636,18 +719,20 @@ func (d *DB) ImportSwanCSV(ctx context.Context, rows []exchange.SwanRow) (*Impor
 
 // SourceBalance holds per-source aggregated balances for the portfolio view.
 type SourceBalance struct {
-	Source        string
-	NetSats       int64 // signed: purchases + receives - sales - sends
-	PurchasedSats int64 // for "purchased in period" stats
+	Source           string
+	NetSats          int64   // signed: purchases + receives - sales - sends
+	PurchasedSats    int64   // for "purchased in period" stats
+	TotalCostBasisUSD float64 // USD spent on purchases (CostBasisUSD fallback AmountUSD)
 }
 
 // PortfolioPositionResult holds the aggregated portfolio position across all sources.
 type PortfolioPositionResult struct {
 	BySource        map[string]SourceBalance
-	ExchangeNetSats int64 // sum of NetSats across all sources
-	PurchasedSats   int64 // sum of PurchasedSats across all sources (for YTD purchased stat)
-	RoutingFeesSats int64 // routing fees from forwarding_events in the period
-	RoutedCount     int64 // number of routed payments in the period
+	ExchangeNetSats    int64   // sum of NetSats across all sources
+	PurchasedSats      int64   // sum of PurchasedSats across all sources (for YTD purchased stat)
+	TotalCostBasisUSD  float64 // sum of cost basis across all sources
+	RoutingFeesSats    int64   // routing fees from forwarding_events in the period
+	RoutedCount        int64   // number of routed payments in the period
 }
 
 // PortfolioPosition aggregates exchange balances per source and routing fees in a single
@@ -672,7 +757,10 @@ func (d *DB) PortfolioPosition(ctx context.Context, since time.Time) (*Portfolio
 			COALESCE(SUM(CASE WHEN COALESCE(json_extract(raw_data, '$.AmountBTC'), 0) != 0
 				THEN json_extract(raw_data, '$.AmountBTC') ELSE 0 END), 0) AS net_btc,
 			COALESCE(SUM(CASE WHEN LOWER(json_extract(raw_data, '$.Type')) IN ('purchase', 'buy')
-				THEN json_extract(raw_data, '$.AmountBTC') ELSE 0 END), 0) AS purchased_btc
+				THEN json_extract(raw_data, '$.AmountBTC') ELSE 0 END), 0) AS purchased_btc,
+			COALESCE(SUM(CASE WHEN LOWER(json_extract(raw_data, '$.Type')) IN ('purchase', 'buy')
+				THEN ABS(COALESCE(json_extract(raw_data, '$.CostBasisUSD'),
+					json_extract(raw_data, '$.AmountUSD'), 0)) ELSE 0 END), 0) AS cost_basis_usd
 		FROM exchange_imports ` + dateFilter + `
 		GROUP BY source`
 
@@ -684,18 +772,20 @@ func (d *DB) PortfolioPosition(ctx context.Context, since time.Time) (*Portfolio
 
 	for rows.Next() {
 		var source string
-		var netBTC, purchasedBTC float64
-		if err := rows.Scan(&source, &netBTC, &purchasedBTC); err != nil {
+		var netBTC, purchasedBTC, costBasis float64
+		if err := rows.Scan(&source, &netBTC, &purchasedBTC, &costBasis); err != nil {
 			return nil, fmt.Errorf("scan portfolio source: %w", err)
 		}
 		sb := SourceBalance{
-			Source:        source,
-			NetSats:       int64(math.Round(netBTC * 1e8)),
-			PurchasedSats: int64(math.Round(purchasedBTC * 1e8)),
+			Source:            source,
+			NetSats:           int64(math.Round(netBTC * 1e8)),
+			PurchasedSats:     int64(math.Round(purchasedBTC * 1e8)),
+			TotalCostBasisUSD: costBasis,
 		}
 		result.BySource[source] = sb
 		result.ExchangeNetSats += sb.NetSats
 		result.PurchasedSats += sb.PurchasedSats
+		result.TotalCostBasisUSD += costBasis
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("portfolio position rows: %w", err)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -462,6 +462,161 @@ func TestImportStrikeCSV_Dedup(t *testing.T) {
 	}
 }
 
+func TestImportStrikeCSV_CostBasisUpdate(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	rows := []exchange.StrikeRow{
+		{TransactionID: "tx-100", Date: now, Type: "Purchase", AmountSat: 100000, AmountBTC: 0.001, AmountUSD: 67.00, CostBasisUSD: 67.00, RawLine: "original"},
+	}
+
+	s1, err := d.ImportStrikeCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	if s1.NewPurchases != 1 {
+		t.Fatalf("expected 1 new purchase, got %d", s1.NewPurchases)
+	}
+
+	// Re-import same transaction with updated cost basis
+	rows[0].CostBasisUSD = 72.50
+	rows[0].RawLine = "updated"
+	s2, err := d.ImportStrikeCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if s2.Updated != 1 {
+		t.Errorf("expected 1 updated, got %d", s2.Updated)
+	}
+	if s2.NewPurchases != 0 {
+		t.Errorf("expected 0 new purchases on update, got %d", s2.NewPurchases)
+	}
+
+	// Verify cost basis was updated in btc_lots
+	var priceUSD float64
+	err = d.db.QueryRow("SELECT price_usd FROM btc_lots WHERE source = 'strike' AND external_id = 'tx-100'").Scan(&priceUSD)
+	if err != nil {
+		t.Fatalf("query btc_lot: %v", err)
+	}
+	if priceUSD != 72.50 {
+		t.Errorf("expected price_usd 72.50, got %.2f", priceUSD)
+	}
+
+	// Verify only 1 lot exists (not duplicated)
+	var count int
+	d.db.QueryRow("SELECT COUNT(*) FROM btc_lots WHERE source = 'strike'").Scan(&count)
+	if count != 1 {
+		t.Errorf("expected 1 btc_lot, got %d", count)
+	}
+}
+
+func TestImportRiverCSV_CostBasisUpdate(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	rows := []exchange.RiverRow{
+		{Date: now, Type: "buy", AmountBTC: 0.002, AmountSat: 200000, AmountUSD: 134.00, CostBasisUSD: 134.00, RawLine: "original"},
+	}
+
+	_, err := d.ImportRiverCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+
+	// Re-import with updated cost basis
+	rows[0].CostBasisUSD = 140.00
+	rows[0].RawLine = "updated"
+	s2, err := d.ImportRiverCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if s2.Updated != 1 {
+		t.Errorf("expected 1 updated, got %d", s2.Updated)
+	}
+
+	// Verify updated price
+	externalID := fmt.Sprintf("%s|%s|%.8f", now.Format("2006-01-02T15:04:05"), "buy", 0.002)
+	var priceUSD float64
+	err = d.db.QueryRow("SELECT price_usd FROM btc_lots WHERE source = 'river' AND external_id = ?", externalID).Scan(&priceUSD)
+	if err != nil {
+		t.Fatalf("query btc_lot: %v", err)
+	}
+	if priceUSD != 140.00 {
+		t.Errorf("expected price_usd 140.00, got %.2f", priceUSD)
+	}
+}
+
+func TestImportCoinbaseCSV_CostBasisUpdate(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	rows := []exchange.CoinbaseRow{
+		{Date: now, Type: "buy", AmountBTC: 0.003, AmountSat: 300000, AmountUSD: 200.00, CostBasisUSD: 200.00, RawLine: "original"},
+	}
+
+	_, err := d.ImportCoinbaseCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+
+	rows[0].CostBasisUSD = 210.00
+	rows[0].RawLine = "updated"
+	s2, err := d.ImportCoinbaseCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if s2.Updated != 1 {
+		t.Errorf("expected 1 updated, got %d", s2.Updated)
+	}
+
+	externalID := fmt.Sprintf("%s|%s|%.8f", now.Format("2006-01-02T15:04:05"), "buy", 0.003)
+	var priceUSD float64
+	err = d.db.QueryRow("SELECT price_usd FROM btc_lots WHERE source = 'coinbase' AND external_id = ?", externalID).Scan(&priceUSD)
+	if err != nil {
+		t.Fatalf("query btc_lot: %v", err)
+	}
+	if priceUSD != 210.00 {
+		t.Errorf("expected price_usd 210.00, got %.2f", priceUSD)
+	}
+}
+
+func TestImportSwanCSV_CostBasisUpdate(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	now := time.Now().UTC()
+	rows := []exchange.SwanRow{
+		{TransactionID: "swan-100", Date: now, Type: "purchase", AmountBTC: 0.004, AmountSat: 400000, AmountUSD: 268.00, CostBasisUSD: 268.00, RawLine: "original"},
+	}
+
+	_, err := d.ImportSwanCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+
+	rows[0].CostBasisUSD = 280.00
+	rows[0].RawLine = "updated"
+	s2, err := d.ImportSwanCSV(context.Background(), rows)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if s2.Updated != 1 {
+		t.Errorf("expected 1 updated, got %d", s2.Updated)
+	}
+
+	var priceUSD float64
+	err = d.db.QueryRow("SELECT price_usd FROM btc_lots WHERE source = 'swan' AND external_id = 'swan-100'").Scan(&priceUSD)
+	if err != nil {
+		t.Fatalf("query btc_lot: %v", err)
+	}
+	if priceUSD != 280.00 {
+		t.Errorf("expected price_usd 280.00, got %.2f", priceUSD)
+	}
+}
+
 func TestImportStrikeCSV_Empty(t *testing.T) {
 	d := newTestDB(t)
 	defer d.Close()

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2329,8 +2329,8 @@ func TestBackfillPortfolioSnapshots_PreservesLiveSnapshots(t *testing.T) {
 		t.Fatalf("insert live: %v", err)
 	}
 
-	// Insert exchange data for today
-	today := time.Now().Format("2006-01-02")
+	// Insert exchange data for today (use UTC to match SQLite CURRENT_TIMESTAMP)
+	today := time.Now().UTC().Format("2006-01-02")
 	rawData := fmt.Sprintf(`{"Date":"%s","AmountBTC":0.01,"Type":"purchase"}`, today)
 	_, err = d.db.ExecContext(ctx,
 		`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data)

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -507,6 +507,7 @@ func (h *Handler) HandleStrikeImport(w http.ResponseWriter, r *http.Request) {
 	resp := importResponse{
 		Total:          summary.Total,
 		NewPurchases:   summary.NewPurchases,
+		Updated:        summary.Updated,
 		Duplicates:     summary.Duplicates,
 		FilesProcessed: len(files),
 		ParseErrors:    allErrors,
@@ -527,6 +528,7 @@ func (h *Handler) HandleStrikeImport(w http.ResponseWriter, r *http.Request) {
 type importResponse struct {
 	Total          int      `json:"total"`
 	NewPurchases   int      `json:"new_purchases"`
+	Updated        int      `json:"updated,omitempty"`
 	Duplicates     int      `json:"duplicates"`
 	FilesProcessed int      `json:"files_processed,omitempty"`
 	ParseErrors    []string `json:"parse_errors,omitempty"`
@@ -592,6 +594,7 @@ func (h *Handler) HandleRiverImport(w http.ResponseWriter, r *http.Request) {
 	resp := importResponse{
 		Total:          summary.Total,
 		NewPurchases:   summary.NewPurchases,
+		Updated:        summary.Updated,
 		Duplicates:     summary.Duplicates,
 		FilesProcessed: len(files),
 		ParseErrors:    allErrors,
@@ -668,6 +671,7 @@ func (h *Handler) HandleCoinbaseImport(w http.ResponseWriter, r *http.Request) {
 	resp := importResponse{
 		Total:          summary.Total,
 		NewPurchases:   summary.NewPurchases,
+		Updated:        summary.Updated,
 		Duplicates:     summary.Duplicates,
 		FilesProcessed: len(files),
 		ParseErrors:    allErrors,
@@ -767,6 +771,7 @@ func (h *Handler) HandleSwanImport(w http.ResponseWriter, r *http.Request) {
 	resp := importResponse{
 		Total:        summary.Total,
 		NewPurchases: summary.NewPurchases,
+		Updated:      summary.Updated,
 		Duplicates:   summary.Duplicates,
 		ParseErrors:  allErrors,
 	}

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -361,6 +361,175 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// HandleLightningPage serves GET /lightning (Lightning node stats page).
+func (h *Handler) HandleLightningPage(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	now := time.Now()
+	since30d := now.AddDate(0, 0, -30)
+	since7d := now.AddDate(0, 0, -7)
+	data := DashboardData{
+		DefaultFrom: since30d.Format("2006-01-02"),
+		DefaultTo:   now.Format("2006-01-02"),
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	type result struct {
+		feesAllTime, routedAllTime int64
+		fees30d, routed30d         int64
+		fees7d, routed7d           int64
+		activeChannels             int
+		balance                    *db.WalletBalanceSnapshot
+		channels                   []db.ChannelStat
+		dailyFees                  []db.DailyFeeStat
+		nodeInfo                   *lnd.NodeInfo
+		lastSynced                 time.Time
+		btcPrice                   float64
+		priceFetched               time.Time
+	}
+	var res result
+
+	fetch := func(fn func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fn()
+		}()
+	}
+
+	fetch(func() {
+		fees, routed, err := h.store.FeeSummary(ctx, time.Time{})
+		if err == nil {
+			mu.Lock()
+			res.feesAllTime = fees
+			res.routedAllTime = routed
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		fees, routed, err := h.store.FeeSummary(ctx, since30d)
+		if err == nil {
+			mu.Lock()
+			res.fees30d = fees
+			res.routed30d = routed
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		fees, routed, err := h.store.FeeSummary(ctx, since7d)
+		if err == nil {
+			mu.Lock()
+			res.fees7d = fees
+			res.routed7d = routed
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		count, err := h.store.ActiveChannelCount(ctx)
+		if err == nil {
+			mu.Lock()
+			res.activeChannels = count
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		bal, err := h.store.LatestWalletBalance(ctx)
+		if err == nil {
+			mu.Lock()
+			res.balance = bal
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		stats, err := h.store.ChannelStats(ctx)
+		if err == nil {
+			mu.Lock()
+			res.channels = stats
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		fees, err := h.store.DailyFees(ctx, since30d)
+		if err == nil {
+			mu.Lock()
+			res.dailyFees = fees
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		info, err := h.node.GetInfo(ctx)
+		if err == nil {
+			mu.Lock()
+			res.nodeInfo = info
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		t, err := h.store.LastSyncedAt(ctx)
+		if err == nil {
+			mu.Lock()
+			res.lastSynced = t
+			mu.Unlock()
+		}
+	})
+
+	fetch(func() {
+		price, err := h.price.GetBTCPrice(ctx)
+		if err == nil {
+			mu.Lock()
+			res.btcPrice = price
+			res.priceFetched = h.price.FetchedAt()
+			mu.Unlock()
+		}
+	})
+
+	wg.Wait()
+
+	if res.nodeInfo != nil {
+		data.NodeAlias = res.nodeInfo.Alias
+		data.NodePubKey = res.nodeInfo.PubKey
+		data.NodeSynced = res.nodeInfo.Synced
+		data.BlockHeight = res.nodeInfo.BlockHeight
+		data.LNDVersion = res.nodeInfo.Version
+	}
+
+	data.FeesAllTimeSats = res.feesAllTime / 1000
+	data.RoutedAllTime = res.routedAllTime
+	data.Fees30dSats = res.fees30d / 1000
+	data.Fees7dSats = res.fees7d / 1000
+	data.Routed30d = res.routed30d
+	data.Routed7d = res.routed7d
+	data.ActiveChannels = res.activeChannels
+	data.LastSyncedAt = res.lastSynced
+	data.DailyFees = res.dailyFees
+	data.Channels = res.channels
+
+	if res.balance != nil {
+		data.WalletBalanceSats = res.balance.TotalSat
+	}
+
+	if res.btcPrice > 0 {
+		data.BTCPriceUSD = res.btcPrice
+		data.PriceFetchedAt = res.priceFetched
+		data.FeesAllTimeUSD = satsToUSD(data.FeesAllTimeSats, res.btcPrice)
+		data.WalletBalanceUSD = satsToUSD(data.WalletBalanceSats, res.btcPrice)
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "lightning_layout", data); err != nil {
+		h.logger.Printf("failed to render lightning page: %v", err)
+	}
+}
+
 // HandlePortfolioChartPartial serves GET /partials/portfolio-chart (HTMX partial).
 func (h *Handler) HandlePortfolioChartPartial(w http.ResponseWriter, r *http.Request) {
 	days := parseIntParam(r, "days", 30)

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -51,6 +51,10 @@ type DashboardData struct {
 	ExchangeBalanceSats   int64
 	ExchangeBalanceUSD    float64
 
+	// Cost basis (from exchange imports)
+	TotalCostBasisUSD float64
+	AvgCostPerBTC     float64 // TotalCostBasisUSD / total purchased BTC
+
 	// Cold storage (watched wallets)
 	ColdStorageSats int64
 	ColdStorageUSD  float64
@@ -290,6 +294,10 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		data.CoinbaseBalanceSats = res.portfolioAll.BySource["coinbase"].NetSats
 		data.SwanBalanceSats = res.portfolioAll.BySource["swan"].NetSats
 		data.ExchangeBalanceSats = res.portfolioAll.ExchangeNetSats
+		data.TotalCostBasisUSD = res.portfolioAll.TotalCostBasisUSD
+		if res.portfolioAll.PurchasedSats > 0 {
+			data.AvgCostPerBTC = res.portfolioAll.TotalCostBasisUSD / (float64(res.portfolioAll.PurchasedSats) / 1e8)
+		}
 	}
 
 	data.Fees30dSats = res.fees30d / 1000

--- a/internal/web/handler_html_test.go
+++ b/internal/web/handler_html_test.go
@@ -210,17 +210,12 @@ func TestHandleDashboard_Success(t *testing.T) {
 
 	body := w.Body.String()
 
-	// Check key elements are present
+	// Check key elements are present (lightning-specific content moved to /lightning)
 	checks := []string{
 		"Satsbook",
 		"test-node",
-		"Fee Income",
-		"Payments Routed",
-		"Active Channels",
-		"Wallet Balance",
-		"Daily Fee Income",
-		"Channels",
-		"Forwarding Events",
+		"Total BTC Position",
+		"Portfolio Value",
 		"synced",
 		"$67,000.00",
 	}
@@ -239,6 +234,41 @@ func TestHandleDashboard_NotFoundForOtherPaths(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404 for /nonexistent, got %d", w.Code)
+	}
+}
+
+func TestHandleLightningPage_Success(t *testing.T) {
+	store := fullMockStore()
+	node := &mockNodeInfo{info: &lnd.NodeInfo{
+		Alias: "test-node", PubKey: "02abc", Synced: true,
+		NumActiveChannels: 5, BlockHeight: 800000, Version: "0.17.0",
+	}}
+	price := &mockPrice{price: 67000.0, fetchedAt: time.Now()}
+	h := newTestHandler(store, node, price)
+
+	req := httptest.NewRequest(http.MethodGet, "/lightning", nil)
+	w := httptest.NewRecorder()
+	h.HandleLightningPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	checks := []string{
+		"Lightning Node",
+		"Fee Income",
+		"Payments Routed",
+		"Active Channels",
+		"Wallet Balance",
+		"Daily Fee Income",
+		"Channels",
+		"Forwarding Events",
+	}
+	for _, check := range checks {
+		if !strings.Contains(body, check) {
+			t.Errorf("expected body to contain %q", check)
+		}
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -21,6 +21,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
 
 	// HTML routes
 	mux.HandleFunc("/", handler.HandleDashboard)
+	mux.HandleFunc("/lightning", handler.HandleLightningPage)
 	mux.HandleFunc("/import", handler.HandleImportPage)
 	mux.HandleFunc("/pl", handler.HandlePLPage)
 	mux.HandleFunc("/wallets", handler.HandleWalletsPage)

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -85,6 +85,8 @@ func NewRenderer() *Renderer {
 			"templates/partials/clear_import_result.html",
 			"templates/partials/danger_zone.html",
 			"templates/partials/nav.html",
+			"templates/lightning_layout.html",
+			"templates/lightning.html",
 			"templates/pl_layout.html",
 			"templates/pl.html",
 			"templates/wallets_layout.html",

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -94,62 +94,6 @@
 </div>
 {{end}}
 
-<!-- Summary Cards -->
-<div class="cards">
-  <div class="card">
-    <div class="card-label">Fee Income</div>
-    <div class="card-value">{{formatSats .FeesAllTimeSats}} <small>sats</small></div>
-    {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .FeesAllTimeUSD}}</div>{{end}}
-    <div class="card-breakdown">
-      <span>30d: {{formatSats .Fees30dSats}}</span>
-      <span>7d: {{formatSats .Fees7dSats}}</span>
-    </div>
-  </div>
-
-  <div class="card">
-    <div class="card-label">Payments Routed</div>
-    <div class="card-value">{{formatSats .RoutedAllTime}}</div>
-    <div class="card-breakdown">
-      <span>30d: {{formatSats .Routed30d}}</span>
-      <span>7d: {{formatSats .Routed7d}}</span>
-    </div>
-  </div>
-
-  <div class="card">
-    <div class="card-label">Active Channels</div>
-    <div class="card-value">{{.ActiveChannels}}</div>
-  </div>
-
-  <div class="card">
-    <div class="card-label">Wallet Balance</div>
-    <div class="card-value">{{formatSats .WalletBalanceSats}} <small>sats</small></div>
-    {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .WalletBalanceUSD}}</div>{{end}}
-  </div>
-
-  {{if or .StrikeBalanceSats .RiverBalanceSats .CoinbaseBalanceSats .SwanBalanceSats}}
-  <div class="card">
-    <div class="card-label">Exchange Balance <span style="font-size:0.75em;color:var(--text-muted);">(from CSV import)</span></div>
-    <div class="card-value">{{formatSats .ExchangeBalanceSats}} <small>sats</small></div>
-    {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .ExchangeBalanceUSD}}</div>{{end}}
-    <div style="margin-top: 8px; font-size: 0.8em; color: var(--text-muted);">
-      {{if .StrikeBalanceSats}}<div><a href="/exchange/strike" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">Strike</a>: {{formatSats .StrikeBalanceSats}} sats</div>{{end}}
-      {{if .RiverBalanceSats}}<div><a href="/exchange/river" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">River</a>: {{formatSats .RiverBalanceSats}} sats</div>{{end}}
-      {{if .CoinbaseBalanceSats}}<div><a href="/exchange/coinbase" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">Coinbase</a>: {{formatSats .CoinbaseBalanceSats}} sats</div>{{end}}
-      {{if .SwanBalanceSats}}<div><a href="/exchange/swan" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">Swan</a>: {{formatSats .SwanBalanceSats}} sats</div>{{end}}
-    </div>
-  </div>
-
-  {{end}}
-</div>
-
-<!-- Daily Fee Chart -->
-<div class="chart-section">
-  <h2>Daily Fee Income (last 30 days)</h2>
-  <div class="chart-container">
-    {{feeChart .DailyFees}}
-  </div>
-</div>
-
 <!-- Portfolio Value Chart -->
 <div class="chart-section">
   <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;">
@@ -178,35 +122,4 @@ function setPortfolioRange(days) {
 }
 </script>
 
-<!-- Channel Table -->
-<div class="table-section">
-  <h2>Channels</h2>
-  {{template "channel_table" .Channels}}
-</div>
-
-<!-- Forwarding Events -->
-<div class="table-section">
-  <h2>Forwarding Events</h2>
-  <form class="filter-form"
-        hx-get="/partials/forwarding"
-        hx-target="#forwarding-table"
-        hx-swap="innerHTML"
-        hx-indicator="#fwd-loading">
-    <div>
-      <label for="from">From</label>
-      <input type="date" id="from" name="from" value="{{.DefaultFrom}}">
-    </div>
-    <div>
-      <label for="to">To</label>
-      <input type="date" id="to" name="to" value="{{.DefaultTo}}">
-    </div>
-    <button type="submit">Filter</button>
-    <span id="fwd-loading" class="htmx-indicator">Loading...</span>
-  </form>
-  <div id="forwarding-table"
-       hx-get="/partials/forwarding?from={{.DefaultFrom}}&to={{.DefaultTo}}"
-       hx-trigger="load"
-       hx-swap="innerHTML">
-  </div>
-</div>
 {{end}}

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -132,6 +132,16 @@
       {{if .SwanBalanceSats}}<div><a href="/exchange/swan" style="color: inherit; text-decoration: underline; text-decoration-style: dotted;">Swan</a>: {{formatSats .SwanBalanceSats}} sats</div>{{end}}
     </div>
   </div>
+
+  {{if gt .TotalCostBasisUSD 0.0}}
+  <div class="card">
+    <div class="card-label">Cost Basis
+      <span title="Total USD spent on BTC purchases as reported by your exchange CSV exports. Verify with your tax advisor." style="cursor:help;font-size:0.75em;color:var(--text-muted);border:1px solid var(--text-muted);border-radius:50%;display:inline-block;width:14px;height:14px;text-align:center;line-height:14px;margin-left:4px;">i</span>
+    </div>
+    <div class="card-value">{{formatUSD .TotalCostBasisUSD}}</div>
+    {{if gt .AvgCostPerBTC 0.0}}<div class="card-sub">Avg {{formatUSD .AvgCostPerBTC}} / BTC</div>{{end}}
+  </div>
+  {{end}}
   {{end}}
 </div>
 

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -66,6 +66,12 @@
     Routing fees earned: {{formatSats .FeesAllTimeSats}} sats (all-time)
   </div>
   {{end}}
+  {{if gt .TotalCostBasisUSD 0.0}}
+  <div style="margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border); font-size: 0.85em; color: var(--text-muted); display: flex; gap: 16px; flex-wrap: wrap; align-items: baseline;">
+    <span>Cost basis: {{formatUSD .TotalCostBasisUSD}} <span title="Total USD spent on BTC purchases as reported by your exchange CSV exports. Verify with your tax advisor." style="cursor:help;font-size:0.75em;border:1px solid var(--text-muted);border-radius:50%;display:inline-block;width:13px;height:13px;text-align:center;line-height:13px;">i</span></span>
+    {{if gt .AvgCostPerBTC 0.0}}<span>Avg {{formatUSD .AvgCostPerBTC}} / BTC</span>{{end}}
+  </div>
+  {{end}}
 </div>
 
 <!-- YTD strip -->
@@ -133,15 +139,6 @@
     </div>
   </div>
 
-  {{if gt .TotalCostBasisUSD 0.0}}
-  <div class="card">
-    <div class="card-label">Cost Basis
-      <span title="Total USD spent on BTC purchases as reported by your exchange CSV exports. Verify with your tax advisor." style="cursor:help;font-size:0.75em;color:var(--text-muted);border:1px solid var(--text-muted);border-radius:50%;display:inline-block;width:14px;height:14px;text-align:center;line-height:14px;margin-left:4px;">i</span>
-    </div>
-    <div class="card-value">{{formatUSD .TotalCostBasisUSD}}</div>
-    {{if gt .AvgCostPerBTC 0.0}}<div class="card-sub">Avg {{formatUSD .AvgCostPerBTC}} / BTC</div>{{end}}
-  </div>
-  {{end}}
   {{end}}
 </div>
 

--- a/internal/web/templates/import.html
+++ b/internal/web/templates/import.html
@@ -1,6 +1,10 @@
 {{define "import_content"}}
 <h1 style="margin-bottom: 24px; font-size: 1.25rem;">Import Transactions</h1>
 
+<div style="background: var(--card-bg); border: 1px solid var(--border); border-left: 3px solid var(--text-muted); border-radius: 4px; padding: 10px 14px; margin-bottom: 20px; max-width: 600px; font-size: 0.8rem; color: var(--text-muted);">
+  <strong>Cost basis note:</strong> Cost basis values come from your exchange CSV exports. Some exchanges (e.g. Strike) allow editing cost basis before export. Satsbook uses these values as-is — verify with your tax advisor.
+</div>
+
 <div style="display: flex; gap: 16px; margin-bottom: 16px;">
   <button class="filter-form" id="tab-strike" onclick="showTab('strike')" style="display: inline-block;">Strike</button>
   <button class="filter-form" id="tab-river" onclick="showTab('river')" style="display: inline-block; opacity: 0.6;">River</button>

--- a/internal/web/templates/lightning.html
+++ b/internal/web/templates/lightning.html
@@ -1,0 +1,76 @@
+{{define "lightning_content"}}
+<h1 style="margin-bottom: 24px; font-size: 1.25rem;">Lightning Node</h1>
+
+<!-- Summary Cards -->
+<div class="cards">
+  <div class="card">
+    <div class="card-label">Fee Income</div>
+    <div class="card-value">{{formatSats .FeesAllTimeSats}} <small>sats</small></div>
+    {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .FeesAllTimeUSD}}</div>{{end}}
+    <div class="card-breakdown">
+      <span>30d: {{formatSats .Fees30dSats}}</span>
+      <span>7d: {{formatSats .Fees7dSats}}</span>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-label">Payments Routed</div>
+    <div class="card-value">{{formatSats .RoutedAllTime}}</div>
+    <div class="card-breakdown">
+      <span>30d: {{formatSats .Routed30d}}</span>
+      <span>7d: {{formatSats .Routed7d}}</span>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-label">Active Channels</div>
+    <div class="card-value">{{.ActiveChannels}}</div>
+  </div>
+
+  <div class="card">
+    <div class="card-label">Wallet Balance</div>
+    <div class="card-value">{{formatSats .WalletBalanceSats}} <small>sats</small></div>
+    {{if .BTCPriceUSD}}<div class="card-sub">{{formatUSD .WalletBalanceUSD}}</div>{{end}}
+  </div>
+</div>
+
+<!-- Daily Fee Chart -->
+<div class="chart-section">
+  <h2>Daily Fee Income (last 30 days)</h2>
+  <div class="chart-container">
+    {{feeChart .DailyFees}}
+  </div>
+</div>
+
+<!-- Channel Table -->
+<div class="table-section">
+  <h2>Channels</h2>
+  {{template "channel_table" .Channels}}
+</div>
+
+<!-- Forwarding Events -->
+<div class="table-section">
+  <h2>Forwarding Events</h2>
+  <form class="filter-form"
+        hx-get="/partials/forwarding"
+        hx-target="#forwarding-table"
+        hx-swap="innerHTML"
+        hx-indicator="#fwd-loading">
+    <div>
+      <label for="from">From</label>
+      <input type="date" id="from" name="from" value="{{.DefaultFrom}}">
+    </div>
+    <div>
+      <label for="to">To</label>
+      <input type="date" id="to" name="to" value="{{.DefaultTo}}">
+    </div>
+    <button type="submit">Filter</button>
+    <span id="fwd-loading" class="htmx-indicator">Loading...</span>
+  </form>
+  <div id="forwarding-table"
+       hx-get="/partials/forwarding?from={{.DefaultFrom}}&to={{.DefaultTo}}"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+  </div>
+</div>
+{{end}}

--- a/internal/web/templates/lightning_layout.html
+++ b/internal/web/templates/lightning_layout.html
@@ -1,0 +1,43 @@
+{{define "lightning_layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Satsbook — Lightning{{if .NodeAlias}} — {{.NodeAlias}}{{end}}</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="/static/htmx.min.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <a class="logo" href="/">Satsbook</a>
+        {{template "nav" "lightning"}}
+      </div>
+      <div class="node-info-bar">
+        {{if .NodeAlias}}
+          <strong>{{.NodeAlias}}</strong> &middot;
+          <span class="truncate" title="{{.NodePubKey}}">{{.NodePubKey}}</span> &middot;
+          {{if .NodeSynced}}<span class="synced">synced</span>{{else}}<span class="not-synced">not synced</span>{{end}}
+          &middot; block {{.BlockHeight}} &middot; LND {{.LNDVersion}}
+        {{else}}
+          <span class="not-synced">node unreachable</span>
+        {{end}}
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    {{template "lightning_content" .}}
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Last synced: {{timeAgo .LastSyncedAt}}</span>
+      <span>
+        {{if .BTCPriceUSD}}BTC {{formatUSD .BTCPriceUSD}} (mempool.space, {{timeAgo .PriceFetchedAt}}){{else}}BTC price unavailable{{end}}
+      </span>
+    </div>
+  </footer>
+</body>
+</html>{{end}}

--- a/internal/web/templates/partials/import_result.html
+++ b/internal/web/templates/partials/import_result.html
@@ -4,6 +4,7 @@
   <p style="margin-top: 8px;">
     {{if gt .FilesProcessed 1}}Processed <strong>{{.FilesProcessed}}</strong> files — {{end}}Imported <strong>{{.Total}}</strong> transaction{{if ne .Total 1}}s{{end}},
     <strong>{{.NewPurchases}}</strong> new purchase{{if ne .NewPurchases 1}}s{{end}},
+    {{if .Updated}}<strong>{{.Updated}}</strong> updated,{{end}}
     <strong>{{.Duplicates}}</strong> duplicate{{if ne .Duplicates 1}}s{{end}} skipped.
   </p>
   {{if .ParseErrors}}

--- a/internal/web/templates/partials/nav.html
+++ b/internal/web/templates/partials/nav.html
@@ -1,6 +1,7 @@
 {{define "nav"}}
 <nav style="font-size: 0.85rem;">
   <a href="/" class="nav-link{{if eq . "dashboard"}} nav-active{{end}}">Dashboard</a>
+  <a href="/lightning" class="nav-link{{if eq . "lightning"}} nav-active{{end}}">Lightning</a>
   <a href="/import" class="nav-link{{if eq . "import"}} nav-active{{end}}">Import</a>
   <a href="/wallets" class="nav-link{{if eq . "wallets"}} nav-active{{end}}">Wallets</a>
   <a href="/pl" class="nav-link{{if eq . "pl"}} nav-active{{end}}">P&L</a>


### PR DESCRIPTION
## Summary
- Adds cost basis card to dashboard showing total USD spent and avg cost per BTC, with info tooltip
- Adds cost basis disclaimer note on the import page
- Replaces SHA256 content-hash dedup with key-field matching across all 4 exchange importers (Strike/Swan use TransactionID, River/Coinbase use date|type|amount composite key)
- Re-importing a CSV with edited cost basis now updates existing `btc_lots.price_usd` instead of creating duplicates
- Shows "X updated" count in import result feedback

## Test plan
- [x] 4 new integration tests verify cost basis update for Strike, River, Coinbase, Swan
- [x] All existing import dedup tests still pass
- [x] Full test suite green (`go test ./...`)
- [ ] Manual: import a Strike CSV, edit cost basis in CSV, re-import — verify dashboard cost basis updates

Closes #67