### PR TITLE
feat(license): Ed25519 signed license validation with tier gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Binaries
 /satsbook
 /lndcheck
+/licsign
+/demoserver
+/seedemo
 *.exe
 *.dll
 *.so

--- a/cmd/demoserver/main.go
+++ b/cmd/demoserver/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/satsbook/satsbook/internal/license"
+)
+
+// demoserver runs a fake license validation server for testing.
+//
+// Usage:
+//   go run ./cmd/demoserver <real|fake> [port]
+//
+// "real" uses the project's actual private key (tokens will be accepted).
+// "fake" generates a random keypair (tokens will be rejected by the app).
+
+// Set via SATSBOOK_LICENSE_SIGNING_KEY env var for "real" mode.
+var realPrivKeyHex = os.Getenv("SATSBOOK_LICENSE_SIGNING_KEY")
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: demoserver <real|fake> [port]\n")
+		os.Exit(1)
+	}
+
+	mode := os.Args[1]
+	port := "3098"
+	if len(os.Args) > 2 {
+		port = os.Args[2]
+	}
+
+	var priv ed25519.PrivateKey
+
+	switch mode {
+	case "real":
+		if realPrivKeyHex == "" {
+			fmt.Fprintf(os.Stderr, "SATSBOOK_LICENSE_SIGNING_KEY env var required for real mode\n")
+			os.Exit(1)
+		}
+		privBytes, err := hex.DecodeString(realPrivKeyHex)
+		if err != nil || len(privBytes) != ed25519.PrivateKeySize {
+			fmt.Fprintf(os.Stderr, "invalid SATSBOOK_LICENSE_SIGNING_KEY (expected %d hex-encoded bytes)\n", ed25519.PrivateKeySize)
+			os.Exit(1)
+		}
+		priv = ed25519.PrivateKey(privBytes)
+		log.Printf("REAL server: signing with the project's private key")
+	case "fake":
+		_, fakePriv, _ := ed25519.GenerateKey(nil)
+		priv = fakePriv
+		log.Printf("FAKE server: signing with a random key (will be rejected)")
+	default:
+		fmt.Fprintf(os.Stderr, "mode must be 'real' or 'fake'\n")
+		os.Exit(1)
+	}
+
+	http.HandleFunc("/v1/license/validate", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Key string `json:"key"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		log.Printf("received validation request for key: %s", req.Key)
+
+		tier := "power" // always return power for demo
+		token, err := license.SignToken(license.TokenPayload{
+			Key:       req.Key,
+			Tier:      tier,
+			ExpiresAt: time.Now().Add(30 * 24 * time.Hour).Unix(),
+		}, priv)
+		if err != nil {
+			log.Printf("sign error: %v", err)
+			http.Error(w, "internal error", 500)
+			return
+		}
+
+		resp := map[string]interface{}{
+			"valid": true,
+			"tier":  tier,
+			"token": token,
+		}
+		log.Printf("responding: valid=true tier=%s mode=%s", tier, mode)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	addr := ":" + port
+	log.Printf("demo validation server listening on %s (mode=%s)", addr, mode)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}

--- a/cmd/licsign/main.go
+++ b/cmd/licsign/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/satsbook/satsbook/internal/license"
+)
+
+// licsign generates Ed25519 keypairs and signs license tokens for testing.
+//
+// Usage:
+//   go run ./cmd/licsign keygen                              # generate a new keypair
+//   go run ./cmd/licsign sign <privkey-hex> <tier> <key> [days]  # sign a token
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "keygen":
+		keygen()
+	case "sign":
+		if len(os.Args) < 5 {
+			fmt.Fprintf(os.Stderr, "usage: licsign sign <privkey-hex> <tier> <license-key> [days]\n")
+			os.Exit(1)
+		}
+		sign(os.Args[2], os.Args[3], os.Args[4])
+	default:
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage:\n")
+	fmt.Fprintf(os.Stderr, "  licsign keygen\n")
+	fmt.Fprintf(os.Stderr, "  licsign sign <privkey-hex> <tier> <license-key> [days]\n")
+}
+
+func keygen() {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "keygen failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Private key (keep secret): %s\n", hex.EncodeToString(priv))
+	fmt.Printf("Public key (embed in app): %s\n", hex.EncodeToString(pub))
+}
+
+func sign(privKeyHex, tier, licenseKey string) {
+	privBytes, err := hex.DecodeString(privKeyHex)
+	if err != nil || len(privBytes) != ed25519.PrivateKeySize {
+		fmt.Fprintf(os.Stderr, "invalid private key hex (expected %d bytes)\n", ed25519.PrivateKeySize)
+		os.Exit(1)
+	}
+	priv := ed25519.PrivateKey(privBytes)
+
+	if !license.ValidTier(tier) {
+		fmt.Fprintf(os.Stderr, "invalid tier %q (use free, pro, or power)\n", tier)
+		os.Exit(1)
+	}
+
+	days := 30
+	if len(os.Args) > 5 {
+		d, err := strconv.Atoi(os.Args[5])
+		if err != nil || d < 1 {
+			fmt.Fprintf(os.Stderr, "invalid days: %s\n", os.Args[5])
+			os.Exit(1)
+		}
+		days = d
+	}
+
+	payload := license.TokenPayload{
+		Key:       licenseKey,
+		Tier:      tier,
+		ExpiresAt: time.Now().Add(time.Duration(days) * 24 * time.Hour).Unix(),
+	}
+
+	token, err := license.SignToken(payload, priv)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sign failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Token (valid %d days):\n%s\n", days, token)
+}

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/satsbook/satsbook/internal/config"
 	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/license"
 	"github.com/satsbook/satsbook/internal/lnd"
 	"github.com/satsbook/satsbook/internal/price"
 	"github.com/satsbook/satsbook/internal/syncer"
@@ -47,6 +48,27 @@ func main() {
 	}
 	defer database.Close()
 	log.Printf("database initialized at %s", cfg.DatabasePath)
+
+	// Initialize license checker
+	var licenseChecker license.Checker
+	if cfg.LicenseKey != "" {
+		licenseLogger := log.New(os.Stdout, "[license] ", log.LstdFlags)
+		lc := license.NewChecker(
+			&licenseStoreAdapter{db: database},
+			cfg.LicenseKey,
+			license.WithValidationURL(cfg.LicenseValidationURL),
+			license.WithLogger(licenseLogger),
+		)
+		if err := lc.Verify(context.Background()); err != nil {
+			log.Printf("WARNING: license verification failed: %v — defaulting to free tier", err)
+		} else {
+			log.Printf("License tier: %s", lc.CurrentTier())
+		}
+		licenseChecker = lc
+	} else {
+		licenseChecker = license.FreeChecker{}
+		log.Printf("No license key configured — running free tier")
+	}
 
 	// Initialize price cache
 	priceCache := price.NewCache(price.WithAPIURL(cfg.PriceAPIURL))
@@ -117,7 +139,7 @@ func main() {
 		walletLogger.Printf("wallet scanning disabled (no Electrum or Bitcoin RPC configured)")
 	}
 
-	srv := web.NewServer(handler, cfg.AppPort, httpLogger)
+	srv := web.NewServer(handler, cfg.AppPort, httpLogger, licenseChecker)
 
 	// Setup graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
@@ -153,4 +175,38 @@ func main() {
 	}
 
 	log.Println("shutdown complete")
+}
+
+// licenseStoreAdapter bridges db.DB to the license.LicenseStore interface,
+// converting between db.CachedLicense and license.CachedLicense to avoid
+// circular imports.
+type licenseStoreAdapter struct {
+	db interface {
+		GetCachedLicense(ctx context.Context) (*db.CachedLicense, error)
+		UpdateCachedLicense(ctx context.Context, cl *db.CachedLicense) error
+	}
+}
+
+func (a *licenseStoreAdapter) GetCachedLicense(ctx context.Context) (*license.CachedLicense, error) {
+	cl, err := a.db.GetCachedLicense(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &license.CachedLicense{
+		LicenseKey:   cl.LicenseKey,
+		Tier:         cl.Tier,
+		SignedToken:  cl.SignedToken,
+		LastVerified: cl.LastVerified,
+		ExpiresAt:    cl.ExpiresAt,
+	}, nil
+}
+
+func (a *licenseStoreAdapter) UpdateCachedLicense(ctx context.Context, cl *license.CachedLicense) error {
+	return a.db.UpdateCachedLicense(ctx, &db.CachedLicense{
+		LicenseKey:   cl.LicenseKey,
+		Tier:         cl.Tier,
+		SignedToken:  cl.SignedToken,
+		LastVerified: cl.LastVerified,
+		ExpiresAt:    cl.ExpiresAt,
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	AppPort     int
 	LogLevel    string
 	PriceAPIURL string
+
+	// License settings
+	LicenseKey           string
+	LicenseValidationURL string
 }
 
 // Load reads configuration from environment variables.
@@ -74,6 +78,10 @@ func Load() (*Config, error) {
 		AppPort:     getEnvAsInt("SATSBOOK_APP_PORT", 8080),
 		LogLevel:    getEnv("SATSBOOK_LOG_LEVEL", "info"),
 		PriceAPIURL: getEnv("SATSBOOK_PRICE_API_URL", "https://mempool.space/api/v1/prices"),
+
+		// License defaults
+		LicenseKey:           getEnv("SATSBOOK_LICENSE_KEY", ""),
+		LicenseValidationURL: getEnv("SATSBOOK_LICENSE_URL", "https://api.satsbook.com/v1/license/validate"),
 	}
 
 	// Validate required fields

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -202,6 +202,20 @@ var migrations = []string{
 	);
 	CREATE INDEX IF NOT EXISTS idx_portfolio_snapshots_captured ON portfolio_snapshots(captured_at);
 	`,
+
+	// Migration 7: License cache for phone-home validation with grace period.
+	`
+	CREATE TABLE IF NOT EXISTS license_cache (
+		id            INTEGER PRIMARY KEY CHECK (id = 1),
+		license_key   TEXT NOT NULL DEFAULT '',
+		tier          TEXT NOT NULL DEFAULT 'free',
+		signed_token  TEXT NOT NULL DEFAULT '',
+		last_verified DATETIME,
+		expires_at    DATETIME,
+		updated_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	INSERT OR IGNORE INTO license_cache (id, tier) VALUES (1, 'free');
+	`,
 }
 
 // NewDB opens a SQLite database at the given path, runs migrations, and returns a DB.

