### PR TITLE
fix(config): update license validation URL to satsbook.io

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,30 @@
+# fly.toml app configuration file generated for satsbook-api on 2026-05-17T13:10:03-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'satsbook-api'
+primary_region = 'iad'
+
+[build]
+  dockerfile = 'deploy/licenseserver/Dockerfile'
+
+[env]
+  SATSBOOK_LICENSE_DB_PATH = '/data/licenses.db'
+
+[mounts]
+  source = 'licensedb'
+  destination = '/data'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '256mb'
+  cpus = 1
+  memory_mb = 256

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,7 +81,7 @@ func Load() (*Config, error) {
 
 		// License defaults
 		LicenseKey:           getEnv("SATSBOOK_LICENSE_KEY", ""),
-		LicenseValidationURL: getEnv("SATSBOOK_LICENSE_URL", "https://api.satsbook.com/v1/license/validate"),
+		LicenseValidationURL: getEnv("SATSBOOK_LICENSE_URL", "https://api.satsbook.io/v1/license/validate"),
 	}
 
 	// Validate required fields

--- a/internal/license/checker.go
+++ b/internal/license/checker.go
@@ -79,7 +79,7 @@ func withNowFunc(fn func() time.Time) Option {
 	return func(c *DefaultChecker) { c.nowFunc = fn }
 }
 
-const defaultValidationURL = "https://api.satsbook.com/v1/license/validate"
+const defaultValidationURL = "https://api.satsbook.io/v1/license/validate"
 
 // NewChecker creates a license checker with the given options.
 func NewChecker(store LicenseStore, licenseKey string, opts ...Option) *DefaultChecker {


### PR DESCRIPTION
## Summary
- Updates default license validation URL from `api.satsbook.com` to `api.satsbook.io` (correct domain)
- Adds `fly.toml` for license server deployment on Fly.io

## Files changed
- `internal/license/checker.go` — default URL constant
- `internal/config/config.go` — env var default
- `fly.toml` — Fly.io app config (satsbook-api, volume mount, env vars)

Closes #84