### PR TITLE
feat(license): license validation server and customer database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /licsign
 /demoserver
 /seedemo
+/licenseserver
 
 # Local dev tools (not for distribution)
 cmd/seedemo/
@@ -19,6 +20,10 @@ dist/
 *.db
 *.sqlite
 *.sqlite3
+
+# Runtime artifacts
+*.pid
+*.log
 
 # Secrets and config
 .env

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-lndcheck run run-binary run-local run-umbrel run-daemon run-demo stop stop-demo test clean docker docker-multiarch
+.PHONY: build build-lndcheck build-licenseserver run run-binary run-local run-umbrel run-daemon run-demo run-licenseserver stop stop-demo stop-licenseserver test clean docker docker-multiarch
 
 # Load environment variables from .env file if it exists
 ifneq (,$(wildcard .env))
@@ -53,6 +53,23 @@ stop-demo:
 		echo "No demoserver.pid found — is it running?"; \
 	fi
 
+# Build the license server
+build-licenseserver:
+	go build -o licenseserver ./cmd/licenseserver
+
+# Run the license server in the background
+run-licenseserver: build-licenseserver
+	@bash -c 'set -a && source .env && nohup ./licenseserver serve > licenseserver.log 2>&1 & echo $$! > licenseserver.pid'
+	@echo "License server started (PID $$(cat licenseserver.pid), port $${PORT:-8080}). Logs: licenseserver.log"
+
+# Stop the license server
+stop-licenseserver:
+	@if [ -f licenseserver.pid ]; then \
+		kill $$(cat licenseserver.pid) 2>/dev/null; rm licenseserver.pid; echo "Stopped license server."; \
+	else \
+		echo "No licenseserver.pid found — is it running?"; \
+	fi
+
 # Run as Umbrel app (uses Umbrel-injected env vars, no .env file)
 run-umbrel: build
 	./satsbook
@@ -71,5 +88,5 @@ docker-multiarch:
 
 # Clean build artifacts
 clean:
-	rm -f satsbook lndcheck demoserver
+	rm -f satsbook lndcheck demoserver licenseserver
 	go clean

