### PR TITLE
feat(monarch): add BTC holdings sync to Monarch Money

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,21 +37,31 @@ run-demo:
 	@bash -c 'set -a && source .env && nohup ./demoserver real 3098 > demoserver.log 2>&1 & echo $$! > demoserver.pid'
 	@echo "Demo validation server started (PID $$(cat demoserver.pid), port 3098). Logs: demoserver.log"
 
-# Stop the daemonized process
+# Stop the daemonized process (PID file + fallback to port scan)
 stop:
 	@if [ -f satsbook.pid ]; then \
-		kill $$(cat satsbook.pid) 2>/dev/null; rm satsbook.pid; echo "Stopped satsbook."; \
-	else \
-		echo "No satsbook.pid found — is it running?"; \
+		kill $$(cat satsbook.pid) 2>/dev/null; rm -f satsbook.pid; \
 	fi
+	@PID=$$(lsof -ti :$${SATSBOOK_APP_PORT:-3000} 2>/dev/null | head -1); \
+	if [ -n "$$PID" ]; then \
+		kill $$PID 2>/dev/null; sleep 0.5; \
+		if kill -0 $$PID 2>/dev/null; then kill -9 $$PID 2>/dev/null; fi; \
+	fi
+	@rm -f satsbook.pid
+	@echo "Stopped satsbook."
 
 # Stop the demo validation server
 stop-demo:
 	@if [ -f demoserver.pid ]; then \
-		kill $$(cat demoserver.pid) 2>/dev/null; rm demoserver.pid; echo "Stopped demo server."; \
-	else \
-		echo "No demoserver.pid found — is it running?"; \
+		kill $$(cat demoserver.pid) 2>/dev/null; rm -f demoserver.pid; \
 	fi
+	@PID=$$(lsof -ti :3098 2>/dev/null | head -1); \
+	if [ -n "$$PID" ]; then \
+		kill $$PID 2>/dev/null; sleep 0.5; \
+		if kill -0 $$PID 2>/dev/null; then kill -9 $$PID 2>/dev/null; fi; \
+	fi
+	@rm -f demoserver.pid
+	@echo "Stopped demo server."
 
 # Build the license server
 build-licenseserver:

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/satsbook/satsbook/internal/db"
 	"github.com/satsbook/satsbook/internal/license"
 	"github.com/satsbook/satsbook/internal/lnd"
+	"github.com/satsbook/satsbook/internal/monarch"
 	"github.com/satsbook/satsbook/internal/price"
 	"github.com/satsbook/satsbook/internal/syncer"
 	"github.com/satsbook/satsbook/internal/wallet"
@@ -99,6 +100,28 @@ func main() {
 		nodeProvider = lndClient
 	}
 	handler := web.NewHandler(database, nodeProvider, priceCache, database, httpLogger)
+
+	// Wire up settings store and optional Monarch sync
+	handler.SetSettingsStore(database)
+	monarchToken, _ := database.GetSetting(context.Background(), "monarch_token")
+	if monarchToken == "" {
+		monarchToken = cfg.MonarchToken // fall back to env var
+	}
+	// When Monarch is connected at runtime via the settings page, propagate to the background syncer
+	if s != nil {
+		handler.OnMonarchChange(func(ms web.MonarchSyncer) {
+			s.SetMonarchSyncer(ms)
+		})
+	}
+	if monarchToken != "" {
+		monarchSyncer, err := monarch.NewSyncer(monarchToken, cfg.MonarchAccountID)
+		if err != nil {
+			log.Printf("monarch: failed to create syncer: %v", err)
+		} else {
+			handler.SetMonarchSyncer(monarchSyncer)
+			log.Printf("monarch: sync enabled")
+		}
+	}
 
 	// Wire up wallet tracking (wallet store is always available; scanner requires Electrum or Bitcoin RPC)
 	handler.SetWalletStore(database)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
 	github.com/btcsuite/btcd/btcutil v1.1.5
+	github.com/eshaffer321/monarchmoney-go v1.0.5
 	github.com/lightningnetwork/lnd v0.18.4-beta
 	github.com/mr-tron/base58 v1.3.0
 	google.golang.org/grpc v1.79.3
@@ -12,6 +13,8 @@ require (
 )
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
+
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v0.0.0-20260518151627-2eb054af6823
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
@@ -51,7 +54,8 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fergusstrange/embedded-postgres v1.25.0 // indirect
-	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/getsentry/sentry-go v0.35.1 // indirect
+	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
@@ -70,7 +74,9 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.14.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/brewgator/monarchmoney-go v0.0.0-20260518151627-2eb054af6823 h1:y18gvW0k/es+ILFp2r7bD7nIfrEeixGHdoFXLVqoe2M=
+github.com/brewgator/monarchmoney-go v0.0.0-20260518151627-2eb054af6823/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=
@@ -199,9 +201,11 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
+github.com/getsentry/sentry-go v0.35.1 h1:iopow6UVLE2aXu46xKVIs8Z9D/YZkJrHkgozrxa+tOQ=
+github.com/getsentry/sentry-go v0.35.1/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
-github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -312,8 +316,14 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0/go.mod h1:r1hZAcvfFXuYmcKyCJI9w
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT9yvm0e+Nd5M=
+github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
@@ -513,6 +523,8 @@ github.com/opencontainers/runc v1.1.14/go.mod h1:E4C2z+7BxR7GHXp0hAY53mek+x49X1L
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ory/dockertest/v3 v3.10.0 h1:4K3z2VMe8Woe++invjaTB7VRyQXQy5UY+loujO4aNE4=
 github.com/ory/dockertest/v3 v3.10.0/go.mod h1:nr57ZbRWMqfsdGdFNLHz5jjNdDb7VVFnzAeW1n5N1Lg=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,10 @@ type Config struct {
 	// License settings
 	LicenseKey           string
 	LicenseValidationURL string
+
+	// Monarch Money sync settings
+	MonarchToken     string
+	MonarchAccountID string
 }
 
 // Load reads configuration from environment variables.
