### PR TITLE
fix(docker): resolve Umbrel startup crash and add CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,56 @@ jobs:
 
       - name: Cross-compile (linux/arm64)
         run: GOOS=linux GOARCH=arm64 go build -o /dev/null ./cmd/satsbook
+
+  docker:
+    name: Docker build & smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t satsbook:ci-test .
+
+      - name: Smoke test — container starts and serves HTTP
+        run: |
+          # Create data dir writable by UID 1000
+          DATA_DIR="$(mktemp -d)"
+          mkdir -p "$DATA_DIR/data"
+          chmod 777 "$DATA_DIR/data"
+
+          # Start container in background
+          docker run -d --name satsbook-smoke \
+            --user 1000:1000 \
+            -p 3000:3000 \
+            -v "$DATA_DIR/data:/data" \
+            -e SATSBOOK_DATABASE_PATH=/data/satsbook.db \
+            -e SATSBOOK_APP_PORT=3000 \
+            satsbook:ci-test
+
+          # Wait for HTTP to be ready (up to 15s)
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:3000/ > /dev/null 2>&1; then
+              echo "OK: HTTP responding after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 15 ]; then
+              echo "FAIL: container did not respond within 15s"
+              docker logs satsbook-smoke
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # Verify key pages return 200
+          for path in / /lightning /import /wallets /pl; do
+            STATUS=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:3000${path}")
+            if [ "$STATUS" != "200" ]; then
+              echo "FAIL: GET ${path} returned ${STATUS}"
+              docker logs satsbook-smoke
+              exit 1
+            fi
+            echo "OK: GET ${path} -> ${STATUS}"
+          done
+
+          docker rm -f satsbook-smoke

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apk add --no-cache ca-certificates tzdata
 
 COPY --from=builder /satsbook /usr/local/bin/satsbook
 
-# Data directory for SQLite
-RUN mkdir -p /data
+# Data directory for SQLite — writable by UID 1000 (Umbrel runs with user: "1000:1000")
+RUN mkdir -p /data && chown 1000:1000 /data
 VOLUME /data
 
 EXPOSE 3000

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -48,27 +48,35 @@ func main() {
 	defer database.Close()
 	log.Printf("database initialized at %s", cfg.DatabasePath)
 
-	// Initialize LND client
-	lndClient, err := lnd.NewClient(cfg.LNDHost, cfg.LNDPort, cfg.LNDMacaroonPath, cfg.LNDTLSCertPath)
-	if err != nil {
-		log.Fatalf("failed to connect to LND: %v", err)
-	}
-	defer lndClient.Close()
-	log.Printf("connected to LND at %s:%d", cfg.LNDHost, cfg.LNDPort)
-
-	// Initialize syncer
-	syncerLogger := log.New(os.Stdout, "[syncer] ", log.LstdFlags)
-	s := syncer.New(lndClient, database, syncerLogger, cfg.SyncInterval, cfg.MaxHistoryDays)
-
 	// Initialize price cache
 	priceCache := price.NewCache(price.WithAPIURL(cfg.PriceAPIURL))
 
-	// Enable portfolio snapshots after each sync
-	s.SetSnapshotStore(database, priceCache)
+	// Initialize LND client (optional — app works without it for dashboard-only mode)
+	var lndClient *lnd.Client
+	var s *syncer.Syncer
+	if cfg.LNDConfigured() {
+		lndClient, err = lnd.NewClient(cfg.LNDHost, cfg.LNDPort, cfg.LNDMacaroonPath, cfg.LNDTLSCertPath)
+		if err != nil {
+			log.Printf("WARNING: failed to connect to LND: %v — running without node sync", err)
+		} else {
+			defer lndClient.Close()
+			log.Printf("connected to LND at %s:%d", cfg.LNDHost, cfg.LNDPort)
+
+			syncerLogger := log.New(os.Stdout, "[syncer] ", log.LstdFlags)
+			s = syncer.New(lndClient, database, syncerLogger, cfg.SyncInterval, cfg.MaxHistoryDays)
+			s.SetSnapshotStore(database, priceCache)
+		}
+	} else {
+		log.Printf("LND not configured — running in dashboard-only mode")
+	}
 
 	// Initialize HTTP server
 	httpLogger := log.New(os.Stdout, "[http] ", log.LstdFlags)
-	handler := web.NewHandler(database, lndClient, priceCache, database, httpLogger)
+	var nodeProvider web.NodeInfoProvider
+	if lndClient != nil {
+		nodeProvider = lndClient
+	}
+	handler := web.NewHandler(database, nodeProvider, priceCache, database, httpLogger)
 
 	// Wire up wallet tracking (wallet store is always available; scanner requires Electrum or Bitcoin RPC)
 	handler.SetWalletStore(database)
@@ -137,8 +145,12 @@ func main() {
 		}
 	}()
 
-	// Run syncer (blocks until ctx is cancelled)
-	s.Run(ctx)
+	// Run syncer (blocks until ctx is cancelled) or just wait for signal
+	if s != nil {
+		s.Run(ctx)
+	} else {
+		<-ctx.Done()
+	}
 
 	log.Println("shutdown complete")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,13 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: satsbook_server_1