--- a/cmd/licenseserver/main.go
+++ b/cmd/licenseserver/main.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/satsbook/satsbook/internal/license"
+	"github.com/satsbook/satsbook/internal/licensedb"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "serve":
+		cmdServe(os.Args[2:])
+	case "create":
+		cmdCreate(os.Args[2:])
+	case "revoke":
+		cmdRevoke(os.Args[2:])
+	case "upgrade":
+		cmdUpgrade(os.Args[2:])
+	case "list":
+		cmdList(os.Args[2:])
+	default:
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage: licenseserver <command> [flags]
+
+Commands:
+  serve     Start the license validation HTTP server
+  create    Create a new license key
+  revoke    Revoke a license key
+  upgrade   Change a license's tier
+  list      List all licenses
+`)
+}
+
+func getDBPath() string {
+	p := os.Getenv("SATSBOOK_LICENSE_DB_PATH")
+	if p == "" {
+		p = "licenses.db"
+	}
+	return p
+}
+
+func openStore() *licensedb.Store {
+	s, err := licensedb.Open(getDBPath())
+	if err != nil {
+		log.Fatalf("open database: %v", err)
+	}
+	return s
+}
+
+func cmdServe(args []string) {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	port := fs.String("port", "", "listen port (default: $PORT or 8080)")
+	fs.Parse(args)
+
+	p := *port
+	if p == "" {
+		p = os.Getenv("PORT")
+	}
+	if p == "" {
+		p = "8080"
+	}
+
+	privKeyHex := os.Getenv("SATSBOOK_LICENSE_SIGNING_KEY")
+	if privKeyHex == "" {
+		log.Fatal("SATSBOOK_LICENSE_SIGNING_KEY env var is required")
+	}
+	privBytes, err := hex.DecodeString(privKeyHex)
+	if err != nil || len(privBytes) != ed25519.PrivateKeySize {
+		log.Fatalf("invalid SATSBOOK_LICENSE_SIGNING_KEY (expected %d hex-encoded bytes)", ed25519.PrivateKeySize)
+	}
+	priv := ed25519.PrivateKey(privBytes)
+
+	store := openStore()
+	defer store.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/v1/license/validate", validateHandler(store, priv))
+
+	addr := ":" + p
+	log.Printf("license server listening on %s (db=%s)", addr, getDBPath())
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+type validateRequest struct {
+	Key string `json:"key"`
+}
+
+type validateResponse struct {
+	Valid bool   `json:"valid"`
+	Tier  string `json:"tier"`
+	Token string `json:"token"`
+}
+
+func validateHandler(store *licensedb.Store, priv ed25519.PrivateKey) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req validateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Key == "" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(validateResponse{Valid: false})
+			return
+		}
+
+		lic, err := store.Lookup(req.Key)
+		if err != nil {
+			log.Printf("lookup error: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		if !lic.IsValid() {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(validateResponse{Valid: false})
+			return
+		}
+
+		token, err := license.SignToken(license.TokenPayload{
+			Key:       req.Key,
+			Tier:      lic.Tier,
+			ExpiresAt: time.Now().Add(30 * 24 * time.Hour).Unix(),
+		}, priv)
+		if err != nil {
+			log.Printf("sign error: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(validateResponse{
+			Valid: true,
+			Tier:  lic.Tier,
+			Token: token,
+		})
+	}
+}
+
+func cmdCreate(args []string) {
+	fs := flag.NewFlagSet("create", flag.ExitOnError)
+	email := fs.String("email", "", "customer email")
+	tier := fs.String("tier", "pro", "license tier (free, pro, power)")
+	days := fs.Int("days", 0, "days until expiry (0 = no expiry)")
+	fs.Parse(args)
+
+	var expiresAt *time.Time
+	if *days > 0 {
+		t := time.Now().Add(time.Duration(*days) * 24 * time.Hour)
+		expiresAt = &t
+	}
+
+	store := openStore()
+	defer store.Close()
+
+	lic, err := store.Create(*email, *tier, expiresAt)
+	if err != nil {
+		log.Fatalf("create: %v", err)
+	}
+
+	fmt.Printf("Created license:\n")
+	fmt.Printf("  Key:     %s\n", lic.LicenseKey)
+	fmt.Printf("  Email:   %s\n", lic.Email)
+	fmt.Printf("  Tier:    %s\n", lic.Tier)
+	if lic.ExpiresAt != nil {
+		fmt.Printf("  Expires: %s\n", lic.ExpiresAt.Format(time.RFC3339))
+	} else {
+		fmt.Printf("  Expires: never\n")
+	}
+}
+
+func cmdRevoke(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintf(os.Stderr, "usage: licenseserver revoke <license_key>\n")
+		os.Exit(1)
+	}
+
+	store := openStore()
+	defer store.Close()
+
+	if err := store.Revoke(args[0]); err != nil {
+		log.Fatalf("revoke: %v", err)
+	}
+	fmt.Printf("Revoked: %s\n", args[0])
+}
+
+func cmdUpgrade(args []string) {
+	fs := flag.NewFlagSet("upgrade", flag.ExitOnError)
+	tier := fs.String("tier", "", "new tier (pro, power)")
+	fs.Parse(args)
+
+	if fs.NArg() < 1 || *tier == "" {
+		fmt.Fprintf(os.Stderr, "usage: licenseserver upgrade -tier <tier> <license_key>\n")
+		os.Exit(1)
+	}
+
+	store := openStore()
+	defer store.Close()
+
+	if err := store.Upgrade(fs.Arg(0), *tier); err != nil {
+		log.Fatalf("upgrade: %v", err)
+	}
+	fmt.Printf("Upgraded %s to %s\n", fs.Arg(0), *tier)
+}
+
+func cmdList(args []string) {
+	store := openStore()
+	defer store.Close()
+
+	licenses, err := store.List()
+	if err != nil {
+		log.Fatalf("list: %v", err)
+	}
+
+	if len(licenses) == 0 {
+		fmt.Println("No licenses found.")
+		return
+	}
+
+	fmt.Printf("%-30s %-25s %-8s %-10s %s\n", "KEY", "EMAIL", "TIER", "STATUS", "EXPIRES")
+	for _, l := range licenses {
+		exp := "never"
+		if l.ExpiresAt != nil {
+			exp = l.ExpiresAt.Format("2006-01-02")
+		}
+		fmt.Printf("%-30s %-25s %-8s %-10s %s\n", l.LicenseKey, l.Email, l.Tier, l.Status, exp)
+	}
+}

--- a/deploy/licenseserver/Dockerfile
+++ b/deploy/licenseserver/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /licenseserver ./cmd/licenseserver
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /licenseserver /usr/local/bin/licenseserver
+EXPOSE 8080
+ENTRYPOINT ["licenseserver"]
+CMD ["serve"]

--- a/internal/licensedb/integration_test.go
+++ b/internal/licensedb/integration_test.go
@@ -1,0 +1,104 @@
+package licensedb_test
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/satsbook/satsbook/internal/license"
+	"github.com/satsbook/satsbook/internal/licensedb"
+)
+
+// TestValidateFlow tests the full flow: create key → validate → verify token.
+func TestValidateFlow(t *testing.T) {
+	store, err := licensedb.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// Create a license
+	lic, err := store.Create("user@test.com", "pro", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up a validate handler (simulates the server)
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Key string `json:"key"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+
+		found, _ := store.Lookup(req.Key)
+		if !found.IsValid() {
+			json.NewEncoder(w).Encode(map[string]any{"valid": false})
+			return
+		}
+
+		token, _ := license.SignToken(license.TokenPayload{
+			Key:       req.Key,
+			Tier:      found.Tier,
+			ExpiresAt: time.Now().Add(30 * 24 * time.Hour).Unix(),
+		}, priv)
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"valid": true,
+			"tier":  found.Tier,
+			"token": token,
+		})
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Hit the validate endpoint with a valid key
+	body := `{"key":"` + lic.LicenseKey + `"}`
+	resp, err := http.Post(srv.URL, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Valid bool   `json:"valid"`
+		Tier  string `json:"tier"`
+		Token string `json:"token"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	if !result.Valid {
+		t.Fatal("expected valid=true")
+	}
+	if result.Tier != "pro" {
+		t.Errorf("expected pro, got %s", result.Tier)
+	}
+
+	// Verify the token signature
+	payload, err := license.VerifyToken(result.Token, pub)
+	if err != nil {
+		t.Fatalf("verify token: %v", err)
+	}
+	if payload.Tier != "pro" {
+		t.Errorf("token tier: expected pro, got %s", payload.Tier)
+	}
+
+	// Now revoke and try again
+	store.Revoke(lic.LicenseKey)
+	body = `{"key":"` + lic.LicenseKey + `"}`
+	resp2, _ := http.Post(srv.URL, "application/json", strings.NewReader(body))
+	defer resp2.Body.Close()
+
+	var result2 struct {
+		Valid bool `json:"valid"`
+	}
+	json.NewDecoder(resp2.Body).Decode(&result2)
+	if result2.Valid {
+		t.Error("revoked license should return valid=false")
+	}
+}

--- a/internal/licensedb/integration_test.go
+++ b/internal/licensedb/integration_test.go
@@ -91,7 +91,10 @@ func TestValidateFlow(t *testing.T) {
 	// Now revoke and try again
 	store.Revoke(lic.LicenseKey)
 	body = `{"key":"` + lic.LicenseKey + `"}`
-	resp2, _ := http.Post(srv.URL, "application/json", strings.NewReader(body))
+	resp2, err := http.Post(srv.URL, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer resp2.Body.Close()
 
 	var result2 struct {

--- a/internal/licensedb/store.go
+++ b/internal/licensedb/store.go
@@ -1,0 +1,179 @@
+package licensedb
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const migration = `
+CREATE TABLE IF NOT EXISTS licenses (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    license_key TEXT NOT NULL UNIQUE,
+    email       TEXT,
+    tier        TEXT NOT NULL DEFAULT 'free',
+    status      TEXT NOT NULL DEFAULT 'active',
+    expires_at  DATETIME,
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+type License struct {
+	ID         int64
+	LicenseKey string
+	Email      string
+	Tier       string
+	Status     string
+	ExpiresAt  *time.Time
+	CreatedAt  time.Time
+}
+
+type Store struct {
+	db *sql.DB
+}
+
+func Open(dsn string) (*Store, error) {
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	if _, err := db.Exec(migration); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+	return &Store{db: db}, nil
+}
+
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
+// Lookup finds a license by key. Returns nil if not found.
+func (s *Store) Lookup(key string) (*License, error) {
+	row := s.db.QueryRow(
+		`SELECT id, license_key, email, tier, status, expires_at, created_at FROM licenses WHERE license_key = ?`,
+		key,
+	)
+	var l License
+	var expiresAt sql.NullTime
+	err := row.Scan(&l.ID, &l.LicenseKey, &l.Email, &l.Tier, &l.Status, &expiresAt, &l.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lookup: %w", err)
+	}
+	if expiresAt.Valid {
+		l.ExpiresAt = &expiresAt.Time
+	}
+	return &l, nil
+}
+
+// IsValid returns true if the license exists, is active, and not expired.
+func (l *License) IsValid() bool {
+	if l == nil {
+		return false
+	}
+	if l.Status != "active" {
+		return false
+	}
+	if l.ExpiresAt != nil && l.ExpiresAt.Before(time.Now()) {
+		return false
+	}
+	return true
+}
+
+// Create inserts a new license with a generated key.
+func (s *Store) Create(email, tier string, expiresAt *time.Time) (*License, error) {
+	key, err := generateKey()
+	if err != nil {
+		return nil, fmt.Errorf("generate key: %w", err)
+	}
+
+	var expVal any
+	if expiresAt != nil {
+		expVal = *expiresAt
+	}
+
+	res, err := s.db.Exec(
+		`INSERT INTO licenses (license_key, email, tier, expires_at) VALUES (?, ?, ?, ?)`,
+		key, email, tier, expVal,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert: %w", err)
+	}
+
+	id, _ := res.LastInsertId()
+	return &License{
+		ID:         id,
+		LicenseKey: key,
+		Email:      email,
+		Tier:       tier,
+		Status:     "active",
+		ExpiresAt:  expiresAt,
+		CreatedAt:  time.Now(),
+	}, nil
+}
+
+// Revoke sets a license's status to "cancelled".
+func (s *Store) Revoke(key string) error {
+	res, err := s.db.Exec(`UPDATE licenses SET status = 'cancelled' WHERE license_key = ?`, key)
+	if err != nil {
+		return fmt.Errorf("revoke: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("license not found: %s", key)
+	}
+	return nil
+}
+
+// Upgrade changes a license's tier.
+func (s *Store) Upgrade(key, tier string) error {
+	res, err := s.db.Exec(`UPDATE licenses SET tier = ? WHERE license_key = ?`, tier, key)
+	if err != nil {
+		return fmt.Errorf("upgrade: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("license not found: %s", key)
+	}
+	return nil
+}
+
+// List returns all licenses.
+func (s *Store) List() ([]License, error) {
+	rows, err := s.db.Query(
+		`SELECT id, license_key, email, tier, status, expires_at, created_at FROM licenses ORDER BY created_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list: %w", err)
+	}
+	defer rows.Close()
+
+	var licenses []License
+	for rows.Next() {
+		var l License
+		var expiresAt sql.NullTime
+		if err := rows.Scan(&l.ID, &l.LicenseKey, &l.Email, &l.Tier, &l.Status, &expiresAt, &l.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		if expiresAt.Valid {
+			l.ExpiresAt = &expiresAt.Time
+		}
+		licenses = append(licenses, l)
+	}
+	return licenses, rows.Err()
+}
+
+func generateKey() (string, error) {
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "sk_" + hex.EncodeToString(b), nil
+}

--- a/internal/licensedb/store_test.go
+++ b/internal/licensedb/store_test.go
@@ -1,0 +1,170 @@
+package licensedb
+
+import (
+	"testing"
+	"time"
+)
+
+func testStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestCreateAndLookup(t *testing.T) {
+	s := testStore(t)
+
+	lic, err := s.Create("test@example.com", "pro", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if lic.LicenseKey[:3] != "sk_" {
+		t.Errorf("key should start with sk_, got %s", lic.LicenseKey)
+	}
+	if len(lic.LicenseKey) != 27 { // "sk_" + 24 hex chars
+		t.Errorf("key length should be 27, got %d", len(lic.LicenseKey))
+	}
+	if lic.Tier != "pro" {
+		t.Errorf("tier should be pro, got %s", lic.Tier)
+	}
+	if lic.Status != "active" {
+		t.Errorf("status should be active, got %s", lic.Status)
+	}
+
+	found, err := s.Lookup(lic.LicenseKey)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected license, got nil")
+	}
+	if found.Email != "test@example.com" {
+		t.Errorf("email mismatch: %s", found.Email)
+	}
+	if found.Tier != "pro" {
+		t.Errorf("tier mismatch: %s", found.Tier)
+	}
+}
+
+func TestLookupNotFound(t *testing.T) {
+	s := testStore(t)
+
+	found, err := s.Lookup("sk_nonexistent")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if found != nil {
+		t.Errorf("expected nil, got %+v", found)
+	}
+}
+
+func TestIsValid_Active(t *testing.T) {
+	s := testStore(t)
+	lic, _ := s.Create("a@b.com", "pro", nil)
+
+	found, _ := s.Lookup(lic.LicenseKey)
+	if !found.IsValid() {
+		t.Error("active license should be valid")
+	}
+}
+
+func TestIsValid_Cancelled(t *testing.T) {
+	s := testStore(t)
+	lic, _ := s.Create("a@b.com", "pro", nil)
+	s.Revoke(lic.LicenseKey)
+
+	found, _ := s.Lookup(lic.LicenseKey)
+	if found.IsValid() {
+		t.Error("cancelled license should not be valid")
+	}
+}
+
+func TestIsValid_Expired(t *testing.T) {
+	s := testStore(t)
+	past := time.Now().Add(-24 * time.Hour)
+	lic, _ := s.Create("a@b.com", "pro", &past)
+
+	found, _ := s.Lookup(lic.LicenseKey)
+	if found.IsValid() {
+		t.Error("expired license should not be valid")
+	}
+}
+
+func TestIsValid_FutureExpiry(t *testing.T) {
+	s := testStore(t)
+	future := time.Now().Add(30 * 24 * time.Hour)
+	lic, _ := s.Create("a@b.com", "pro", &future)
+
+	found, _ := s.Lookup(lic.LicenseKey)
+	if !found.IsValid() {
+		t.Error("license with future expiry should be valid")
+	}
+}
+
+func TestIsValid_Nil(t *testing.T) {
+	var l *License
+	if l.IsValid() {
+		t.Error("nil license should not be valid")
+	}
+}
+
+func TestRevoke(t *testing.T) {
+	s := testStore(t)
+	lic, _ := s.Create("a@b.com", "pro", nil)
+
+	if err := s.Revoke(lic.LicenseKey); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	found, _ := s.Lookup(lic.LicenseKey)
+	if found.Status != "cancelled" {
+		t.Errorf("expected cancelled, got %s", found.Status)
+	}
+}
+
+func TestRevokeNotFound(t *testing.T) {
+	s := testStore(t)
+	if err := s.Revoke("sk_nope"); err == nil {
+		t.Error("expected error for nonexistent key")
+	}
+}
+
+func TestUpgrade(t *testing.T) {
+	s := testStore(t)
+	lic, _ := s.Create("a@b.com", "pro", nil)
+
+	if err := s.Upgrade(lic.LicenseKey, "power"); err != nil {
+		t.Fatalf("upgrade: %v", err)
+	}
+
+	found, _ := s.Lookup(lic.LicenseKey)
+	if found.Tier != "power" {
+		t.Errorf("expected power, got %s", found.Tier)
+	}
+}
+
+func TestUpgradeNotFound(t *testing.T) {
+	s := testStore(t)
+	if err := s.Upgrade("sk_nope", "power"); err == nil {
+		t.Error("expected error for nonexistent key")
+	}
+}
+
+func TestList(t *testing.T) {
+	s := testStore(t)
+	s.Create("a@b.com", "pro", nil)
+	s.Create("c@d.com", "power", nil)
+
+	list, err := s.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 licenses, got %d", len(list))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `cmd/licenseserver/` — production license validation server with admin CLI
- Adds `internal/licensedb/` — SQLite-backed customer license store
- Adds `deploy/licenseserver/Dockerfile` — containerized deployment (Fly.io, VPS, etc.)
- Adds Makefile targets for building/running the license server locally

### Server endpoints
- `POST /v1/license/validate` — looks up key, checks status/expiry, returns signed token
- `GET /health` — health check

### Admin CLI
- `licenseserver create --email user@x.com --tier pro --days 365`
- `licenseserver revoke sk_abc123`
- `licenseserver upgrade -tier power sk_abc123`
- `licenseserver list`

### Config (env vars only — deployment-agnostic)
- `SATSBOOK_LICENSE_SIGNING_KEY` — Ed25519 private key (hex)
- `SATSBOOK_LICENSE_DB_PATH` — SQLite path (default: `licenses.db`)
- `PORT` — listen port (default: `8080`)

## Test plan
- [x] `go test ./internal/licensedb/` — 12 unit tests + 1 integration test pass
- [x] `go test ./...` — full suite passes
- [x] CLI commands work: create, list, revoke, upgrade
- [x] Docker image builds and runs (`docker run --rm licenseserver:test list`)
- [x] Manual: start server with signing key, POST a valid key, verify token

Closes #85
Closes #86