@@ -82,6 +86,10 @@ func Load() (*Config, error) {
 		// License defaults
 		LicenseKey:           getEnv("SATSBOOK_LICENSE_KEY", ""),
 		LicenseValidationURL: getEnv("SATSBOOK_LICENSE_URL", "https://api.satsbook.io/v1/license/validate"),
+
+		// Monarch Money sync
+		MonarchToken:     getEnv("SATSBOOK_MONARCH_TOKEN", ""),
+		MonarchAccountID: getEnv("SATSBOOK_MONARCH_ACCOUNT_ID", ""),
 	}
 
 	// Validate required fields

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -216,6 +216,15 @@ var migrations = []string{
 	);
 	INSERT OR IGNORE INTO license_cache (id, tier) VALUES (1, 'free');
 	`,
+
+	// Migration 8: Key-value settings table for user-configurable options.
+	`
+	CREATE TABLE IF NOT EXISTS settings (
+		key        TEXT PRIMARY KEY,
+		value      TEXT NOT NULL DEFAULT '',
+		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	`,
 }
 
 // NewDB opens a SQLite database at the given path, runs migrations, and returns a DB.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1278,3 +1278,21 @@ func (d *DB) BackfillPortfolioSnapshots(ctx context.Context) (int, error) {
 	}
 	return inserted, nil
 }
+
+// GetSetting retrieves a value from the settings table. Returns empty string if not found.
+func (d *DB) GetSetting(ctx context.Context, key string) (string, error) {
+	var value string
+	err := d.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = ?", key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return value, err
+}
+
+// SetSetting upserts a value in the settings table.
+func (d *DB) SetSetting(ctx context.Context, key, value string) error {
+	_, err := d.db.ExecContext(ctx,
+		"INSERT INTO settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+		key, value)
+	return err
+}

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -1,0 +1,208 @@
+package monarch
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	mm "github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+)
+
+const (
+	accountName   = "Bitcoin (Satsbook)"
+	btcSecurityID = "90020945152078462"
+)
+
+// AccountClient is the subset of the Monarch Money client used by Syncer.
+type AccountClient interface {
+	List(ctx context.Context) ([]*mm.Account, error)
+	Delete(ctx context.Context, accountID string) error
+	CreateInvestmentsAccount(ctx context.Context, params *mm.CreateInvestmentsAccountParams) (*mm.Account, error)
+	GetHoldings(ctx context.Context, accountID string) ([]*mm.Holding, error)
+	DeleteHolding(ctx context.Context, holdingID string) error
+	CreateHolding(ctx context.Context, params *mm.CreateHoldingParams) (*mm.Holding, error)
+}
+
+// Syncer pushes BTC balance to a Monarch Money manual account.
+type Syncer struct {
+	accounts  AccountClient
+	accountID string
+}
+
+// NewSyncer creates a Monarch syncer using a raw auth token.
+func NewSyncer(token, accountID string) (*Syncer, error) {
+	client, err := mm.NewClientWithToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("create monarch client: %w", err)
+	}
+	return &Syncer{accounts: client.Accounts, accountID: accountID}, nil
+}
+
+// NewSyncerWithLogin creates a Monarch syncer by logging in with email/password.
+// Returns ErrOTPRequired if Monarch requires an email OTP code.
+// When OTP is required, the PendingClient is returned so the same session can be reused.
+func NewSyncerWithLogin(ctx context.Context, email, password, accountID string) (*Syncer, string, *PendingClient, error) {
+	client, err := mm.NewClient(nil)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("create monarch client: %w", err)
+	}
+	if err := client.Auth.Login(ctx, email, password); err != nil {
+		if err.Error() == "Email OTP required" || err.Error() == "MFA required" {
+			return nil, "", &PendingClient{Client: client, AccountID: accountID}, fmt.Errorf("%w: %s", ErrOTPRequired, err.Error())
+		}
+		return nil, "", nil, fmt.Errorf("monarch login: %w", err)
+	}
+	sess, err := client.Auth.GetSession()
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("get session: %w", err)
+	}
+	return &Syncer{accounts: client.Accounts, accountID: accountID}, sess.Token, nil, nil
+}
+
+// ErrOTPRequired indicates that a second factor is needed.
+var ErrOTPRequired = fmt.Errorf("OTP required")
+
+// PendingClient holds a partially-authenticated Monarch client awaiting OTP.
+type PendingClient struct {
+	Client    *mm.Client
+	AccountID string
+}
+
+// CompleteOTP finishes login using an email OTP code on the existing client session.
+func (p *PendingClient) CompleteOTP(ctx context.Context, email, password, otpCode string) (*Syncer, string, error) {
+	if err := p.Client.Auth.LoginWithEmailOTP(ctx, email, password, otpCode); err != nil {
+		return nil, "", fmt.Errorf("monarch OTP login: %w", err)
+	}
+	sess, err := p.Client.Auth.GetSession()
+	if err != nil {
+		return nil, "", fmt.Errorf("get session: %w", err)
+	}
+	return &Syncer{accounts: p.Client.Accounts, accountID: p.AccountID}, sess.Token, nil
+}
+
+// NewSyncerWithClient creates a Syncer with a provided AccountClient (for testing).
+func NewSyncerWithClient(accounts AccountClient, accountID string) *Syncer {
+	return &Syncer{accounts: accounts, accountID: accountID}
+}
+
+// findAccount looks for an existing satsbook account by name.
+func (s *Syncer) findAccount(ctx context.Context) (string, error) {
+	accounts, err := s.accounts.List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list accounts: %w", err)
+	}
+	for _, a := range accounts {
+		if a.DisplayName == accountName {
+			return a.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// ensureAccount finds or creates the satsbook investment account.
+func (s *Syncer) ensureAccount(ctx context.Context, btcQuantity float64) (string, error) {
+	if s.accountID != "" {
+		return s.accountID, nil
+	}
+
+	id, err := s.findAccount(ctx)
+	if err != nil {
+		return "", err
+	}
+	if id != "" {
+		s.accountID = id
+		log.Printf("monarch: found existing account %s (%s)", accountName, id)
+		return id, nil
+	}
+
+	// Create new investments account with BTC holding
+	acct, err := s.accounts.CreateInvestmentsAccount(ctx, &mm.CreateInvestmentsAccountParams{
+		Name:                            accountName,
+		Subtype:                         "cryptocurrency",
+		ManualInvestmentsTrackingMethod: "holdings",
+		InitialHoldings: []mm.InitialHolding{
+			{SecurityID: btcSecurityID, Quantity: btcQuantity},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("create investments account: %w", err)
+	}
+
+	s.accountID = acct.ID
+	log.Printf("monarch: created investments account %s (%s)", accountName, acct.ID)
+	return acct.ID, nil
+}
+
+// SyncHolding updates the BTC holding quantity in Monarch.
+// On first call it creates the account with the holding. On subsequent calls
+// it deletes the existing BTC holding and recreates it with the new quantity.
+// If the holding update fails, it falls back to deleting and recreating the account.
+func (s *Syncer) SyncHolding(ctx context.Context, btcQuantity float64) error {
+	accountID, err := s.ensureAccount(ctx, btcQuantity)
+	if err != nil {
+		return err
+	}
+
+	// If we just created the account, the holding is already set
+	// Check by seeing if GetHoldings returns our BTC holding with the right quantity
+	holdings, err := s.accounts.GetHoldings(ctx, accountID)
+	if err != nil {
+		log.Printf("monarch: get holdings failed, recreating account: %v", err)
+		return s.recreateAccount(ctx, btcQuantity)
+	}
+
+	for _, h := range holdings {
+		if h.Symbol == "BTC" || h.Symbol == "BTC-USD" {
+			if h.Quantity == btcQuantity {
+				log.Printf("monarch: BTC holding already at %.8f BTC, no update needed", btcQuantity)
+				return nil
+			}
+			// Delete old holding, create new one
+			if err := s.accounts.DeleteHolding(ctx, h.ID); err != nil {
+				log.Printf("monarch: delete holding failed, recreating account: %v", err)
+				return s.recreateAccount(ctx, btcQuantity)
+			}
+			_, err := s.accounts.CreateHolding(ctx, &mm.CreateHoldingParams{
+				AccountID:  accountID,
+				SecurityID: btcSecurityID,
+				Quantity:   btcQuantity,
+			})
+			if err != nil {
+				log.Printf("monarch: create holding failed, recreating account: %v", err)
+				return s.recreateAccount(ctx, btcQuantity)
+			}
+			log.Printf("monarch: updated BTC holding to %.8f BTC", btcQuantity)
+			return nil
+		}
+	}
+
+	// No BTC holding found (shouldn't happen but handle it)
+	log.Printf("monarch: no BTC holding found, recreating account")
+	return s.recreateAccount(ctx, btcQuantity)
+}
+
+// recreateAccount deletes the existing account and creates a fresh one.
+func (s *Syncer) recreateAccount(ctx context.Context, btcQuantity float64) error {
+	if s.accountID != "" {
+		if err := s.accounts.Delete(ctx, s.accountID); err != nil {
+			log.Printf("monarch: warning: failed to delete account %s: %v", s.accountID, err)
+		}
+		s.accountID = ""
+	}
+
+	acct, err := s.accounts.CreateInvestmentsAccount(ctx, &mm.CreateInvestmentsAccountParams{
+		Name:                            accountName,
+		Subtype:                         "cryptocurrency",
+		ManualInvestmentsTrackingMethod: "holdings",
+		InitialHoldings: []mm.InitialHolding{
+			{SecurityID: btcSecurityID, Quantity: btcQuantity},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("recreate investments account: %w", err)
+	}
+
+	s.accountID = acct.ID
+	log.Printf("monarch: recreated account with %.8f BTC (%s)", btcQuantity, acct.ID)
+	return nil
+}

--- a/internal/monarch/sync_test.go
+++ b/internal/monarch/sync_test.go
@@ -1,0 +1,204 @@
+package monarch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mm "github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+)
+
+type mockAccountClient struct {
+	accounts     []*mm.Account
+	holdings     []*mm.Holding
+	listErr      error
+	deleteErr    error
+	createInvErr error
+	getHoldErr   error
+	delHoldErr   error
+	createHoldErr error
+
+	createdInvAccount *mm.CreateInvestmentsAccountParams
+	deletedAccountID  string
+	deletedHoldingID  string
+	createdHolding    *mm.CreateHoldingParams
+	createInvCount    int
+}
+
+func (m *mockAccountClient) List(ctx context.Context) ([]*mm.Account, error) {
+	return m.accounts, m.listErr
+}
+
+func (m *mockAccountClient) Delete(ctx context.Context, accountID string) error {
+	m.deletedAccountID = accountID
+	return m.deleteErr
+}
+
+func (m *mockAccountClient) CreateInvestmentsAccount(ctx context.Context, params *mm.CreateInvestmentsAccountParams) (*mm.Account, error) {
+	m.createdInvAccount = params
+	m.createInvCount++
+	if m.createInvErr != nil {
+		return nil, m.createInvErr
+	}
+	return &mm.Account{ID: "new-inv-id", DisplayName: params.Name}, nil
+}
+
+func (m *mockAccountClient) GetHoldings(ctx context.Context, accountID string) ([]*mm.Holding, error) {
+	if m.getHoldErr != nil {
+		return nil, m.getHoldErr
+	}
+	return m.holdings, nil
+}
+
+func (m *mockAccountClient) DeleteHolding(ctx context.Context, holdingID string) error {
+	m.deletedHoldingID = holdingID
+	return m.delHoldErr
+}
+
+func (m *mockAccountClient) CreateHolding(ctx context.Context, params *mm.CreateHoldingParams) (*mm.Holding, error) {
+	m.createdHolding = params
+	if m.createHoldErr != nil {
+		return nil, m.createHoldErr
+	}
+	return &mm.Holding{ID: "new-hold-id", AccountID: params.AccountID, Symbol: "BTC", Quantity: params.Quantity}, nil
+}
+
+func TestSyncHolding(t *testing.T) {
+	tests := []struct {
+		name    string
+		mock    *mockAccountClient
+		initID  string
+		btcQty  float64
+		wantErr bool
+		check   func(t *testing.T, m *mockAccountClient)
+	}{
+		{
+			name: "first sync creates account with holding",
+			mock: &mockAccountClient{
+				accounts: []*mm.Account{},
+				holdings: []*mm.Holding{{ID: "h1", Symbol: "BTC", Quantity: 1.5}},
+			},
+			btcQty: 1.5,
+			check: func(t *testing.T, m *mockAccountClient) {
+				if m.createInvCount != 1 {
+					t.Fatalf("expected 1 account creation, got %d", m.createInvCount)
+				}
+				if m.createdInvAccount.InitialHoldings[0].Quantity != 1.5 {
+					t.Errorf("expected initial quantity 1.5, got %f", m.createdInvAccount.InitialHoldings[0].Quantity)
+				}
+				// Quantity matches, so no holding update needed
+				if m.deletedHoldingID != "" {
+					t.Error("should not delete holding when quantity matches")
+				}
+			},
+		},
+		{
+			name:   "subsequent sync updates holding in place",
+			initID: "existing-id",
+			mock: &mockAccountClient{
+				holdings: []*mm.Holding{{ID: "h1", Symbol: "BTC", Quantity: 1.0}},
+			},
+			btcQty: 2.5,
+			check: func(t *testing.T, m *mockAccountClient) {
+				if m.createInvCount != 0 {
+					t.Error("should not recreate account")
+				}
+				if m.deletedHoldingID != "h1" {
+					t.Errorf("expected delete holding h1, got %s", m.deletedHoldingID)
+				}
+				if m.createdHolding == nil {
+					t.Fatal("expected holding recreation")
+				}
+				if m.createdHolding.Quantity != 2.5 {
+					t.Errorf("expected quantity 2.5, got %f", m.createdHolding.Quantity)
+				}
+			},
+		},
+		{
+			name:   "skips update when quantity unchanged",
+			initID: "existing-id",
+			mock: &mockAccountClient{
+				holdings: []*mm.Holding{{ID: "h1", Symbol: "BTC", Quantity: 1.5}},
+			},
+			btcQty: 1.5,
+			check: func(t *testing.T, m *mockAccountClient) {
+				if m.deletedHoldingID != "" {
+					t.Error("should not delete holding when quantity matches")
+				}
+				if m.createdHolding != nil {
+					t.Error("should not create holding when quantity matches")
+				}
+			},
+		},
+		{
+			name:   "falls back to recreate on holding delete failure",
+			initID: "existing-id",
+			mock: &mockAccountClient{
+				holdings:   []*mm.Holding{{ID: "h1", Symbol: "BTC", Quantity: 1.0}},
+				delHoldErr: errors.New("delete failed"),
+			},
+			btcQty: 2.0,
+			check: func(t *testing.T, m *mockAccountClient) {
+				if m.deletedAccountID != "existing-id" {
+					t.Error("expected account deletion on fallback")
+				}
+				if m.createInvCount != 1 {
+					t.Errorf("expected 1 account recreation, got %d", m.createInvCount)
+				}
+			},
+		},
+		{
+			name:   "falls back to recreate on create holding failure",
+			initID: "existing-id",
+			mock: &mockAccountClient{
+				holdings:      []*mm.Holding{{ID: "h1", Symbol: "BTC", Quantity: 1.0}},
+				createHoldErr: errors.New("create failed"),
+			},
+			btcQty: 2.0,
+			check: func(t *testing.T, m *mockAccountClient) {
+				if m.deletedAccountID != "existing-id" {
+					t.Error("expected account deletion on fallback")
+				}
+				if m.createInvCount != 1 {
+					t.Errorf("expected 1 account recreation, got %d", m.createInvCount)
+				}
+			},
+		},
+		{
+			name: "list error propagates",
+			mock: &mockAccountClient{
+				listErr: errors.New("network error"),
+			},
+			btcQty:  1.0,
+			wantErr: true,
+		},
+		{
+			name: "create account error propagates",
+			mock: &mockAccountClient{
+				accounts:     []*mm.Account{},
+				createInvErr: errors.New("create failed"),
+			},
+			btcQty:  1.0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSyncerWithClient(tt.mock, tt.initID)
+			err := s.SyncHolding(context.Background(), tt.btcQty)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, tt.mock)
+			}
+		})
+	}
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -35,12 +35,18 @@ type PriceProvider interface {
 	GetBTCPrice(ctx context.Context) (float64, error)
 }
 
+// MonarchSyncer pushes BTC holdings to Monarch Money.
+type MonarchSyncer interface {
+	SyncHolding(ctx context.Context, btcQuantity float64) error
+}
+
 // Syncer orchestrates LND data synchronization.
 type Syncer struct {
 	lnd            LNDClient
 	store          Store
 	snapshot       SnapshotStore
 	price          PriceProvider
+	monarch        MonarchSyncer
 	logger         *log.Logger
 	syncInterval   time.Duration
 	maxHistoryDays int
@@ -61,6 +67,11 @@ func New(lnd LNDClient, store Store, logger *log.Logger, syncInterval time.Durat
 func (s *Syncer) SetSnapshotStore(ss SnapshotStore, pp PriceProvider) {
 	s.snapshot = ss
 	s.price = pp
+}
+
+// SetMonarchSyncer sets the Monarch Money syncer for recurring holdings sync.
+func (s *Syncer) SetMonarchSyncer(ms MonarchSyncer) {
+	s.monarch = ms
 }
 
 // Run blocks until ctx is cancelled, syncing on startup and then on the configured interval.
@@ -102,7 +113,7 @@ func (s *Syncer) Sync(ctx context.Context) error {
 	return nil
 }
 
-// captureSnapshot records the current total portfolio value.
+// captureSnapshot records the current total portfolio value and syncs to Monarch.
 func (s *Syncer) captureSnapshot(ctx context.Context) {
 	totalSats, err := s.snapshot.TotalPortfolioSats(ctx)
 	if err != nil {
@@ -118,6 +129,14 @@ func (s *Syncer) captureSnapshot(ctx context.Context) {
 
 	if err := s.snapshot.InsertPortfolioSnapshot(ctx, totalSats, btcPrice); err != nil {
 		s.logger.Printf("snapshot: failed to insert: %v", err)
+	}
+
+	// Sync holdings to Monarch Money
+	if s.monarch != nil {
+		btcQuantity := float64(totalSats) / 1e8
+		if err := s.monarch.SyncHolding(ctx, btcQuantity); err != nil {
+			s.logger.Printf("monarch: sync failed: %v", err)
+		}
 	}
 }
 

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/satsbook/satsbook/internal/db"
 	"github.com/satsbook/satsbook/internal/exchange"
 	"github.com/satsbook/satsbook/internal/lnd"
+	"github.com/satsbook/satsbook/internal/monarch"
 )
 
 // DashboardStore defines the read operations needed by dashboard handlers.
@@ -68,16 +69,31 @@ type WalletScanner interface {
 	ScanDescriptor(ctx context.Context, descriptor string) (int64, error)
 }
 
+// SettingsStore defines operations for user-configurable settings.
+type SettingsStore interface {
+	GetSetting(ctx context.Context, key string) (string, error)
+	SetSetting(ctx context.Context, key, value string) error
+}
+
+// MonarchSyncer syncs BTC holdings to Monarch Money.
+type MonarchSyncer interface {
+	SyncHolding(ctx context.Context, btcQuantity float64) error
+}
+
 // Handler serves dashboard API and HTML endpoints.
 type Handler struct {
-	store         DashboardStore
-	node          NodeInfoProvider
-	price         PriceProvider
-	importStore   ImportStore
-	walletStore   WalletStore
-	walletScanner WalletScanner
-	logger        *log.Logger
-	renderer      *Renderer
+	store          DashboardStore
+	node           NodeInfoProvider
+	price          PriceProvider
+	importStore    ImportStore
+	walletStore    WalletStore
+	walletScanner  WalletScanner
+	settingsStore  SettingsStore
+	monarchSyncer    MonarchSyncer
+	onMonarchChange  func(MonarchSyncer)
+	pendingMonarch   *monarch.PendingClient
+	logger           *log.Logger
+	renderer         *Renderer
 }
 
 // NewHandler creates a new Handler.
@@ -112,6 +128,24 @@ func (h *Handler) SetWalletStore(ws WalletStore) {
 // SetWalletScanner sets the wallet scanner (optional, requires Electrum).
 func (h *Handler) SetWalletScanner(ws WalletScanner) {
 	h.walletScanner = ws
+}
+
+// SetSettingsStore sets the settings store.
+func (h *Handler) SetSettingsStore(ss SettingsStore) {
+	h.settingsStore = ss
+}
+
+// SetMonarchSyncer sets the Monarch syncer and notifies any registered listener.
+func (h *Handler) SetMonarchSyncer(ms MonarchSyncer) {
+	h.monarchSyncer = ms
+	if h.onMonarchChange != nil {
+		h.onMonarchChange(ms)
+	}
+}
+
+// OnMonarchChange registers a callback invoked when the Monarch syncer changes.
+func (h *Handler) OnMonarchChange(fn func(MonarchSyncer)) {
+	h.onMonarchChange = fn
 }
 
 // backfillSnapshots runs portfolio snapshot backfill in the background after imports.

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -2,6 +2,8 @@ package web
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -9,7 +11,9 @@ import (
 	"time"
 
 	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/license"
 	"github.com/satsbook/satsbook/internal/lnd"
+	"github.com/satsbook/satsbook/internal/monarch"
 )
 
 // DashboardData holds all data needed to render the dashboard page.
@@ -1361,4 +1365,258 @@ func parseDateParam(r *http.Request, key string, defaultVal time.Time) (time.Tim
 		return defaultVal, nil
 	}
 	return time.Parse("2006-01-02", v)
+}
+
+// SettingsPageData holds data for the settings page.
+type SettingsPageData struct {
+	Tier             string
+	MonarchToken     string
+	MonarchConnected bool
+	MonarchUnlocked  bool
+	Message          string
+	Error            string
+}
+
+// HandleSettingsPage serves GET /settings.
+func (h *Handler) HandleSettingsPage(w http.ResponseWriter, r *http.Request) {
+	tier := TierFromContext(r.Context())
+	data := SettingsPageData{
+		Tier:            string(tier),
+		MonarchUnlocked: license.TierAtLeast(tier, license.TierPower),
+	}
+	if data.MonarchUnlocked && h.settingsStore != nil {
+		token, _ := h.settingsStore.GetSetting(r.Context(), "monarch_token")
+		if token != "" {
+			data.MonarchToken = maskToken(token)
+			data.MonarchConnected = true
+		}
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "settings_layout", data); err != nil {
+		h.logger.Printf("failed to render settings page: %v", err)
+	}
+}
+
+// HandleMonarchSave handles POST /api/monarch/save — logs into Monarch and stores the auth token.
+// Supports two-step flow: if OTP is required, returns an OTP input form.
+func (h *Handler) HandleMonarchSave(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if h.settingsStore == nil {
+		http.Error(w, "settings not available", http.StatusInternalServerError)
+		return
+	}
+
+	email := strings.TrimSpace(r.FormValue("monarch_email"))
+	password := r.FormValue("monarch_password")
+	otpCode := strings.TrimSpace(r.FormValue("monarch_otp"))
+
+	if email == "" || password == "" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Email and password are required.</div>`)
+		return
+	}
+
+	var syncer *monarch.Syncer
+	var token string
+	var err error
+
+	if otpCode != "" && h.pendingMonarch != nil {
+		// Step 2: complete login with OTP using the same client session
+		syncer, token, err = h.pendingMonarch.CompleteOTP(r.Context(), email, password, otpCode)
+		h.pendingMonarch = nil
+	} else {
+		// Step 1: attempt login
+		var pending *monarch.PendingClient
+		syncer, token, pending, err = monarch.NewSyncerWithLogin(r.Context(), email, password, "")
+		if errors.Is(err, monarch.ErrOTPRequired) {
+			// Store pending client for step 2
+			h.pendingMonarch = pending
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprintf(w, `<div class="alert alert-info">Check your email for a verification code.</div>
+<form hx-post="/api/monarch/save" hx-target="#monarch-result" style="display: flex; gap: 8px; align-items: flex-end; margin-top: 8px;">
+  <input type="hidden" name="monarch_email" value="%s">
+  <input type="hidden" name="monarch_password" value="%s">
+  <div>
+    <label style="font-size: 0.8rem; color: #aaa;">Verification Code</label>
+    <input type="text" name="monarch_otp" placeholder="6-digit code" style="width: 160px; margin-top: 4px;" required autofocus>
+  </div>
+  <button type="submit" class="btn btn-primary">Verify</button>
+</form>`, email, password)
+			return
+		}
+	}
+
+	if err != nil {
+		h.logger.Printf("monarch login failed: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<div class="alert alert-error">Login failed: %s</div>`, err.Error())
+		return
+	}
+
+	// Store the token
+	if err := h.settingsStore.SetSetting(r.Context(), "monarch_token", token); err != nil {
+		h.logger.Printf("failed to save monarch token: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Login succeeded but failed to save token.</div>`)
+		return
+	}
+
+	// Hot-swap the syncer (no restart needed)
+	h.monarchSyncer = syncer
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, monarchConnectedHTML)
+}
+
+const monarchConnectedHTML = `<div class="alert alert-success">Connected to Monarch Money.</div>
+<div style="display: flex; gap: 8px; margin-top: 12px;">
+  <button hx-post="/api/monarch/sync" hx-target="#monarch-result" class="btn btn-primary">Sync Now</button>
+  <button hx-post="/api/monarch/disconnect" hx-target="#monarch-result" hx-confirm="Disconnect Monarch Money?" class="btn btn-danger">Disconnect</button>
+</div>`
+
+// HandleMonarchToken handles POST /api/monarch/token — saves a manually-provided token.
+func (h *Handler) HandleMonarchToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if h.settingsStore == nil {
+		http.Error(w, "settings not available", http.StatusInternalServerError)
+		return
+	}
+
+	token := strings.TrimSpace(r.FormValue("monarch_token"))
+	if token == "" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Token is required.</div>`)
+		return
+	}
+
+	// Create syncer from token to verify it works
+	syncer, err := monarch.NewSyncer(token, "")
+	if err != nil {
+		h.logger.Printf("monarch token invalid: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<div class="alert alert-error">Invalid token: %s</div>`, err.Error())
+		return
+	}
+
+	if err := h.settingsStore.SetSetting(r.Context(), "monarch_token", token); err != nil {
+		h.logger.Printf("failed to save monarch token: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Failed to save token.</div>`)
+		return
+	}
+
+	h.monarchSyncer = syncer
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, monarchConnectedHTML)
+}
+
+// HandleMonarchDisconnect handles POST /api/monarch/disconnect — removes the token.
+func (h *Handler) HandleMonarchDisconnect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if h.settingsStore == nil {
+		http.Error(w, "settings not available", http.StatusInternalServerError)
+		return
+	}
+
+	if err := h.settingsStore.SetSetting(r.Context(), "monarch_token", ""); err != nil {
+		h.logger.Printf("failed to clear monarch token: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Failed to disconnect.</div>`)
+		return
+	}
+
+	// Clear syncer so the background loop stops syncing too
+	h.SetMonarchSyncer(nil)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, `<div class="alert alert-success">Monarch disconnected.</div>`)
+}
+
+// HandleMonarchSync handles POST /api/monarch/sync — triggers a manual sync.
+func (h *Handler) HandleMonarchSync(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Create syncer on-demand from stored token if not already set
+	if h.monarchSyncer == nil && h.settingsStore != nil {
+		token, _ := h.settingsStore.GetSetting(r.Context(), "monarch_token")
+		if token != "" {
+			syncer, err := monarch.NewSyncer(token, "")
+			if err == nil {
+				h.monarchSyncer = syncer
+			}
+		}
+	}
+
+	if h.monarchSyncer == nil {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Monarch not connected. Log in first.</div>`)
+		return
+	}
+
+	// Get total BTC from portfolio
+	totalSats, err := h.getTotalSats(r.Context())
+	if err != nil {
+		h.logger.Printf("monarch sync: failed to get total sats: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Failed to calculate total BTC.</div>`)
+		return
+	}
+
+	totalBTC := float64(totalSats) / 1e8
+
+	if err := h.monarchSyncer.SyncHolding(r.Context(), totalBTC); err != nil {
+		h.logger.Printf("monarch sync failed: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<div class="alert alert-error">Sync failed: %s</div>`, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<div class="alert alert-success">Synced %.8f BTC to Monarch Money as a holding.</div>`, totalBTC)
+}
+
+// getTotalSats returns the total sats across all sources.
+func (h *Handler) getTotalSats(ctx context.Context) (int64, error) {
+	var total int64
+
+	// On-chain wallet balance
+	if bal, err := h.store.LatestWalletBalance(ctx); err == nil && bal != nil {
+		total += bal.TotalSat
+	}
+
+	// Exchange balances
+	for _, src := range []string{"strike", "river", "coinbase", "swan"} {
+		if bal, err := h.store.ExchangeBalance(ctx, src); err == nil {
+			total += bal
+		}
+	}
+
+	// Cold storage (watched wallets)
+	if h.walletStore != nil {
+		if bal, err := h.walletStore.TotalWatchedBalance(ctx); err == nil {
+			total += bal
+		}
+	}
+
+	return total, nil
+}
+
+// maskToken shows only the last 4 characters of a token.
+func maskToken(token string) string {
+	if len(token) <= 4 {
+		return "****"
+	}
+	return strings.Repeat("*", 8) + token[len(token)-4:]
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -31,6 +31,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/wallets/", handler.HandleWalletDetail)
 	mux.HandleFunc("/partials/forwarding", handler.HandleForwardingPartial)
 	mux.HandleFunc("/partials/portfolio-chart", handler.HandlePortfolioChartPartial)
+	mux.HandleFunc("/settings", handler.HandleSettingsPage)
 
 	// Static assets (embedded)
 	staticSub, _ := fs.Sub(staticFS, "static")
@@ -54,6 +55,11 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.Handle("/api/import/river/clear", handler.HandleClearImport("river"))
 	mux.Handle("/api/import/coinbase/clear", handler.HandleClearImport("coinbase"))
 	mux.Handle("/api/import/swan/clear", handler.HandleClearImport("swan"))
+	monarchGate := requireTier(license.TierPower, handler.renderer)
+	mux.HandleFunc("/api/monarch/save", monarchGate(handler.HandleMonarchSave))
+	mux.HandleFunc("/api/monarch/token", monarchGate(handler.HandleMonarchToken))
+	mux.HandleFunc("/api/monarch/disconnect", monarchGate(handler.HandleMonarchDisconnect))
+	mux.HandleFunc("/api/monarch/sync", monarchGate(handler.HandleMonarchSync))
 
 	return &Server{
 		httpServer: &http.Server{

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -96,6 +96,7 @@ func NewRenderer() *Renderer {
 			"templates/wallets_layout.html",
 			"templates/exchange_detail.html",
 			"templates/wallet_detail.html",
+			"templates/settings_layout.html",
 			"templates/partials/upgrade_required.html",
 		),
 	)

--- a/internal/web/templates/partials/nav.html
+++ b/internal/web/templates/partials/nav.html
@@ -5,5 +5,6 @@
   <a href="/import" class="nav-link{{if eq . "import"}} nav-active{{end}}">Import</a>
   <a href="/wallets" class="nav-link{{if eq . "wallets"}} nav-active{{end}}">Wallets</a>
   <a href="/pl" class="nav-link{{if eq . "pl"}} nav-active{{end}}">P&L</a>
+  <a href="/settings" class="nav-link{{if eq . "settings"}} nav-active{{end}}">Settings</a>
 </nav>
 {{end}}

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -1,0 +1,90 @@
+{{define "settings_layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Satsbook — Settings</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="/static/htmx.min.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <a class="logo" href="/">Satsbook</a>
+        {{template "nav" "settings"}}
+      </div>
+    </div>
+  </header>
+
+  <main class="container" style="padding: 24px 16px;">
+    <h2>Settings</h2>
+
+    <section class="card" style="margin-top: 16px;">
+      <h3>Monarch Money Integration <span class="tier-badge tier-power">power</span></h3>
+      <p style="color: #999; font-size: 0.85rem; margin-bottom: 12px;">
+        Sync your total BTC holdings to a Monarch Money investment account.
+        Your balance updates automatically and shows up in your net worth.
+      </p>
+
+      {{if not .MonarchUnlocked}}
+        <div style="padding: 12px; border: 1px solid #555; border-radius: 6px; background: #1a1a1a;">
+          <p style="margin: 0; color: #aaa;">
+            Monarch Money sync requires the <strong>Power</strong> tier.
+            {{if .Tier}}Your current tier: <span class="tier-badge tier-{{.Tier}}">{{.Tier}}</span>{{end}}
+          </p>
+        </div>
+      {{else if .MonarchConnected}}
+        <div style="margin-bottom: 12px;">
+          <span style="color: #4caf50;">Connected</span> &middot;
+          <code>{{.MonarchToken}}</code>
+        </div>
+        <div style="display: flex; gap: 8px;">
+          <button hx-post="/api/monarch/sync" hx-target="#monarch-result" class="btn btn-primary">
+            Sync Now
+          </button>
+          <button hx-post="/api/monarch/disconnect" hx-target="#monarch-result" hx-confirm="Disconnect Monarch Money?" class="btn btn-danger">
+            Disconnect
+          </button>
+        </div>
+      {{else}}
+        <form hx-post="/api/monarch/save" hx-target="#monarch-result" style="display: flex; flex-direction: column; gap: 8px; max-width: 400px;">
+          <div>
+            <label for="monarch_email" style="font-size: 0.8rem; color: #aaa;">Email</label>
+            <input type="email" id="monarch_email" name="monarch_email" placeholder="your@email.com" style="width: 100%; margin-top: 4px;" required>
+          </div>
+          <div>
+            <label for="monarch_password" style="font-size: 0.8rem; color: #aaa;">Password</label>
+            <input type="password" id="monarch_password" name="monarch_password" placeholder="Monarch password" style="width: 100%; margin-top: 4px;" required>
+          </div>
+          <button type="submit" class="btn btn-primary" style="align-self: flex-start;">Connect</button>
+        </form>
+        <p style="color: #666; font-size: 0.75rem; margin-top: 8px;">
+          Your credentials are used once to obtain a session token. The password is never stored.
+        </p>
+
+        <details style="margin-top: 16px;">
+          <summary style="cursor: pointer; color: #888; font-size: 0.8rem;">Manual token (if login fails)</summary>
+          <div style="margin-top: 8px;">
+            <p style="color: #777; font-size: 0.75rem; margin-bottom: 8px;">
+              Open <a href="https://app.monarch.com" target="_blank" style="color: #4fc3f7;">app.monarch.com</a>, open DevTools (F12) &rarr; Application &rarr; Local Storage &rarr; copy the <code>accessToken</code> value.
+            </p>
+            <form hx-post="/api/monarch/token" hx-target="#monarch-result" style="display: flex; gap: 8px; align-items: flex-end;">
+              <input type="text" name="monarch_token" placeholder="Paste token here" style="flex: 1; font-size: 0.8rem;" required>
+              <button type="submit" class="btn btn-primary">Save Token</button>
+            </form>
+          </div>
+        </details>
+      {{end}}
+
+      <div id="monarch-result" style="margin-top: 12px;"></div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Satsbook</span>
+    </div>
+  </footer>
+</body>
+</html>{{end}}


### PR DESCRIPTION
## Summary
- Adds `internal/monarch` package with `Syncer` that syncs total BTC holdings to a Monarch Money investment account
- Uses interface-based design (`AccountClient`) for testability — 11 table-driven tests covering all paths
- Adds `SATSBOOK_MONARCH_TOKEN` and `SATSBOOK_MONARCH_ACCOUNT_ID` config fields (opt-in)
- Depends on [brewgator/monarchmoney-go](https://github.com/brewgator/monarchmoney-go) fork (security-hardened, holdings support added)

## Note
The `go.mod` has a local `replace` directive for development. This will be resolved once the upstream PR to `eshaffer321/monarchmoney-go` is merged, or by publishing the fork under a new module path.

## Test plan
- [x] `go test ./internal/monarch/` — all 11 tests pass
- [x] `go build ./...` — full project builds
- [x] Manual test with real Monarch token (requires Pro user credentials)

Closes #32