--- a/internal/db/license.go
+++ b/internal/db/license.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// CachedLicense represents the locally cached license validation result.
+type CachedLicense struct {
+	LicenseKey   string
+	Tier         string
+	SignedToken  string
+	LastVerified time.Time
+	ExpiresAt    time.Time
+}
+
+// GetCachedLicense reads the singleton license cache row.
+func (d *DB) GetCachedLicense(ctx context.Context) (*CachedLicense, error) {
+	var cl CachedLicense
+	var lastVerified, expiresAt sql.NullTime
+	var signedToken sql.NullString
+
+	err := d.db.QueryRowContext(ctx,
+		`SELECT license_key, tier, signed_token, last_verified, expires_at FROM license_cache WHERE id = 1`,
+	).Scan(&cl.LicenseKey, &cl.Tier, &signedToken, &lastVerified, &expiresAt)
+
+	if err == sql.ErrNoRows {
+		return &CachedLicense{Tier: "free"}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if signedToken.Valid {
+		cl.SignedToken = signedToken.String
+	}
+	if lastVerified.Valid {
+		cl.LastVerified = lastVerified.Time
+	}
+	if expiresAt.Valid {
+		cl.ExpiresAt = expiresAt.Time
+	}
+	return &cl, nil
+}
+
+// UpdateCachedLicense writes the license validation result to the cache.
+func (d *DB) UpdateCachedLicense(ctx context.Context, cl *CachedLicense) error {
+	_, err := d.db.ExecContext(ctx,
+		`UPDATE license_cache SET license_key = ?, tier = ?, signed_token = ?, last_verified = ?, expires_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = 1`,
+		cl.LicenseKey, cl.Tier, cl.SignedToken, cl.LastVerified, cl.ExpiresAt,
+	)
+	return err
+}

--- a/internal/db/license_test.go
+++ b/internal/db/license_test.go
@@ -1,0 +1,107 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGetCachedLicense_Default(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	cl, err := d.GetCachedLicense(context.Background())
+	if err != nil {
+		t.Fatalf("GetCachedLicense() error: %v", err)
+	}
+	if cl.Tier != "free" {
+		t.Errorf("Tier = %q, want %q", cl.Tier, "free")
+	}
+	if cl.LicenseKey != "" {
+		t.Errorf("LicenseKey = %q, want empty", cl.LicenseKey)
+	}
+	if !cl.LastVerified.IsZero() {
+		t.Errorf("LastVerified should be zero, got %v", cl.LastVerified)
+	}
+	if !cl.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt should be zero, got %v", cl.ExpiresAt)
+	}
+}
+
+func TestUpdateAndGetCachedLicense(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	expires := now.Add(7 * 24 * time.Hour)
+
+	err := d.UpdateCachedLicense(ctx, &CachedLicense{
+		LicenseKey:   "sk_test_abc123",
+		Tier:         "power",
+		LastVerified: now,
+		ExpiresAt:    expires,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCachedLicense() error: %v", err)
+	}
+
+	cl, err := d.GetCachedLicense(ctx)
+	if err != nil {
+		t.Fatalf("GetCachedLicense() error: %v", err)
+	}
+
+	if cl.LicenseKey != "sk_test_abc123" {
+		t.Errorf("LicenseKey = %q, want %q", cl.LicenseKey, "sk_test_abc123")
+	}
+	if cl.Tier != "power" {
+		t.Errorf("Tier = %q, want %q", cl.Tier, "power")
+	}
+	if !cl.LastVerified.Equal(now) {
+		t.Errorf("LastVerified = %v, want %v", cl.LastVerified, now)
+	}
+	if !cl.ExpiresAt.Equal(expires) {
+		t.Errorf("ExpiresAt = %v, want %v", cl.ExpiresAt, expires)
+	}
+}
+
+func TestUpdateCachedLicense_Overwrite(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// First write: power tier
+	err := d.UpdateCachedLicense(ctx, &CachedLicense{
+		LicenseKey:   "key1",
+		Tier:         "power",
+		LastVerified: now,
+		ExpiresAt:    now.Add(7 * 24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("first UpdateCachedLicense() error: %v", err)
+	}
+
+	// Overwrite: downgrade to free
+	err = d.UpdateCachedLicense(ctx, &CachedLicense{
+		LicenseKey:   "",
+		Tier:         "free",
+		LastVerified: time.Time{},
+		ExpiresAt:    time.Time{},
+	})
+	if err != nil {
+		t.Fatalf("second UpdateCachedLicense() error: %v", err)
+	}
+
+	cl, err := d.GetCachedLicense(ctx)
+	if err != nil {
+		t.Fatalf("GetCachedLicense() error: %v", err)
+	}
+	if cl.Tier != "free" {
+		t.Errorf("Tier = %q, want %q after downgrade", cl.Tier, "free")
+	}
+	if cl.LicenseKey != "" {
+		t.Errorf("LicenseKey = %q, want empty after downgrade", cl.LicenseKey)
+	}
+}

--- a/internal/license/checker.go
+++ b/internal/license/checker.go
@@ -1,0 +1,270 @@
+package license
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// LicenseStore is the DB interface consumed by the checker.
+type LicenseStore interface {
+	GetCachedLicense(ctx context.Context) (*CachedLicense, error)
+	UpdateCachedLicense(ctx context.Context, cl *CachedLicense) error
+}
+
+// CachedLicense mirrors db.CachedLicense to avoid circular imports.
+type CachedLicense struct {
+	LicenseKey   string
+	Tier         string
+	SignedToken  string
+	LastVerified time.Time
+	ExpiresAt    time.Time
+}
+
+// Checker validates license keys and provides the current tier.
+type Checker interface {
+	CurrentTier() Tier
+	Verify(ctx context.Context) error
+}
+
+// DefaultChecker implements phone-home license validation with local caching.
+type DefaultChecker struct {
+	store         LicenseStore
+	licenseKey    string
+	validationURL string
+	gracePeriod   time.Duration
+	httpClient    *http.Client
+	logger        *log.Logger
+	publicKey     ed25519.PublicKey
+	currentTier   atomic.Value // stores Tier
+	nowFunc       func() time.Time
+}
+
+// Option configures a DefaultChecker.
+type Option func(*DefaultChecker)
+
+// WithValidationURL overrides the default validation endpoint.
+func WithValidationURL(url string) Option {
+	return func(c *DefaultChecker) { c.validationURL = url }
+}
+
+// WithGracePeriod overrides the default 7-day grace period.
+func WithGracePeriod(d time.Duration) Option {
+	return func(c *DefaultChecker) { c.gracePeriod = d }
+}
+
+// WithHTTPClient overrides the default HTTP client (useful for testing).
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *DefaultChecker) { c.httpClient = client }
+}
+
+// WithLogger sets the logger for the checker.
+func WithLogger(l *log.Logger) Option {
+	return func(c *DefaultChecker) { c.logger = l }
+}
+
+// WithPublicKey overrides the embedded public key (for testing).
+func WithPublicKey(key ed25519.PublicKey) Option {
+	return func(c *DefaultChecker) { c.publicKey = key }
+}
+
+// withNowFunc overrides time.Now for testing.
+func withNowFunc(fn func() time.Time) Option {
+	return func(c *DefaultChecker) { c.nowFunc = fn }
+}
+
+const defaultValidationURL = "https://api.satsbook.com/v1/license/validate"
+
+// NewChecker creates a license checker with the given options.
+func NewChecker(store LicenseStore, licenseKey string, opts ...Option) *DefaultChecker {
+	c := &DefaultChecker{
+		store:         store,
+		licenseKey:    licenseKey,
+		validationURL: defaultValidationURL,
+		gracePeriod:   7 * 24 * time.Hour,
+		httpClient:    &http.Client{Timeout: 10 * time.Second},
+		logger:        log.New(log.Writer(), "[license] ", log.LstdFlags),
+		publicKey:     PublicKey(),
+		nowFunc:       time.Now,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	c.currentTier.Store(TierFree)
+	return c
+}
+
+// CurrentTier returns the cached tier. Safe for concurrent use.
+func (c *DefaultChecker) CurrentTier() Tier {
+	return c.currentTier.Load().(Tier)
+}
+
+func (c *DefaultChecker) setTier(t Tier) {
+	c.currentTier.Store(t)
+}
+
+// Verify performs a phone-home check and updates the local cache.
+// On network failure, it falls back to the cached result within the grace period.
+func (c *DefaultChecker) Verify(ctx context.Context) error {
+	// No license key = free tier, no network call needed.
+	if c.licenseKey == "" {
+		c.setTier(TierFree)
+		return c.store.UpdateCachedLicense(ctx, &CachedLicense{Tier: string(TierFree)})
+	}
+
+	// Attempt phone-home validation.
+	tier, signedToken, err := c.phoneHome(ctx)
+	if err == nil {
+		// Success: update cache with new grace period and the signed token.
+		now := c.nowFunc()
+		cl := &CachedLicense{
+			LicenseKey:   c.licenseKey,
+			Tier:         string(tier),
+			SignedToken:  signedToken,
+			LastVerified: now,
+			ExpiresAt:    now.Add(c.gracePeriod),
+		}
+		c.setTier(tier)
+		if storeErr := c.store.UpdateCachedLicense(ctx, cl); storeErr != nil {
+			c.logger.Printf("failed to update license cache: %v", storeErr)
+		}
+		c.logger.Printf("license verified: tier=%s (signed)", tier)
+		return nil
+	}
+
+	c.logger.Printf("phone-home failed: %v — checking cache", err)
+
+	// Fallback to cached license within grace period.
+	return c.fallbackToCache(ctx)
+}
+
+// phoneHome calls the validation API and returns the tier and signed token.
+func (c *DefaultChecker) phoneHome(ctx context.Context) (Tier, string, error) {
+	body, err := json.Marshal(map[string]string{"key": c.licenseKey})
+	if err != nil {
+		return TierFree, "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.validationURL, bytes.NewReader(body))
+	if err != nil {
+		return TierFree, "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return TierFree, "", fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return TierFree, "", fmt.Errorf("validation returned status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Valid bool   `json:"valid"`
+		Tier  string `json:"tier"`
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return TierFree, "", fmt.Errorf("decode response: %w", err)
+	}
+
+	if !result.Valid {
+		return TierFree, "", nil
+	}
+
+	// Verify the signed token from the server.
+	if result.Token == "" {
+		return TierFree, "", fmt.Errorf("server returned valid=true but no signed token")
+	}
+
+	payload, err := VerifyTokenAt(result.Token, c.publicKey, c.nowFunc())
+	if err != nil {
+		return TierFree, "", fmt.Errorf("invalid token from server: %w", err)
+	}
+
+	// Token's key must match our license key.
+	if payload.Key != c.licenseKey {
+		return TierFree, "", fmt.Errorf("token key mismatch")
+	}
+
+	tier := Tier(payload.Tier)
+	if !ValidTier(payload.Tier) {
+		return TierFree, "", fmt.Errorf("unknown tier %q in token", payload.Tier)
+	}
+
+	return tier, result.Token, nil
+}
+
+// fallbackToCache reads the cached license, verifies the stored token signature,
+// and checks the grace period.
+func (c *DefaultChecker) fallbackToCache(ctx context.Context) error {
+	cached, err := c.store.GetCachedLicense(ctx)
+	if err != nil {
+		c.logger.Printf("failed to read license cache: %v", err)
+		c.setTier(TierFree)
+		return err
+	}
+
+	// If the cached key doesn't match the current key, we can't trust it.
+	if cached.LicenseKey != c.licenseKey {
+		c.logger.Printf("cached key mismatch — defaulting to free")
+		c.setTier(TierFree)
+		return nil
+	}
+
+	// Verify the cached signed token. If there's no token or it has an
+	// invalid signature, don't trust the cached tier.
+	if cached.SignedToken == "" {
+		c.logger.Printf("no signed token in cache — defaulting to free")
+		c.setTier(TierFree)
+		return nil
+	}
+
+	// Use the grace period expiry for time check, not the token's own expiry,
+	// since the token expiry may be shorter than the grace period.
+	// We still verify the signature is valid.
+	payload, err := VerifyTokenAt(cached.SignedToken, c.publicKey, c.nowFunc())
+	if err != nil {
+		// Token signature invalid or token itself expired — check grace period.
+		// If grace period is still active, we accept the cached tier from the DB
+		// but only if the signature at least verifies (just expired).
+		// For simplicity: if signature is bad, downgrade immediately.
+		c.logger.Printf("cached token verification failed: %v — downgrading to free", err)
+		c.setTier(TierFree)
+		return nil
+	}
+
+	// Signature valid, token not expired — trust it.
+	now := c.nowFunc()
+	if now.Before(cached.ExpiresAt) {
+		tier := Tier(payload.Tier)
+		c.setTier(tier)
+		c.logger.Printf("grace period active: tier=%s (signed, expires %s)", tier, cached.ExpiresAt.Format(time.RFC3339))
+		return nil
+	}
+
+	// Grace period expired — downgrade to free.
+	c.logger.Printf("grace period expired — downgrading to free")
+	c.setTier(TierFree)
+	if storeErr := c.store.UpdateCachedLicense(ctx, &CachedLicense{
+		LicenseKey: c.licenseKey,
+		Tier:       string(TierFree),
+	}); storeErr != nil {
+		c.logger.Printf("failed to update cache on downgrade: %v", storeErr)
+	}
+	return nil
+}
+
+// FreeChecker always returns TierFree. Used when no license system is configured.
+type FreeChecker struct{}
+
+func (FreeChecker) CurrentTier() Tier              { return TierFree }
+func (FreeChecker) Verify(_ context.Context) error { return nil }

--- a/internal/license/checker_test.go
+++ b/internal/license/checker_test.go
@@ -1,0 +1,397 @@
+package license
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// mockStore implements LicenseStore for testing.
+type mockStore struct {
+	cached *CachedLicense
+	err    error
+}
+
+func (m *mockStore) GetCachedLicense(_ context.Context) (*CachedLicense, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.cached == nil {
+		return &CachedLicense{Tier: string(TierFree)}, nil
+	}
+	return m.cached, nil
+}
+
+func (m *mockStore) UpdateCachedLicense(_ context.Context, cl *CachedLicense) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.cached = cl
+	return nil
+}
+
+// testKeys generates a keypair and returns common checker options for testing.
+func testKeys(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+// signedValidationServer creates a test HTTP server that returns signed tokens.
+func signedValidationServer(t *testing.T, priv ed25519.PrivateKey, tier string, valid bool, tokenExpiry time.Time) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]string
+		json.NewDecoder(r.Body).Decode(&req)
+
+		resp := map[string]interface{}{"valid": valid, "tier": tier}
+
+		if valid {
+			token, err := SignToken(TokenPayload{
+				Key:       req["key"],
+				Tier:      tier,
+				ExpiresAt: tokenExpiry.Unix(),
+			}, priv)
+			if err != nil {
+				t.Fatalf("SignToken in test server: %v", err)
+			}
+			resp["token"] = token
+		}
+
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestNewChecker_NoKey_FreeImmediately(t *testing.T) {
+	store := &mockStore{}
+	checker := NewChecker(store, "")
+
+	if err := checker.Verify(context.Background()); err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+
+	if got := checker.CurrentTier(); got != TierFree {
+		t.Errorf("CurrentTier() = %q, want %q", got, TierFree)
+	}
+	if store.cached == nil || store.cached.Tier != string(TierFree) {
+		t.Error("expected cache to be updated to free")
+	}
+}
+
+func TestVerify_ValidKey_ServerReturnsPro(t *testing.T) {
+	pub, priv := testKeys(t)
+	srv := signedValidationServer(t, priv, "pro", true, time.Now().Add(24*time.Hour))
+	defer srv.Close()
+
+	store := &mockStore{}
+	checker := NewChecker(store, "sk_test_123",
+		WithValidationURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithPublicKey(pub),
+	)
+
+	if err := checker.Verify(context.Background()); err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+
+	if got := checker.CurrentTier(); got != TierPro {
+		t.Errorf("CurrentTier() = %q, want %q", got, TierPro)
+	}
+	if store.cached.Tier != string(TierPro) {
+		t.Errorf("cached tier = %q, want %q", store.cached.Tier, string(TierPro))
+	}
+	if store.cached.SignedToken == "" {
+		t.Error("cached signed token should not be empty")
+	}
+}
+
+func TestVerify_ValidKey_ServerReturnsPower(t *testing.T) {
+	pub, priv := testKeys(t)
+	srv := signedValidationServer(t, priv, "power", true, time.Now().Add(24*time.Hour))
+	defer srv.Close()
+
+	store := &mockStore{}
+	checker := NewChecker(store, "sk_power_key",
+		WithValidationURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithPublicKey(pub),
+	)
+
+	if err := checker.Verify(context.Background()); err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+
+	if got := checker.CurrentTier(); got != TierPower {
+		t.Errorf("CurrentTier() = %q, want %q", got, TierPower)
+	}
+}
+
+func TestVerify_ServerReturnsInvalid(t *testing.T) {
+	pub, priv := testKeys(t)
+	srv := signedValidationServer(t, priv, "", false, time.Time{})
+	defer srv.Close()
+
+	store := &mockStore{}
+	checker := NewChecker(store, "sk_bad_key",
+		WithValidationURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithPublicKey(pub),
+	)
+
+	if err := checker.Verify(context.Background()); err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+
+	if got := checker.CurrentTier(); got != TierFree {
+		t.Errorf("CurrentTier() = %q, want %q", got, TierFree)
+	}
+}
+
+func TestVerify_FakeServer_WrongSigningKey(t *testing.T) {
+	realPub, _ := testKeys(t)
+	_, fakePriv := testKeys(t) // different keypair
+
+	// Fake server signs with the wrong key
+	srv := signedValidationServer(t, fakePriv, "power", true, time.Now().Add(24*time.Hour))
+	defer srv.Close()
+
+	store := &mockStore{}
+	checker := NewChecker(store, "sk_test",
+		WithValidationURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithPublicKey(realPub), // app has the real public key
+	)
+
+	// Should fail verification and fall back to cache (which is empty = free)
+	_ = checker.Verify(context.Background())
+
+	if got := checker.CurrentTier(); got != TierFree {
+		t.Errorf("CurrentTier() = %q, want %q (fake server should be rejected)", got, TierFree)
+	}
+}
+
+func TestVerify_ServerReturns401_FallsBackToSignedCache(t *testing.T) {
+	pub, priv := testKeys(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	now := time.Now()
+	// Create a valid signed token for the cache
+	token, _ := SignToken(TokenPayload{
+		Key:       "sk_test_123",
+		Tier:      "pro",
+		ExpiresAt: now.Add(30 * 24 * time.Hour).Unix(), // token valid for 30 days
+	}, priv)
+
+	store := &mockStore{
+		cached: &CachedLicense{
+			LicenseKey:   "sk_test_123",
+			Tier:         string(TierPro),
+			SignedToken:  token,
+			LastVerified: now.Add(-24 * time.Hour),
+			ExpiresAt:    now.Add(6 * 24 * time.Hour),
+		},
+	}
+
+	checker := NewChecker(store, "sk_test_123",
+		WithValidationURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithPublicKey(pub),
+		withNowFunc(func() time.Time { return now }),
+	)
+
+	if err := checker.Verify(context.Background()); err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+
+	if got := checker.CurrentTier(); got != TierPro {
+		t.Errorf("CurrentTier() = %q, want %q (signed cache should be trusted)", got, TierPro)
+	}
+}
+
+func TestVerify_NetworkError_GracePeriodActive_SignedToken(t *testing.T) {
+	pub, priv := testKeys(t)
+
+	now := time.Now()
+	token, _ := SignToken(TokenPayload{
+		Key:       "sk_test_123",
+		Tier:      "power",
+		ExpiresAt: now.Add(30 * 24 * time.Hour).Unix(),
+	}, priv)
+
+	store := &mockStore{
+		cached: &CachedLicense{
+			LicenseKey:   "sk_test_123",
+			Tier:         string(TierPower),
+			SignedToken:  token,
+			LastVerified: now.Add(-48 * time.Hour),
+			ExpiresAt:    now.Add(5 * 24 * time.Hour),
+		},
+	}
+
+	checker := NewChecker(store, "sk_test_123",
+		WithValidationURL("http://localhost:1"), // unreachable
+		WithPublicKey(pub),
+		withNowFunc(func() time.Time { return now }),
+	)
+
+	if err := checker.Verify(context.Background()); err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+
+	if got := checker.CurrentTier(); got != TierPower {
+		t.Errorf("CurrentTier() = %q, want %q (grace period active, signed)", got, TierPower)
+	}
+}
+
+func TestVerify_NetworkError_GracePeriodExpired(t *testing.T) {
+	pub, priv := testKeys(t)
+
+	now := time.Now()
+	token, _ := SignToken(TokenPayload{
+		Key:       "sk_test_123",
+		Tier:      "power",
+		ExpiresAt: now.Add(30 * 24 * time.Hour).Unix(),
+	}, priv)
+
+	store := &mockStore{
+		cached: &CachedLicense{
+			LicenseKey:   "sk_test_123",
+			Tier:         string(TierPower),
+			SignedToken:  token,
+			LastVerified: now.Add(-10 * 24 * time.Hour),
+			ExpiresAt:    now.Add(-3 * 24 * time.Hour), // expired 3 days ago
+		},
+	}
+
+	checker := NewChecker(store, "sk_test_123",
+		WithValidationURL("http://localhost:1"),
+		WithPublicKey(pub),
+		withNowFunc(func() time.Time { return now }),
+	)
+
+	if err := checker.Verify(context.Background()); err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+
+	if got := checker.CurrentTier(); got != TierFree {
+		t.Errorf("CurrentTier() = %q, want %q (grace period expired)", got, TierFree)
+	}
+}
+
+func TestVerify_KeyChanged_CacheMismatch(t *testing.T) {
+	pub, priv := testKeys(t)
+
+	now := time.Now()
+	token, _ := SignToken(TokenPayload{
+		Key:       "old_key",
+		Tier:      "power",
+		ExpiresAt: now.Add(30 * 24 * time.Hour).Unix(),
+	}, priv)
+
+	store := &mockStore{
+		cached: &CachedLicense{
+			LicenseKey:   "old_key",
+			Tier:         string(TierPower),
+			SignedToken:  token,
+			LastVerified: now.Add(-24 * time.Hour),
+			ExpiresAt:    now.Add(6 * 24 * time.Hour),
+		},
+	}
+
+	checker := NewChecker(store, "new_key",
+		WithValidationURL("http://localhost:1"),
+		WithPublicKey(pub),
+		withNowFunc(func() time.Time { return now }),
+	)
+
+	if err := checker.Verify(context.Background()); err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+
+	if got := checker.CurrentTier(); got != TierFree {
+		t.Errorf("CurrentTier() = %q, want %q (key mismatch)", got, TierFree)
+	}
+}
+
+func TestVerify_CachedToken_TamperedInDB(t *testing.T) {
+	pub, _ := testKeys(t)
+
+	now := time.Now()
+	store := &mockStore{
+		cached: &CachedLicense{
+			LicenseKey:   "sk_test",
+			Tier:         string(TierPower),
+			SignedToken:  "tampered.garbage", // not a valid signature
+			LastVerified: now.Add(-24 * time.Hour),
+			ExpiresAt:    now.Add(6 * 24 * time.Hour),
+		},
+	}
+
+	checker := NewChecker(store, "sk_test",
+		WithValidationURL("http://localhost:1"),
+		WithPublicKey(pub),
+		withNowFunc(func() time.Time { return now }),
+	)
+
+	_ = checker.Verify(context.Background())
+
+	if got := checker.CurrentTier(); got != TierFree {
+		t.Errorf("CurrentTier() = %q, want %q (tampered token should be rejected)", got, TierFree)
+	}
+}
+
+func TestVerify_CachedToken_NoSignedToken(t *testing.T) {
+	pub, _ := testKeys(t)
+
+	now := time.Now()
+	store := &mockStore{
+		cached: &CachedLicense{
+			LicenseKey:   "sk_test",
+			Tier:         string(TierPower),
+			SignedToken:  "", // no token
+			LastVerified: now.Add(-24 * time.Hour),
+			ExpiresAt:    now.Add(6 * 24 * time.Hour),
+		},
+	}
+
+	checker := NewChecker(store, "sk_test",
+		WithValidationURL("http://localhost:1"),
+		WithPublicKey(pub),
+		withNowFunc(func() time.Time { return now }),
+	)
+
+	_ = checker.Verify(context.Background())
+
+	if got := checker.CurrentTier(); got != TierFree {
+		t.Errorf("CurrentTier() = %q, want %q (no signed token = free)", got, TierFree)
+	}
+}
+
+func TestFreeChecker(t *testing.T) {
+	var c FreeChecker
+	if got := c.CurrentTier(); got != TierFree {
+		t.Errorf("FreeChecker.CurrentTier() = %q, want %q", got, TierFree)
+	}
+	if err := c.Verify(context.Background()); err != nil {
+		t.Errorf("FreeChecker.Verify() error: %v", err)
+	}
+}
+
+func TestCurrentTier_DefaultIsFree(t *testing.T) {
+	store := &mockStore{}
+	checker := NewChecker(store, "some-key")
+	if got := checker.CurrentTier(); got != TierFree {
+		t.Errorf("CurrentTier() before Verify = %q, want %q", got, TierFree)
+	}
+}

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -1,0 +1,47 @@
+package license
+
+// Tier represents a subscription tier level.
+type Tier string
+
+const (
+	TierFree  Tier = "free"
+	TierPro   Tier = "pro"
+	TierPower Tier = "power"
+)
+
+// tierOrder maps each tier to its rank for comparison.
+var tierOrder = map[Tier]int{
+	TierFree:  0,
+	TierPro:   1,
+	TierPower: 2,
+}
+
+// TierAtLeast returns true if current tier is at or above the required tier.
+func TierAtLeast(current, required Tier) bool {
+	return tierOrder[current] >= tierOrder[required]
+}
+
+// ValidTier returns true if the tier string is a known tier.
+func ValidTier(t string) bool {
+	_, ok := tierOrder[Tier(t)]
+	return ok
+}
+
+// FeatureTiers maps feature names to the minimum tier required.
+var FeatureTiers = map[string]Tier{
+	"tax_export":      TierPro,
+	"api_imports":     TierPro,
+	"cloud_sync":      TierPro,
+	"monarch_sync":    TierPower,
+	"telegram_alerts": TierPower,
+	"multi_node":      TierPower,
+}
+
+// FeatureAllowed returns true if the given tier can access the named feature.
+func FeatureAllowed(tier Tier, feature string) bool {
+	required, ok := FeatureTiers[feature]
+	if !ok {
+		return true // unknown features default to allowed (free)
+	}
+	return TierAtLeast(tier, required)
+}

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -1,0 +1,93 @@
+package license
+
+import "testing"
+
+func TestTierAtLeast(t *testing.T) {
+	tests := []struct {
+		current  Tier
+		required Tier
+		want     bool
+	}{
+		{TierFree, TierFree, true},
+		{TierFree, TierPro, false},
+		{TierFree, TierPower, false},
+		{TierPro, TierFree, true},
+		{TierPro, TierPro, true},
+		{TierPro, TierPower, false},
+		{TierPower, TierFree, true},
+		{TierPower, TierPro, true},
+		{TierPower, TierPower, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.current)+"_vs_"+string(tt.required), func(t *testing.T) {
+			got := TierAtLeast(tt.current, tt.required)
+			if got != tt.want {
+				t.Errorf("TierAtLeast(%q, %q) = %v, want %v", tt.current, tt.required, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidTier(t *testing.T) {
+	tests := []struct {
+		tier string
+		want bool
+	}{
+		{"free", true},
+		{"pro", true},
+		{"power", true},
+		{"", false},
+		{"premium", false},
+		{"enterprise", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tier, func(t *testing.T) {
+			if got := ValidTier(tt.tier); got != tt.want {
+				t.Errorf("ValidTier(%q) = %v, want %v", tt.tier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFeatureAllowed(t *testing.T) {
+	tests := []struct {
+		tier    Tier
+		feature string
+		want    bool
+	}{
+		// Pro features
+		{TierFree, "tax_export", false},
+		{TierPro, "tax_export", true},
+		{TierPower, "tax_export", true},
+		{TierFree, "api_imports", false},
+		{TierPro, "api_imports", true},
+		{TierFree, "cloud_sync", false},
+		{TierPro, "cloud_sync", true},
+
+		// Power features
+		{TierFree, "monarch_sync", false},
+		{TierPro, "monarch_sync", false},
+		{TierPower, "monarch_sync", true},
+		{TierFree, "telegram_alerts", false},
+		{TierPro, "telegram_alerts", false},
+		{TierPower, "telegram_alerts", true},
+		{TierFree, "multi_node", false},
+		{TierPro, "multi_node", false},
+		{TierPower, "multi_node", true},
+
+		// Unknown features default to allowed
+		{TierFree, "unknown_feature", true},
+		{TierFree, "", true},
+	}
+
+	for _, tt := range tests {
+		name := string(tt.tier) + "_" + tt.feature
+		t.Run(name, func(t *testing.T) {
+			got := FeatureAllowed(tt.tier, tt.feature)
+			if got != tt.want {
+				t.Errorf("FeatureAllowed(%q, %q) = %v, want %v", tt.tier, tt.feature, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/license/pubkey.go
+++ b/internal/license/pubkey.go
@@ -1,0 +1,21 @@
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+)
+
+// publicKeyHex is the Ed25519 public key used to verify license tokens.
+// The corresponding private key is kept on the satsbook validation server.
+// To rotate: generate a new keypair with `go run ./cmd/licsign keygen`,
+// update this value, and deploy the new private key to the server.
+const publicKeyHex = "0f0f19de4a7ad68955ee477d9e19a6a08a47569f6240c7ae62858b86f4321eee"
+
+// PublicKey returns the embedded Ed25519 public key for token verification.
+func PublicKey() ed25519.PublicKey {
+	key, err := hex.DecodeString(publicKeyHex)
+	if err != nil {
+		panic("license: invalid embedded public key: " + err.Error())
+	}
+	return ed25519.PublicKey(key)
+}

--- a/internal/license/token.go
+++ b/internal/license/token.go
@@ -1,0 +1,96 @@
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TokenPayload is the signed content of a license token.
+type TokenPayload struct {
+	Key       string `json:"key"`
+	Tier      string `json:"tier"`
+	ExpiresAt int64  `json:"exp"`
+}
+
+// SignToken creates a signed token string: base64(payload).base64(signature).
+func SignToken(payload TokenPayload, privateKey ed25519.PrivateKey) (string, error) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal payload: %w", err)
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	sig := ed25519.Sign(privateKey, payloadBytes)
+	sigB64 := base64.RawURLEncoding.EncodeToString(sig)
+	return payloadB64 + "." + sigB64, nil
+}
+
+// VerifyToken parses and verifies a signed token against the public key.
+// Returns the payload if valid, or an error if the signature is invalid or the token is expired.
+func VerifyToken(token string, publicKey ed25519.PublicKey) (*TokenPayload, error) {
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid token format")
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode payload: %w", err)
+	}
+
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+
+	if !ed25519.Verify(publicKey, payloadBytes, sig) {
+		return nil, fmt.Errorf("invalid signature")
+	}
+
+	var payload TokenPayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, fmt.Errorf("unmarshal payload: %w", err)
+	}
+
+	if payload.ExpiresAt > 0 && time.Unix(payload.ExpiresAt, 0).Before(time.Now()) {
+		return nil, fmt.Errorf("token expired")
+	}
+
+	return &payload, nil
+}
+
+// VerifyTokenAt is like VerifyToken but uses a custom time for expiry checks (for testing).
+func VerifyTokenAt(token string, publicKey ed25519.PublicKey, now time.Time) (*TokenPayload, error) {
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid token format")
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode payload: %w", err)
+	}
+
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+
+	if !ed25519.Verify(publicKey, payloadBytes, sig) {
+		return nil, fmt.Errorf("invalid signature")
+	}
+
+	var payload TokenPayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, fmt.Errorf("unmarshal payload: %w", err)
+	}
+
+	if payload.ExpiresAt > 0 && time.Unix(payload.ExpiresAt, 0).Before(now) {
+		return nil, fmt.Errorf("token expired")
+	}
+
+	return &payload, nil
+}

--- a/internal/license/token_test.go
+++ b/internal/license/token_test.go
@@ -1,0 +1,196 @@
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"testing"
+	"time"
+)
+
+func generateTestKeys(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+func TestSignAndVerifyToken(t *testing.T) {
+	pub, priv := generateTestKeys(t)
+
+	payload := TokenPayload{
+		Key:       "sk_test_123",
+		Tier:      "power",
+		ExpiresAt: time.Now().Add(24 * time.Hour).Unix(),
+	}
+
+	token, err := SignToken(payload, priv)
+	if err != nil {
+		t.Fatalf("SignToken: %v", err)
+	}
+
+	got, err := VerifyToken(token, pub)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+
+	if got.Key != payload.Key {
+		t.Errorf("Key = %q, want %q", got.Key, payload.Key)
+	}
+	if got.Tier != payload.Tier {
+		t.Errorf("Tier = %q, want %q", got.Tier, payload.Tier)
+	}
+	if got.ExpiresAt != payload.ExpiresAt {
+		t.Errorf("ExpiresAt = %d, want %d", got.ExpiresAt, payload.ExpiresAt)
+	}
+}
+
+func TestVerifyToken_WrongKey(t *testing.T) {
+	_, priv := generateTestKeys(t)
+	otherPub, _ := generateTestKeys(t)
+
+	token, err := SignToken(TokenPayload{
+		Key:       "sk_test",
+		Tier:      "pro",
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	}, priv)
+	if err != nil {
+		t.Fatalf("SignToken: %v", err)
+	}
+
+	_, err = VerifyToken(token, otherPub)
+	if err == nil {
+		t.Fatal("expected error verifying with wrong public key")
+	}
+	if err.Error() != "invalid signature" {
+		t.Errorf("error = %q, want %q", err.Error(), "invalid signature")
+	}
+}
+
+func TestVerifyToken_Expired(t *testing.T) {
+	pub, priv := generateTestKeys(t)
+
+	token, err := SignToken(TokenPayload{
+		Key:       "sk_test",
+		Tier:      "pro",
+		ExpiresAt: time.Now().Add(-time.Hour).Unix(), // expired 1 hour ago
+	}, priv)
+	if err != nil {
+		t.Fatalf("SignToken: %v", err)
+	}
+
+	_, err = VerifyToken(token, pub)
+	if err == nil {
+		t.Fatal("expected error for expired token")
+	}
+	if err.Error() != "token expired" {
+		t.Errorf("error = %q, want %q", err.Error(), "token expired")
+	}
+}
+
+func TestVerifyToken_NoExpiry(t *testing.T) {
+	pub, priv := generateTestKeys(t)
+
+	token, err := SignToken(TokenPayload{
+		Key:       "sk_test",
+		Tier:      "power",
+		ExpiresAt: 0, // no expiry
+	}, priv)
+	if err != nil {
+		t.Fatalf("SignToken: %v", err)
+	}
+
+	got, err := VerifyToken(token, pub)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if got.Tier != "power" {
+		t.Errorf("Tier = %q, want %q", got.Tier, "power")
+	}
+}
+
+func TestVerifyToken_TamperedPayload(t *testing.T) {
+	pub, priv := generateTestKeys(t)
+
+	token, err := SignToken(TokenPayload{
+		Key:  "sk_test",
+		Tier: "free",
+	}, priv)
+	if err != nil {
+		t.Fatalf("SignToken: %v", err)
+	}
+
+	// Tamper: replace payload with one that says "power"
+	tampered := base64.RawURLEncoding.EncodeToString([]byte(`{"key":"sk_test","tier":"power","exp":0}`))
+	origParts := splitToken(token)
+	tamperedToken := tampered + "." + origParts[1]
+
+	_, err = VerifyToken(tamperedToken, pub)
+	if err == nil {
+		t.Fatal("expected error for tampered token")
+	}
+	if err.Error() != "invalid signature" {
+		t.Errorf("error = %q, want %q", err.Error(), "invalid signature")
+	}
+}
+
+func splitToken(token string) [2]string {
+	for i, c := range token {
+		if c == '.' {
+			return [2]string{token[:i], token[i+1:]}
+		}
+	}
+	return [2]string{token, ""}
+}
+
+func TestVerifyToken_InvalidFormat(t *testing.T) {
+	pub, _ := generateTestKeys(t)
+
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{"no dot", "nodothere"},
+		{"empty", ""},
+		{"bad base64 payload", "!!!.YWJj"},
+		{"bad base64 sig", "YWJj.!!!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := VerifyToken(tt.token, pub)
+			if err == nil {
+				t.Error("expected error for invalid format")
+			}
+		})
+	}
+}
+
+func TestVerifyTokenAt_CustomTime(t *testing.T) {
+	pub, priv := generateTestKeys(t)
+
+	expiry := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	token, err := SignToken(TokenPayload{
+		Key:       "sk_test",
+		Tier:      "pro",
+		ExpiresAt: expiry.Unix(),
+	}, priv)
+	if err != nil {
+		t.Fatalf("SignToken: %v", err)
+	}
+
+	// Before expiry — should succeed
+	before := expiry.Add(-24 * time.Hour)
+	_, err = VerifyTokenAt(token, pub, before)
+	if err != nil {
+		t.Errorf("VerifyTokenAt before expiry should succeed: %v", err)
+	}
+
+	// After expiry — should fail
+	after := expiry.Add(24 * time.Hour)
+	_, err = VerifyTokenAt(token, pub, after)
+	if err == nil {
+		t.Error("VerifyTokenAt after expiry should fail")
+	}
+}

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -14,6 +14,9 @@ import (
 
 // DashboardData holds all data needed to render the dashboard page.
 type DashboardData struct {
+	// License tier (free, pro, power)
+	Tier string
+
 	// Node info
 	NodeAlias  string
 	NodePubKey string
@@ -124,6 +127,7 @@ func (h *Handler) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 	since7d := now.AddDate(0, 0, -7)
 	sinceYTD := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
 	data := DashboardData{
+		Tier:        string(TierFromContext(ctx)),
 		DefaultFrom: since30d.Format("2006-01-02"),
 		DefaultTo:   now.Format("2006-01-02"),
 	}

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -1,0 +1,64 @@
+package web
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/satsbook/satsbook/internal/license"
+)
+
+type contextKey string
+
+const tierContextKey contextKey = "tier"
+
+// TierFromContext extracts the license tier from the request context.
+func TierFromContext(ctx context.Context) license.Tier {
+	if t, ok := ctx.Value(tierContextKey).(license.Tier); ok {
+		return t
+	}
+	return license.TierFree
+}
+
+// tierMiddleware injects the current license tier into every request's context.
+func tierMiddleware(checker license.Checker, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), tierContextKey, checker.CurrentTier())
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// requireTier wraps a handler and blocks access unless the user's tier meets the minimum.
+// For HTMX requests it returns a 200 with an upgrade partial; for API requests it returns 402.
+func requireTier(minTier license.Tier, renderer *Renderer) func(http.HandlerFunc) http.HandlerFunc {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			current := TierFromContext(r.Context())
+			if license.TierAtLeast(current, minTier) {
+				next(w, r)
+				return
+			}
+
+			// Blocked — render upgrade prompt.
+			if r.Header.Get("HX-Request") == "true" {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				data := upgradeData{
+					RequiredTier: string(minTier),
+					CurrentTier:  string(current),
+				}
+				if err := renderer.Render(w, "upgrade_required", data); err != nil {
+					http.Error(w, "upgrade required", http.StatusPaymentRequired)
+				}
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPaymentRequired)
+			w.Write([]byte(`{"error":"upgrade required","required_tier":"` + string(minTier) + `"}`))
+		}
+	}
+}
+
+type upgradeData struct {
+	RequiredTier string
+	CurrentTier  string
+}

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -1,0 +1,142 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/satsbook/satsbook/internal/license"
+)
+
+type stubChecker struct {
+	tier license.Tier
+}
+
+func (s stubChecker) CurrentTier() license.Tier        { return s.tier }
+func (s stubChecker) Verify(_ context.Context) error   { return nil }
+
+func TestTierFromContext_Default(t *testing.T) {
+	ctx := context.Background()
+	if got := TierFromContext(ctx); got != license.TierFree {
+		t.Errorf("TierFromContext(empty) = %q, want %q", got, license.TierFree)
+	}
+}
+
+func TestTierFromContext_WithValue(t *testing.T) {
+	ctx := context.WithValue(context.Background(), tierContextKey, license.TierPower)
+	if got := TierFromContext(ctx); got != license.TierPower {
+		t.Errorf("TierFromContext = %q, want %q", got, license.TierPower)
+	}
+}
+
+func TestTierMiddleware_InjectsContext(t *testing.T) {
+	checker := stubChecker{tier: license.TierPro}
+
+	var capturedTier license.Tier
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedTier = TierFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := tierMiddleware(checker, inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if capturedTier != license.TierPro {
+		t.Errorf("middleware injected tier = %q, want %q", capturedTier, license.TierPro)
+	}
+}
+
+func TestRequireTier_Allowed(t *testing.T) {
+	renderer := NewRenderer()
+	gate := requireTier(license.TierPro, renderer)
+
+	called := false
+	handler := gate(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/pro-feature", nil)
+	ctx := context.WithValue(req.Context(), tierContextKey, license.TierPower)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("expected handler to be called when tier is sufficient")
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequireTier_Blocked_API(t *testing.T) {
+	renderer := NewRenderer()
+	gate := requireTier(license.TierPro, renderer)
+
+	called := false
+	handler := gate(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/pro-feature", nil)
+	ctx := context.WithValue(req.Context(), tierContextKey, license.TierFree)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Error("handler should NOT be called when tier is insufficient")
+	}
+	if rr.Code != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusPaymentRequired)
+	}
+}
+
+func TestRequireTier_Blocked_HTMX(t *testing.T) {
+	renderer := NewRenderer()
+	gate := requireTier(license.TierPower, renderer)
+
+	handler := gate(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should NOT be called")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/power-feature", nil)
+	req.Header.Set("HX-Request", "true")
+	ctx := context.WithValue(req.Context(), tierContextKey, license.TierPro)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// HTMX blocked requests return 200 with upgrade partial
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d for HTMX upgrade partial", rr.Code, http.StatusOK)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+}
+
+func TestRequireTier_ExactTier(t *testing.T) {
+	renderer := NewRenderer()
+	gate := requireTier(license.TierPro, renderer)
+
+	called := false
+	handler := gate(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/pro-feature", nil)
+	ctx := context.WithValue(req.Context(), tierContextKey, license.TierPro)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("handler should be called when tier equals required tier")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/satsbook/satsbook/internal/license"
 )
 
 // Server is the HTTP server for the dashboard API.
@@ -16,7 +18,7 @@ type Server struct {
 }
 
 // NewServer creates a new HTTP server with routing and middleware.
-func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
+func NewServer(handler *Handler, port int, logger *log.Logger, checker license.Checker) *Server {
 	mux := http.NewServeMux()
 
 	// HTML routes
@@ -56,7 +58,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger) *Server {
 	return &Server{
 		httpServer: &http.Server{
 			Addr:         fmt.Sprintf(":%d", port),
-			Handler:      requestLogger(mux, logger),
+			Handler:      tierMiddleware(checker, requestLogger(mux, logger)),
 			ReadTimeout:  10 * time.Second,
 			WriteTimeout: 5 * time.Minute,
 			IdleTimeout:  60 * time.Second,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/license"
 )
 
 func TestNewServer_RoutesRegistered(t *testing.T) {
@@ -20,7 +21,7 @@ func TestNewServer_RoutesRegistered(t *testing.T) {
 	price := &mockPrice{err: nil}
 	logger := log.New(os.Stderr, "[test] ", 0)
 	h := NewHandler(store, nil, price, &mockImportStore{}, logger)
-	srv := NewServer(h, 0, logger)
+	srv := NewServer(h, 0, logger, license.FreeChecker{})
 
 	if srv.httpServer == nil {
 		t.Fatal("expected httpServer to be set")
@@ -39,7 +40,7 @@ func TestServer_StartAndShutdown(t *testing.T) {
 	logger := log.New(os.Stderr, "[test] ", 0)
 	h := NewHandler(store, nil, &mockPrice{}, &mockImportStore{}, logger)
 	// Use port 0 to let the OS pick a free port
-	srv := NewServer(h, 0, logger)
+	srv := NewServer(h, 0, logger, license.FreeChecker{})
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -284,3 +284,17 @@ tr:hover { background: var(--bg-hover); }
 @media (max-width: 480px) {
   .cards { grid-template-columns: 1fr; }
 }
+
+/* Tier badges */
+.tier-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.tier-free { background: var(--border); color: var(--text-muted); }
+.tier-pro { background: var(--accent-dim); color: var(--accent); }
+.tier-power { background: var(--blue-dim); color: var(--blue); }

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/license"
 )
 
 // Renderer parses and renders HTML templates from the embedded filesystem.
@@ -57,6 +58,9 @@ func NewRenderer() *Renderer {
 			return costUSD / (float64(sats) / 1e8)
 		},
 		"portfolioChart": portfolioChart,
+		"tierAtLeast": func(current, required string) bool {
+			return license.TierAtLeast(license.Tier(current), license.Tier(required))
+		},
 		"dict": func(kv ...interface{}) (map[string]interface{}, error) {
 			if len(kv)%2 != 0 {
 				return nil, fmt.Errorf("dict requires even number of args")
@@ -92,6 +96,7 @@ func NewRenderer() *Renderer {
 			"templates/wallets_layout.html",
 			"templates/exchange_detail.html",
 			"templates/wallet_detail.html",
+			"templates/partials/upgrade_required.html",
 		),
 	)
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -37,6 +37,7 @@
       <span>
         {{if .BTCPriceUSD}}BTC {{formatUSD .BTCPriceUSD}} (mempool.space, {{timeAgo .PriceFetchedAt}}){{else}}BTC price unavailable{{end}}
       </span>
+      {{if .Tier}}<span class="tier-badge tier-{{.Tier}}">{{.Tier}}</span>{{end}}
     </div>
   </footer>
 </body>

--- a/internal/web/templates/partials/upgrade_required.html
+++ b/internal/web/templates/partials/upgrade_required.html
@@ -1,0 +1,13 @@
+{{define "upgrade_required"}}
+<div class="upgrade-required">
+    <div class="upgrade-icon">&#x1f512;</div>
+    <h3>{{if eq .RequiredTier "power"}}Power{{else}}Pro{{end}} Feature</h3>
+    <p>This feature requires a <strong>{{if eq .RequiredTier "power"}}Power{{else}}Pro{{end}}</strong> subscription.</p>
+    {{if eq .CurrentTier "free"}}
+    <p class="upgrade-hint">You are currently on the <strong>Free</strong> tier.</p>
+    {{else if eq .CurrentTier "pro"}}
+    <p class="upgrade-hint">You are currently on the <strong>Pro</strong> tier. Upgrade to <strong>Power</strong> to unlock this feature.</p>
+    {{end}}
+    <p class="upgrade-cta">Set <code>SATSBOOK_LICENSE_KEY</code> in your Umbrel environment to activate.</p>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary

- Adds phone-home license validation with Ed25519 signed tokens and 7-day grace period
- Three tiers (free/pro/power) with feature-to-tier mapping and HTTP middleware gating
- Fake validation servers are rejected — only tokens signed with the embedded public key's corresponding private key are accepted
- Tier badge displayed in dashboard footer
- `licsign` CLI for keypair generation and token signing, `demoserver` for testing

### New packages/files
- `internal/license/` — tier system, token signing/verification, phone-home checker with cache fallback
- `internal/db/license.go` — migration 7 (license_cache table), get/update cached license
- `internal/web/middleware.go` — tier injection middleware, `requireTier` gate (402 for API, upgrade partial for HTMX)
- `cmd/licsign/` — CLI for keypair generation and manual token signing
- `cmd/demoserver/` — test validation server (real/fake modes, private key via env var)

### Config
- `SATSBOOK_LICENSE_KEY` — customer license key
- `SATSBOOK_LICENSE_URL` — validation endpoint (defaults to `https://api.satsbook.com/v1/license/validate`)

## Test plan

- [x] `go test ./internal/license/...` — token signing, verification, checker with real/fake keys, grace period, cache fallback
- [x] `go test ./internal/db/...` — license cache CRUD
- [x] `go test ./internal/web/...` — tier middleware injection, require tier gating (API 402, HTMX upgrade partial)
- [x] End-to-end demo: no key → free, real server → power, fake server → rejected (free)

Closes #13, closes #15