-      APP_PORT: 3015
+      APP_HOST: satsbook-satsbook_server_1
+      APP_PORT: 3000
 
   server:
-    image: ghcr.io/satsbook/satsbook:1.0.0@sha256:4a265925e6903da45a0aa82653e9f17be97b47d63422212680025bcf418a8cc5
-    container_name: satsbook_server_1
+    image: ghcr.io/satsbook/satsbook:1.1.0
+    container_name: satsbook-satsbook_server_1
+    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     init: true
@@ -21,6 +22,5 @@ services:
       SATSBOOK_LND_MACAROON_PATH: /lnd/data/chain/bitcoin/mainnet/readonly.macaroon
       SATSBOOK_LND_TLS_CERT_PATH: /lnd/tls.cert
       SATSBOOK_DATABASE_PATH: /data/satsbook.db
-      SATSBOOK_APP_PORT: 3015
+      SATSBOOK_APP_PORT: 3000
       SATSBOOK_LOG_LEVEL: info
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,20 +86,19 @@ func Load() (*Config, error) {
 
 // validate checks that required configuration values are present.
 func (c *Config) validate() error {
-	if c.LNDHost == "" {
-		return fmt.Errorf("LND host is required (set SATSBOOK_LND_HOST or LND_IP)")
-	}
-
-	if c.LNDPort <= 0 || c.LNDPort > 65535 {
-		return fmt.Errorf("LND port must be between 1 and 65535, got %d", c.LNDPort)
-	}
-
-	if c.LNDMacaroonPath == "" {
-		return fmt.Errorf("LND macaroon path is required (set SATSBOOK_LND_MACAROON_PATH or LND_MACAROON_PATH)")
-	}
-
-	if c.LNDTLSCertPath == "" {
-		return fmt.Errorf("LND TLS cert path is required (set SATSBOOK_LND_TLS_CERT_PATH or LND_TLS_CERT_PATH)")
+	if c.LNDMacaroonPath != "" || c.LNDTLSCertPath != "" {
+		if c.LNDHost == "" {
+			return fmt.Errorf("LND host is required (set SATSBOOK_LND_HOST or LND_IP)")
+		}
+		if c.LNDPort <= 0 || c.LNDPort > 65535 {
+			return fmt.Errorf("LND port must be between 1 and 65535, got %d", c.LNDPort)
+		}
+		if c.LNDMacaroonPath == "" {
+			return fmt.Errorf("LND macaroon path is required (set SATSBOOK_LND_MACAROON_PATH or LND_MACAROON_PATH)")
+		}
+		if c.LNDTLSCertPath == "" {
+			return fmt.Errorf("LND TLS cert path is required (set SATSBOOK_LND_TLS_CERT_PATH or LND_TLS_CERT_PATH)")
+		}
 	}
 
 	if c.DatabasePath == "" {
@@ -129,6 +128,11 @@ func (c *Config) validate() error {
 	}
 
 	return nil
+}
+
+// LNDConfigured returns true if LND connection details are provided.
+func (c *Config) LNDConfigured() bool {
+	return c.LNDMacaroonPath != "" && c.LNDTLSCertPath != ""
 }
 
 // BitcoinRPCConfigured returns true if Bitcoin Core RPC is configured.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -275,6 +275,58 @@ func TestGetEnvAsInt_ValidValue(t *testing.T) {
 	}
 }
 
+func TestLoad_NoLND_IsValid(t *testing.T) {
+	// When no LND vars are set, config should load successfully (dashboard-only mode)
+	clearEnv()
+	os.Setenv("SATSBOOK_DATABASE_PATH", "/test/db.sqlite")
+	defer clearEnv()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() should succeed without LND config, got: %v", err)
+	}
+	if cfg.LNDConfigured() {
+		t.Error("LNDConfigured() should be false when no LND vars are set")
+	}
+}
+
+func TestLNDConfigured(t *testing.T) {
+	tests := []struct {
+		name     string
+		macaroon string
+		tls      string
+		want     bool
+	}{
+		{"both set", "/mac", "/tls", true},
+		{"macaroon only", "/mac", "", false},
+		{"tls only", "", "/tls", false},
+		{"neither set", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{LNDMacaroonPath: tt.macaroon, LNDTLSCertPath: tt.tls}
+			if got := c.LNDConfigured(); got != tt.want {
+				t.Errorf("LNDConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidate_LNDPartialConfig_MissingHost(t *testing.T) {
+	cfg := &Config{
+		LNDMacaroonPath: "/test/macaroon",
+		LNDTLSCertPath:  "/test/tls.cert",
+		LNDHost:         "",
+		LNDPort:         10009,
+		DatabasePath:    "./satsbook.db",
+		AppPort:         8080,
+		LogLevel:        "info",
+	}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("validate() should fail when LND creds are set but host is empty")
+	}
+}
+
 // clearEnv clears all test environment variables
 func clearEnv() {
 	testVars := []string{

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -92,6 +92,18 @@ func NewHandler(store DashboardStore, node NodeInfoProvider, price PriceProvider
 	}
 }
 
+// getNodeInfo returns node info if an LND connection is configured, otherwise nil.
+func (h *Handler) getNodeInfo(ctx context.Context) *lnd.NodeInfo {
+	if h.node == nil {
+		return nil
+	}
+	info, err := h.node.GetInfo(ctx)
+	if err != nil {
+		return nil
+	}
+	return info
+}
+
 // SetWalletStore sets the wallet store (optional, may not be available without Electrum).
 func (h *Handler) SetWalletStore(ws WalletStore) {
 	h.walletStore = ws

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -234,8 +234,8 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	})
 
 	fetch(func() {
-		info, err := h.node.GetInfo(ctx)
-		if err == nil {
+		info := h.getNodeInfo(ctx)
+		if info != nil {
 			mu.Lock()
 			res.nodeInfo = info
 			mu.Unlock()
@@ -465,8 +465,8 @@ func (h *Handler) HandleLightningPage(w http.ResponseWriter, r *http.Request) {
 	})
 
 	fetch(func() {
-		info, err := h.node.GetInfo(ctx)
-		if err == nil {
+		info := h.getNodeInfo(ctx)
+		if info != nil {
 			mu.Lock()
 			res.nodeInfo = info
 			mu.Unlock()
@@ -793,8 +793,8 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 	})
 
 	fetch(func() {
-		info, err := h.node.GetInfo(ctx)
-		if err == nil {
+		info := h.getNodeInfo(ctx)
+		if info != nil {
 			mu.Lock()
 			res.nodeInfo = info
 			mu.Unlock()
@@ -932,8 +932,8 @@ func (h *Handler) HandleWalletsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fetch(func() {
-		info, err := h.node.GetInfo(ctx)
-		if err == nil {
+		info := h.getNodeInfo(ctx)
+		if info != nil {
 			mu.Lock()
 			data.NodeAlias = info.Alias
 			data.NodePubKey = info.PubKey

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# test-docker.sh — Build and run Satsbook in a Docker container locally,
+# simulating the Umbrel community store environment.
+#
+# Usage:
+#   ./scripts/test-docker.sh          # build + run
+#   ./scripts/test-docker.sh --no-build  # run existing image
+#
+# The app will be available at http://localhost:3000
+# Press Ctrl+C to stop.
+
+set -euo pipefail
+
+IMAGE="ghcr.io/satsbook/satsbook:local-test"
+CONTAINER="satsbook-test"
+DATA_DIR="$(mktemp -d)"
+PORT=3000
+
+BUILD=true
+if [[ "${1:-}" == "--no-build" ]]; then
+  BUILD=false
+fi
+
+cleanup() {
+  echo ""
+  echo "Stopping container..."
+  docker rm -f "$CONTAINER" 2>/dev/null || true
+  echo "Test data was at: $DATA_DIR"
+}
+trap cleanup EXIT
+
+if $BUILD; then
+  echo "==> Building Docker image..."
+  docker build -t "$IMAGE" .
+fi
+
+# Ensure data dir is writable by UID 1000 (matching user: "1000:1000" in compose)
+mkdir -p "$DATA_DIR/data"
+chmod 777 "$DATA_DIR/data"
+
+echo "==> Starting Satsbook container (port $PORT)..."
+echo "    Data dir: $DATA_DIR/data"
+echo "    LND: not connected (dashboard-only mode)"
+echo ""
+
+docker run --rm \
+  --name "$CONTAINER" \
+  --user 1000:1000 \
+  -p "$PORT:$PORT" \
+  -v "$DATA_DIR/data:/data" \
+  -e SATSBOOK_DATABASE_PATH=/data/satsbook.db \
+  -e SATSBOOK_APP_PORT=$PORT \
+  -e SATSBOOK_LOG_LEVEL=debug \
+  "$IMAGE"


### PR DESCRIPTION
## Summary

- Fix `/data` directory permissions for non-root user (UID 1000) in Dockerfile
- Sync `docker-compose.yml` with community store naming convention (`satsbook-satsbook_server_1`)
- Make LND connection optional — app starts in dashboard-only mode when LND is unavailable
- Add nil-safe `getNodeInfo()` to prevent nil pointer panics on all page handlers
- Add Docker build + smoke test CI job (verifies all 5 pages return HTTP 200 as non-root user)
- Add `scripts/test-docker.sh` for local Docker testing

## Problem

The Umbrel community store app was failing with:
```
satsbook-satsbook_app_proxy_1 | Error waiting for port: "The address 'satsbook-satsbook_server_1' cannot be found"
```

Root causes:
1. `/data` dir owned by root but container runs as `user: "1000:1000"` → SQLite can't write → crash
2. LND connection was required at startup — if LND isn't ready yet, the app crashes instead of degrading gracefully

## Test plan

- [x] CI Docker smoke test passes (builds image, runs as UID 1000, checks all pages)
- [x] `./scripts/test-docker.sh` runs locally without errors
- [x] Deploy to Umbrel and verify app starts without the proxy error