### PR TITLE
chore: ignore cmd/seedemo/ and -db local dev artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 /licsign
 /demoserver
 /seedemo
+
+# Local dev tools (not for distribution)
+cmd/seedemo/
+-db
 *.exe
 *.dll
 *.so

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-lndcheck run run-binary run-local run-umbrel run-daemon stop test clean docker docker-multiarch
+.PHONY: build build-lndcheck run run-binary run-local run-umbrel run-daemon run-demo stop stop-demo test clean docker docker-multiarch
 
 # Load environment variables from .env file if it exists
 ifneq (,$(wildcard .env))
@@ -31,12 +31,26 @@ run-daemon: build
 	@bash -c 'set -a && source .env && nohup ./satsbook > satsbook.log 2>&1 & echo $$! > satsbook.pid'
 	@echo "Started (PID $$(cat satsbook.pid)). Logs: satsbook.log"
 
+# Run the demo license validation server in the background (requires SATSBOOK_LICENSE_SIGNING_KEY in .env)
+run-demo:
+	@go build -o demoserver ./cmd/demoserver
+	@bash -c 'set -a && source .env && nohup ./demoserver real 3098 > demoserver.log 2>&1 & echo $$! > demoserver.pid'
+	@echo "Demo validation server started (PID $$(cat demoserver.pid), port 3098). Logs: demoserver.log"
+
 # Stop the daemonized process
 stop:
 	@if [ -f satsbook.pid ]; then \
-		kill $$(cat satsbook.pid) && rm satsbook.pid && echo "Stopped."; \
+		kill $$(cat satsbook.pid) && rm satsbook.pid && echo "Stopped satsbook."; \
 	else \
 		echo "No satsbook.pid found — is it running?"; \
+	fi
+
+# Stop the demo validation server
+stop-demo:
+	@if [ -f demoserver.pid ]; then \
+		kill $$(cat demoserver.pid) && rm demoserver.pid && echo "Stopped demo server."; \
+	else \
+		echo "No demoserver.pid found — is it running?"; \
 	fi
 
 # Run as Umbrel app (uses Umbrel-injected env vars, no .env file)
@@ -57,5 +71,5 @@ docker-multiarch:
 
 # Clean build artifacts
 clean:
-	rm -f satsbook lndcheck
+	rm -f satsbook lndcheck demoserver
 	go clean

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ run-demo:
 # Stop the daemonized process
 stop:
 	@if [ -f satsbook.pid ]; then \
-		kill $$(cat satsbook.pid) && rm satsbook.pid && echo "Stopped satsbook."; \
+		kill $$(cat satsbook.pid) 2>/dev/null; rm satsbook.pid; echo "Stopped satsbook."; \
 	else \
 		echo "No satsbook.pid found — is it running?"; \
 	fi
@@ -48,7 +48,7 @@ stop:
 # Stop the demo validation server
 stop-demo:
 	@if [ -f demoserver.pid ]; then \
-		kill $$(cat demoserver.pid) && rm demoserver.pid && echo "Stopped demo server."; \
+		kill $$(cat demoserver.pid) 2>/dev/null; rm demoserver.pid; echo "Stopped demo server."; \
 	else \
 		echo "No demoserver.pid found — is it running?"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-lndcheck run run-binary run-local run-umbrel test clean docker docker-multiarch
+.PHONY: build build-lndcheck run run-binary run-local run-umbrel run-daemon stop test clean docker docker-multiarch
 
 # Load environment variables from .env file if it exists
 ifneq (,$(wildcard .env))
@@ -25,6 +25,19 @@ run-binary: build
 # Run the built binary via bash (explicit env sourcing, works from fish/zsh/bash)
 run-local: build
 	bash -c 'set -a && source .env && ./satsbook'
+
+# Run in the background, survives terminal exit (logs → satsbook.log, PID → satsbook.pid)
+run-daemon: build
+	@bash -c 'set -a && source .env && nohup ./satsbook > satsbook.log 2>&1 & echo $$! > satsbook.pid'
+	@echo "Started (PID $$(cat satsbook.pid)). Logs: satsbook.log"
+
+# Stop the daemonized process
+stop:
+	@if [ -f satsbook.pid ]; then \
+		kill $$(cat satsbook.pid) && rm satsbook.pid && echo "Stopped."; \
+	else \
+		echo "No satsbook.pid found — is it running?"; \
+	fi
 
 # Run as Umbrel app (uses Umbrel-injected env vars, no .env file)
 run-umbrel: build


### PR DESCRIPTION
## Summary
- Adds `cmd/seedemo/` and `-db` to `.gitignore` to prevent local dev artifacts from being tracked

These are local-only: `cmd/seedemo/` is a demo data seed script useful for testing but not meant for distribution, and `-db` is a misnamed artifact from local runs.