### PR TITLE
feat: unified transaction ledger with Monarch Money sync

### DIFF
--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -104,6 +104,7 @@ func main() {
 	// Wire up settings store, transaction store, and optional Monarch sync
 	handler.SetSettingsStore(database)
 	handler.SetTransactionStore(database)
+	handler.SetMonarchTxStore(database)
 	monarchToken, _ := database.GetSetting(context.Background(), "monarch_token")
 	if monarchToken == "" {
 		monarchToken = cfg.MonarchToken // fall back to env var

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -113,6 +113,7 @@ func main() {
 	if s != nil {
 		handler.OnMonarchChange(func(ms web.MonarchSyncer) {
 			s.SetMonarchSyncer(ms)
+			s.SetMonarchTxSync(database, database)
 		})
 	}
 	if monarchToken != "" {
@@ -121,6 +122,9 @@ func main() {
 			log.Printf("monarch: failed to create syncer: %v", err)
 		} else {
 			handler.SetMonarchSyncer(monarchSyncer)
+			if s != nil {
+				s.SetMonarchTxSync(database, database)
+			}
 			log.Printf("monarch: sync enabled")
 		}
 	}

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -101,8 +101,9 @@ func main() {
 	}
 	handler := web.NewHandler(database, nodeProvider, priceCache, database, httpLogger)
 
-	// Wire up settings store and optional Monarch sync
+	// Wire up settings store, transaction store, and optional Monarch sync
 	handler.SetSettingsStore(database)
+	handler.SetTransactionStore(database)
 	monarchToken, _ := database.GetSetting(context.Background(), "monarch_token")
 	if monarchToken == "" {
 		monarchToken = cfg.MonarchToken // fall back to env var

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214602-da099345913f
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214821-2e7fd82cc694
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v0.0.0-20260518151627-2eb054af6823
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518211251-78cf906eb2e8
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214013-d3dbba2307d2
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214357-b695a61554b4
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214357-b695a61554b4
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214602-da099345913f
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214821-2e7fd82cc694
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518225812-bfdbc3230569
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260519005506-2dd9c53d28d9
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260519210223-8c21a08caefd
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518211251-78cf906eb2e8
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518213208-3683e46901d8
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518225812-bfdbc3230569
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260519005506-2dd9c53d28d9
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
-replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518213208-3683e46901d8
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214013-d3dbba2307d2
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214602-da099345913f h1:XWbmBJZc7GjP87KSvJQ4YF44Hpgdeyk6yhsYb4skJqQ=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214602-da099345913f/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214821-2e7fd82cc694 h1:poPmSX1z5sVfRdlSJg3qUPxmgEusCG1UM+O6mDm8zSQ=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214821-2e7fd82cc694/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518211251-78cf906eb2e8 h1:6VSru/TgUezwUeewpUdu0hxp0jxcWjUMU1BfW3B6l3g=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518211251-78cf906eb2e8/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518213208-3683e46901d8 h1:b9lLAfcY47Rk0TqreDTNpmyHv9yigDrsupxjMx3ELws=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518213208-3683e46901d8/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214357-b695a61554b4 h1:36xEg+UL4zS0wjf9H8SJjKS32To3Vq3dW9B2hzBJgQ8=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214357-b695a61554b4/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214602-da099345913f h1:XWbmBJZc7GjP87KSvJQ4YF44Hpgdeyk6yhsYb4skJqQ=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214602-da099345913f/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518225812-bfdbc3230569 h1:PF3vSrGC60UHlGzd8kHVdYYdRomaOID2gTfYyiqRySY=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518225812-bfdbc3230569/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260519005506-2dd9c53d28d9 h1:aZ3Bp6PYt08qV0QLgaToWgf41bO1Bipy30ViCHdCXbI=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260519005506-2dd9c53d28d9/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260519005506-2dd9c53d28d9 h1:aZ3Bp6PYt08qV0QLgaToWgf41bO1Bipy30ViCHdCXbI=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260519005506-2dd9c53d28d9/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260519210223-8c21a08caefd h1:OA5PyeYhCuh4FiqAKQwtbB4PslzaGc/H5UCirrM27uE=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260519210223-8c21a08caefd/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214821-2e7fd82cc694 h1:poPmSX1z5sVfRdlSJg3qUPxmgEusCG1UM+O6mDm8zSQ=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214821-2e7fd82cc694/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518225812-bfdbc3230569 h1:PF3vSrGC60UHlGzd8kHVdYYdRomaOID2gTfYyiqRySY=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518225812-bfdbc3230569/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214013-d3dbba2307d2 h1:CixuuVaVfkAfhVzqnK7reEwoPofZFFxiQiG4+0hjl4Y=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214013-d3dbba2307d2/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214357-b695a61554b4 h1:36xEg+UL4zS0wjf9H8SJjKS32To3Vq3dW9B2hzBJgQ8=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214357-b695a61554b4/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518213208-3683e46901d8 h1:b9lLAfcY47Rk0TqreDTNpmyHv9yigDrsupxjMx3ELws=
-github.com/brewgator/monarchmoney-go v1.0.6-0.20260518213208-3683e46901d8/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214013-d3dbba2307d2 h1:CixuuVaVfkAfhVzqnK7reEwoPofZFFxiQiG4+0hjl4Y=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518214013-d3dbba2307d2/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brewgator/monarchmoney-go v0.0.0-20260518151627-2eb054af6823 h1:y18gvW0k/es+ILFp2r7bD7nIfrEeixGHdoFXLVqoe2M=
-github.com/brewgator/monarchmoney-go v0.0.0-20260518151627-2eb054af6823/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518211251-78cf906eb2e8 h1:6VSru/TgUezwUeewpUdu0hxp0jxcWjUMU1BfW3B6l3g=
+github.com/brewgator/monarchmoney-go v1.0.6-0.20260518211251-78cf906eb2e8/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -319,14 +319,17 @@ var migrations = []string{
 	FROM exchange_imports;
 	`,
 
-	// Migration 10: Transaction notes table + recreate view to surface Description in memo.
+	// Migration 10: Transaction notes table for user-editable annotations.
 	`
 	CREATE TABLE IF NOT EXISTS transaction_notes (
 		source_id  TEXT PRIMARY KEY,
 		note       TEXT NOT NULL DEFAULT '',
 		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
+	`,
 
+	// Migration 11: Recreate unified view to surface Description in memo column.
+	`
 	DROP VIEW IF EXISTS btc_transactions_v;
 	CREATE VIEW btc_transactions_v AS
 	-- LND forwarding fee income

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -225,6 +225,97 @@ var migrations = []string{
 		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
 	`,
+	// Migration 9: Unified BTC transaction view across all sources.
+	`
+	CREATE VIEW IF NOT EXISTS btc_transactions_v AS
+	-- LND forwarding fee income
+	SELECT
+		'lnd_forward' AS source,
+		'forward:' || id AS source_id,
+		timestamp AS ts,
+		'fee_income' AS tx_type,
+		fee_msat / 1000 AS amount_sat,
+		0.0 AS amount_usd,
+		0 AS fee_sat,
+		0.0 AS fee_usd,
+		0.0 AS price_usd,
+		'routing fee: ' || chan_id_in || ' → ' || chan_id_out AS memo
+	FROM forwarding_events
+
+	UNION ALL
+
+	-- LND invoices received (settled only)
+	SELECT
+		'lnd_invoice' AS source,
+		payment_hash AS source_id,
+		COALESCE(settled_at, created_at) AS ts,
+		'receive' AS tx_type,
+		amt_paid_msat / 1000 AS amount_sat,
+		0.0 AS amount_usd,
+		0 AS fee_sat,
+		0.0 AS fee_usd,
+		0.0 AS price_usd,
+		'' AS memo
+	FROM invoices
+	WHERE settled_at IS NOT NULL
+
+	UNION ALL
+
+	-- LND payments sent (succeeded only)
+	SELECT
+		'lnd_payment' AS source,
+		payment_hash AS source_id,
+		created_at AS ts,
+		'send' AS tx_type,
+		-(value_msat / 1000) AS amount_sat,
+		0.0 AS amount_usd,
+		fee_msat / 1000 AS fee_sat,
+		0.0 AS fee_usd,
+		0.0 AS price_usd,
+		'' AS memo
+	FROM payments
+	WHERE status = 'SUCCEEDED'
+
+	UNION ALL
+
+	-- LND on-chain transactions
+	SELECT
+		'lnd_onchain' AS source,
+		tx_hash AS source_id,
+		timestamp AS ts,
+		CASE WHEN amount_sat >= 0 THEN 'receive' ELSE 'send' END AS tx_type,
+		amount_sat AS amount_sat,
+		0.0 AS amount_usd,
+		0 AS fee_sat,
+		0.0 AS fee_usd,
+		0.0 AS price_usd,
+		COALESCE(label, '') AS memo
+	FROM onchain_txns
+	WHERE num_confirmations > 0
+
+	UNION ALL
+
+	-- Exchange imports (Strike, River, Coinbase, Swan)
+	SELECT
+		source AS source,
+		source || ':' || external_id || ':' || tx_type AS source_id,
+		COALESCE(json_extract(raw_data, '$.Date'), imported_at) AS ts,
+		CASE
+			WHEN LOWER(tx_type) IN ('buy', 'purchase') THEN 'buy'
+			WHEN LOWER(tx_type) IN ('sale', 'sell') THEN 'sell'
+			WHEN LOWER(tx_type) IN ('send', 'withdrawal') THEN 'send'
+			WHEN LOWER(tx_type) IN ('receive', 'deposit') THEN 'receive'
+			ELSE tx_type
+		END AS tx_type,
+		CAST(COALESCE(json_extract(raw_data, '$.AmountBTC'), 0) * 100000000 AS INTEGER) AS amount_sat,
+		COALESCE(json_extract(raw_data, '$.AmountUSD'), 0.0) AS amount_usd,
+		0 AS fee_sat,
+		COALESCE(json_extract(raw_data, '$.FeeUSD'), 0.0) AS fee_usd,
+		COALESCE(json_extract(raw_data, '$.CostBasisUSD'), 0.0) /
+			NULLIF(ABS(COALESCE(json_extract(raw_data, '$.AmountBTC'), 0)), 0) AS price_usd,
+		'' AS memo
+	FROM exchange_imports;
+	`,
 }
 
 // NewDB opens a SQLite database at the given path, runs migrations, and returns a DB.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -226,6 +226,8 @@ var migrations = []string{
 	);
 	`,
 	// Migration 9: Unified BTC transaction view across all sources.
+	// NOTE: The view is defined here and also recreated in migration 10 to add the notes JOIN.
+	// Keeping the original here for schema history.
 	`
 	CREATE VIEW IF NOT EXISTS btc_transactions_v AS
 	-- LND forwarding fee income
@@ -315,6 +317,15 @@ var migrations = []string{
 			NULLIF(ABS(COALESCE(json_extract(raw_data, '$.AmountBTC'), 0)), 0) AS price_usd,
 		'' AS memo
 	FROM exchange_imports;
+	`,
+
+	// Migration 10: Transaction notes table for user-editable annotations.
+	`
+	CREATE TABLE IF NOT EXISTS transaction_notes (
+		source_id  TEXT PRIMARY KEY,
+		note       TEXT NOT NULL DEFAULT '',
+		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
 	`,
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -319,13 +319,103 @@ var migrations = []string{
 	FROM exchange_imports;
 	`,
 
-	// Migration 10: Transaction notes table for user-editable annotations.
+	// Migration 10: Transaction notes table + recreate view to surface Description in memo.
 	`
 	CREATE TABLE IF NOT EXISTS transaction_notes (
 		source_id  TEXT PRIMARY KEY,
 		note       TEXT NOT NULL DEFAULT '',
 		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
+
+	DROP VIEW IF EXISTS btc_transactions_v;
+	CREATE VIEW btc_transactions_v AS
+	-- LND forwarding fee income
+	SELECT
+		'lnd_forward' AS source,
+		'forward:' || id AS source_id,
+		timestamp AS ts,
+		'fee_income' AS tx_type,
+		fee_msat / 1000 AS amount_sat,
+		0.0 AS amount_usd,
+		0 AS fee_sat,
+		0.0 AS fee_usd,
+		0.0 AS price_usd,
+		'routing fee: ' || chan_id_in || ' → ' || chan_id_out AS memo
+	FROM forwarding_events
+
+	UNION ALL
+
+	-- LND invoices received (settled only)
+	SELECT
+		'lnd_invoice' AS source,
+		payment_hash AS source_id,
+		COALESCE(settled_at, created_at) AS ts,
+		'receive' AS tx_type,
+		amt_paid_msat / 1000 AS amount_sat,
+		0.0 AS amount_usd,
+		0 AS fee_sat,
+		0.0 AS fee_usd,
+		0.0 AS price_usd,
+		'' AS memo
+	FROM invoices
+	WHERE settled_at IS NOT NULL
+
+	UNION ALL
+
+	-- LND payments sent (succeeded only)
+	SELECT
+		'lnd_payment' AS source,
+		payment_hash AS source_id,
+		created_at AS ts,
+		'send' AS tx_type,
+		-(value_msat / 1000) AS amount_sat,
+		0.0 AS amount_usd,
+		fee_msat / 1000 AS fee_sat,
+		0.0 AS fee_usd,
+		0.0 AS price_usd,
+		'' AS memo
+	FROM payments
+	WHERE status = 'SUCCEEDED'
+
+	UNION ALL
+
+	-- LND on-chain transactions
+	SELECT
+		'lnd_onchain' AS source,
+		tx_hash AS source_id,
+		timestamp AS ts,
+		CASE WHEN amount_sat >= 0 THEN 'receive' ELSE 'send' END AS tx_type,
+		amount_sat AS amount_sat,
+		0.0 AS amount_usd,
+		0 AS fee_sat,
+		0.0 AS fee_usd,
+		0.0 AS price_usd,
+		COALESCE(label, '') AS memo
+	FROM onchain_txns
+	WHERE num_confirmations > 0
+
+	UNION ALL
+
+	-- Exchange imports (Strike, River, Coinbase, Swan)
+	SELECT
+		source AS source,
+		source || ':' || external_id || ':' || tx_type AS source_id,
+		COALESCE(json_extract(raw_data, '$.Date'), imported_at) AS ts,
+		CASE
+			WHEN LOWER(tx_type) IN ('buy', 'purchase') THEN 'buy'
+			WHEN LOWER(tx_type) IN ('sale', 'sell') THEN 'sell'
+			WHEN LOWER(tx_type) IN ('send', 'withdrawal') THEN 'send'
+			WHEN LOWER(tx_type) IN ('receive', 'deposit') THEN 'receive'
+			ELSE tx_type
+		END AS tx_type,
+		CAST(COALESCE(json_extract(raw_data, '$.AmountBTC'), 0) * 100000000 AS INTEGER) AS amount_sat,
+		COALESCE(json_extract(raw_data, '$.AmountUSD'), 0.0) AS amount_usd,
+		0 AS fee_sat,
+		COALESCE(json_extract(raw_data, '$.FeeUSD'), 0.0) AS fee_usd,
+		COALESCE(json_extract(raw_data, '$.CostBasisUSD'), 0.0) /
+			NULLIF(ABS(COALESCE(json_extract(raw_data, '$.AmountBTC'), 0)), 0) AS price_usd,
+		COALESCE(json_extract(raw_data, '$.Description'), '') AS memo
+	FROM exchange_imports;
 	`,
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -420,6 +420,14 @@ var migrations = []string{
 		COALESCE(json_extract(raw_data, '$.Description'), '') AS memo
 	FROM exchange_imports;
 	`,
+	// Migration 12: Monarch transaction sync tracking.
+	`
+	CREATE TABLE IF NOT EXISTS monarch_tx_sync (
+		source_id     TEXT PRIMARY KEY,
+		monarch_tx_id TEXT NOT NULL,
+		synced_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	`,
 }
 
 // NewDB opens a SQLite database at the given path, runs migrations, and returns a DB.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1332,23 +1332,91 @@ type UnifiedTransactionPage struct {
 	Total        int
 }
 
+// TransactionFilter holds filter/sort parameters for the unified transaction query.
+type TransactionFilter struct {
+	DateFrom string // "YYYY-MM-DD" or empty
+	DateTo   string // "YYYY-MM-DD" or empty
+	TxType   string // e.g. "buy", "send", or empty for all
+	Source   string // e.g. "strike", "lnd_forward", or empty for all
+	Search   string // free-text search across memo and notes
+	SortCol  string // "ts", "amount_sat", "source", "tx_type", "amount_usd"
+	SortDir  string // "asc" or "desc"
+	Limit    int
+	Offset   int
+}
+
+// validSortColumns is the allowlist of columns that can be sorted on.
+var validSortColumns = map[string]string{
+	"ts":         "v.ts",
+	"source":     "v.source",
+	"tx_type":    "v.tx_type",
+	"amount_sat": "v.amount_sat",
+	"amount_usd": "v.amount_usd",
+	"fee":        "v.fee_sat",
+}
+
 // ListUnifiedTransactions returns paginated transactions from the unified view,
 // with user notes joined from the transaction_notes table.
-func (d *DB) ListUnifiedTransactions(ctx context.Context, limit, offset int) (*UnifiedTransactionPage, error) {
+// Supports filtering by date range, type, source, search, and custom sort.
+func (d *DB) ListUnifiedTransactions(ctx context.Context, f TransactionFilter) (*UnifiedTransactionPage, error) {
+	var where []string
+	var args []interface{}
+
+	if f.DateFrom != "" {
+		where = append(where, "v.ts >= ?")
+		args = append(args, f.DateFrom+" 00:00:00")
+	}
+	if f.DateTo != "" {
+		where = append(where, "v.ts <= ?")
+		args = append(args, f.DateTo+" 23:59:59")
+	}
+	if f.TxType != "" {
+		where = append(where, "v.tx_type = ?")
+		args = append(args, f.TxType)
+	}
+	if f.Source != "" {
+		where = append(where, "v.source = ?")
+		args = append(args, f.Source)
+	}
+	if f.Search != "" {
+		where = append(where, "(v.memo LIKE ? OR COALESCE(n.note, '') LIKE ? OR v.source_id LIKE ?)")
+		like := "%" + f.Search + "%"
+		args = append(args, like, like, like)
+	}
+
+	whereClause := ""
+	if len(where) > 0 {
+		whereClause = "WHERE " + strings.Join(where, " AND ")
+	}
+
+	// Count query
+	countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM btc_transactions_v v
+		LEFT JOIN transaction_notes n ON n.source_id = v.source_id %s`, whereClause)
 	var total int
-	err := d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM btc_transactions_v`).Scan(&total)
+	err := d.db.QueryRowContext(ctx, countQuery, args...).Scan(&total)
 	if err != nil {
 		return nil, fmt.Errorf("count unified transactions: %w", err)
 	}
 
-	rows, err := d.db.QueryContext(ctx,
-		`SELECT v.source, v.source_id, v.ts, v.tx_type, v.amount_sat, v.amount_usd,
-		        v.fee_sat, v.fee_usd, COALESCE(v.price_usd, 0), v.memo,
-		        COALESCE(n.note, '')
-		 FROM btc_transactions_v v
-		 LEFT JOIN transaction_notes n ON n.source_id = v.source_id
-		 ORDER BY v.ts DESC
-		 LIMIT ? OFFSET ?`, limit, offset)
+	// Sort
+	orderCol := "v.ts"
+	if col, ok := validSortColumns[f.SortCol]; ok {
+		orderCol = col
+	}
+	orderDir := "DESC"
+	if f.SortDir == "asc" {
+		orderDir = "ASC"
+	}
+
+	dataQuery := fmt.Sprintf(`SELECT v.source, v.source_id, v.ts, v.tx_type, v.amount_sat, v.amount_usd,
+		v.fee_sat, v.fee_usd, COALESCE(v.price_usd, 0), v.memo,
+		COALESCE(n.note, '')
+		FROM btc_transactions_v v
+		LEFT JOIN transaction_notes n ON n.source_id = v.source_id
+		%s ORDER BY %s %s LIMIT ? OFFSET ?`, whereClause, orderCol, orderDir)
+
+	dataArgs := append(args, f.Limit, f.Offset)
+	rows, err := d.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("list unified transactions: %w", err)
 	}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1296,3 +1296,95 @@ func (d *DB) SetSetting(ctx context.Context, key, value string) error {
 		key, value)
 	return err
 }
+
+// UnifiedTransaction represents a single BTC transaction from any source.
+type UnifiedTransaction struct {
+	Source   string    // lnd_forward, lnd_invoice, lnd_payment, lnd_onchain, strike, river, etc.
+	SourceID string   // unique ID within the source
+	Time     time.Time
+	TxType   string   // buy, sell, send, receive, fee_income
+	AmountSat int64   // positive = inflow, negative = outflow
+	AmountUSD float64
+	FeeSat    int64
+	FeeUSD    float64
+	PriceUSD  float64
+	Memo      string
+}
+
+// UnifiedTransactionPage holds paginated results from the unified view.
+type UnifiedTransactionPage struct {
+	Transactions []UnifiedTransaction
+	Total        int
+}
+
+// ListUnifiedTransactions returns paginated transactions from the unified view.
+func (d *DB) ListUnifiedTransactions(ctx context.Context, limit, offset int) (*UnifiedTransactionPage, error) {
+	var total int
+	err := d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM btc_transactions_v`).Scan(&total)
+	if err != nil {
+		return nil, fmt.Errorf("count unified transactions: %w", err)
+	}
+
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT source, source_id, ts, tx_type, amount_sat, amount_usd, fee_sat, fee_usd, COALESCE(price_usd, 0), memo
+		 FROM btc_transactions_v
+		 ORDER BY ts DESC
+		 LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list unified transactions: %w", err)
+	}
+	defer rows.Close()
+
+	var txns []UnifiedTransaction
+	for rows.Next() {
+		var tx UnifiedTransaction
+		var ts string
+		if err := rows.Scan(&tx.Source, &tx.SourceID, &ts, &tx.TxType, &tx.AmountSat, &tx.AmountUSD, &tx.FeeSat, &tx.FeeUSD, &tx.PriceUSD, &tx.Memo); err != nil {
+			return nil, fmt.Errorf("scan unified transaction: %w", err)
+		}
+		tx.Time, _ = time.Parse("2006-01-02T15:04:05Z", ts)
+		if tx.Time.IsZero() {
+			tx.Time, _ = time.Parse("2006-01-02 15:04:05", ts)
+		}
+		if tx.Time.IsZero() {
+			tx.Time, _ = time.Parse(time.RFC3339, ts)
+		}
+		txns = append(txns, tx)
+	}
+
+	return &UnifiedTransactionPage{Transactions: txns, Total: total}, nil
+}
+
+// ListUnifiedTransactionsSince returns transactions after a given timestamp, ordered oldest first.
+// Used for incremental sync (e.g. pushing new transactions to Monarch).
+func (d *DB) ListUnifiedTransactionsSince(ctx context.Context, since time.Time, limit int) ([]UnifiedTransaction, error) {
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT source, source_id, ts, tx_type, amount_sat, amount_usd, fee_sat, fee_usd, COALESCE(price_usd, 0), memo
+		 FROM btc_transactions_v
+		 WHERE ts > ?
+		 ORDER BY ts ASC
+		 LIMIT ?`, since.UTC().Format("2006-01-02 15:04:05"), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list unified transactions since: %w", err)
+	}
+	defer rows.Close()
+
+	var txns []UnifiedTransaction
+	for rows.Next() {
+		var tx UnifiedTransaction
+		var ts string
+		if err := rows.Scan(&tx.Source, &tx.SourceID, &ts, &tx.TxType, &tx.AmountSat, &tx.AmountUSD, &tx.FeeSat, &tx.FeeUSD, &tx.PriceUSD, &tx.Memo); err != nil {
+			return nil, fmt.Errorf("scan unified transaction: %w", err)
+		}
+		tx.Time, _ = time.Parse("2006-01-02T15:04:05Z", ts)
+		if tx.Time.IsZero() {
+			tx.Time, _ = time.Parse("2006-01-02 15:04:05", ts)
+		}
+		if tx.Time.IsZero() {
+			tx.Time, _ = time.Parse(time.RFC3339, ts)
+		}
+		txns = append(txns, tx)
+	}
+
+	return txns, nil
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1299,16 +1299,31 @@ func (d *DB) SetSetting(ctx context.Context, key, value string) error {
 
 // UnifiedTransaction represents a single BTC transaction from any source.
 type UnifiedTransaction struct {
-	Source   string    // lnd_forward, lnd_invoice, lnd_payment, lnd_onchain, strike, river, etc.
-	SourceID string   // unique ID within the source
-	Time     time.Time
-	TxType   string   // buy, sell, send, receive, fee_income
-	AmountSat int64   // positive = inflow, negative = outflow
+	Source    string    // lnd_forward, lnd_invoice, lnd_payment, lnd_onchain, strike, river, etc.
+	SourceID  string   // unique ID within the source
+	Time      time.Time
+	TxType    string   // buy, sell, send, receive, fee_income
+	AmountSat int64    // positive = inflow, negative = outflow
 	AmountUSD float64
 	FeeSat    int64
 	FeeUSD    float64
 	PriceUSD  float64
 	Memo      string
+	Note      string   // user-editable annotation
+}
+
+// parseFlexibleTime tries multiple time formats to parse a timestamp string from SQLite.
+func parseFlexibleTime(ts string) time.Time {
+	for _, fmt := range []string{
+		"2006-01-02T15:04:05Z",
+		"2006-01-02 15:04:05",
+		time.RFC3339,
+	} {
+		if t, err := time.Parse(fmt, ts); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }
 
 // UnifiedTransactionPage holds paginated results from the unified view.
@@ -1317,7 +1332,8 @@ type UnifiedTransactionPage struct {
 	Total        int
 }
 
-// ListUnifiedTransactions returns paginated transactions from the unified view.
+// ListUnifiedTransactions returns paginated transactions from the unified view,
+// with user notes joined from the transaction_notes table.
 func (d *DB) ListUnifiedTransactions(ctx context.Context, limit, offset int) (*UnifiedTransactionPage, error) {
 	var total int
 	err := d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM btc_transactions_v`).Scan(&total)
@@ -1326,9 +1342,12 @@ func (d *DB) ListUnifiedTransactions(ctx context.Context, limit, offset int) (*U
 	}
 
 	rows, err := d.db.QueryContext(ctx,
-		`SELECT source, source_id, ts, tx_type, amount_sat, amount_usd, fee_sat, fee_usd, COALESCE(price_usd, 0), memo
-		 FROM btc_transactions_v
-		 ORDER BY ts DESC
+		`SELECT v.source, v.source_id, v.ts, v.tx_type, v.amount_sat, v.amount_usd,
+		        v.fee_sat, v.fee_usd, COALESCE(v.price_usd, 0), v.memo,
+		        COALESCE(n.note, '')
+		 FROM btc_transactions_v v
+		 LEFT JOIN transaction_notes n ON n.source_id = v.source_id
+		 ORDER BY v.ts DESC
 		 LIMIT ? OFFSET ?`, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("list unified transactions: %w", err)
@@ -1339,16 +1358,10 @@ func (d *DB) ListUnifiedTransactions(ctx context.Context, limit, offset int) (*U
 	for rows.Next() {
 		var tx UnifiedTransaction
 		var ts string
-		if err := rows.Scan(&tx.Source, &tx.SourceID, &ts, &tx.TxType, &tx.AmountSat, &tx.AmountUSD, &tx.FeeSat, &tx.FeeUSD, &tx.PriceUSD, &tx.Memo); err != nil {
+		if err := rows.Scan(&tx.Source, &tx.SourceID, &ts, &tx.TxType, &tx.AmountSat, &tx.AmountUSD, &tx.FeeSat, &tx.FeeUSD, &tx.PriceUSD, &tx.Memo, &tx.Note); err != nil {
 			return nil, fmt.Errorf("scan unified transaction: %w", err)
 		}
-		tx.Time, _ = time.Parse("2006-01-02T15:04:05Z", ts)
-		if tx.Time.IsZero() {
-			tx.Time, _ = time.Parse("2006-01-02 15:04:05", ts)
-		}
-		if tx.Time.IsZero() {
-			tx.Time, _ = time.Parse(time.RFC3339, ts)
-		}
+		tx.Time = parseFlexibleTime(ts)
 		txns = append(txns, tx)
 	}
 
@@ -1376,15 +1389,32 @@ func (d *DB) ListUnifiedTransactionsSince(ctx context.Context, since time.Time, 
 		if err := rows.Scan(&tx.Source, &tx.SourceID, &ts, &tx.TxType, &tx.AmountSat, &tx.AmountUSD, &tx.FeeSat, &tx.FeeUSD, &tx.PriceUSD, &tx.Memo); err != nil {
 			return nil, fmt.Errorf("scan unified transaction: %w", err)
 		}
-		tx.Time, _ = time.Parse("2006-01-02T15:04:05Z", ts)
-		if tx.Time.IsZero() {
-			tx.Time, _ = time.Parse("2006-01-02 15:04:05", ts)
-		}
-		if tx.Time.IsZero() {
-			tx.Time, _ = time.Parse(time.RFC3339, ts)
-		}
+		tx.Time = parseFlexibleTime(ts)
 		txns = append(txns, tx)
 	}
 
 	return txns, nil
+}
+
+// GetTransactionNote returns the user note for a transaction, or empty string if none.
+func (d *DB) GetTransactionNote(ctx context.Context, sourceID string) (string, error) {
+	var note string
+	err := d.db.QueryRowContext(ctx, `SELECT note FROM transaction_notes WHERE source_id = ?`, sourceID).Scan(&note)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return note, err
+}
+
+// SetTransactionNote upserts a user note for a transaction. Empty note deletes the row.
+func (d *DB) SetTransactionNote(ctx context.Context, sourceID, note string) error {
+	if strings.TrimSpace(note) == "" {
+		_, err := d.db.ExecContext(ctx, `DELETE FROM transaction_notes WHERE source_id = ?`, sourceID)
+		return err
+	}
+	_, err := d.db.ExecContext(ctx,
+		`INSERT INTO transaction_notes (source_id, note, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(source_id) DO UPDATE SET note = excluded.note, updated_at = excluded.updated_at`,
+		sourceID, strings.TrimSpace(note))
+	return err
 }

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1517,3 +1517,66 @@ func (d *DB) SetTransactionNote(ctx context.Context, sourceID, note string) erro
 		sourceID, strings.TrimSpace(note))
 	return err
 }
+
+// ListUnsyncedTransactions returns unified transactions of the given types that
+// have not yet been synced to Monarch Money.
+func (d *DB) ListUnsyncedTransactions(ctx context.Context, txTypes []string) ([]UnifiedTransaction, error) {
+	if len(txTypes) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(txTypes))
+	args := make([]interface{}, len(txTypes))
+	for i, t := range txTypes {
+		placeholders[i] = "?"
+		args[i] = t
+	}
+
+	query := fmt.Sprintf(`
+		SELECT v.source, v.source_id, v.ts, v.tx_type, v.amount_sat, v.amount_usd,
+		       v.fee_sat, v.fee_usd, COALESCE(v.price_usd, 0), v.memo
+		FROM btc_transactions_v v
+		LEFT JOIN monarch_tx_sync m ON m.source_id = v.source_id
+		WHERE v.tx_type IN (%s) AND m.source_id IS NULL
+		ORDER BY v.ts ASC`,
+		strings.Join(placeholders, ","))
+
+	rows, err := d.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list unsynced transactions: %w", err)
+	}
+	defer rows.Close()
+
+	var txns []UnifiedTransaction
+	for rows.Next() {
+		var tx UnifiedTransaction
+		var ts string
+		if err := rows.Scan(&tx.Source, &tx.SourceID, &ts, &tx.TxType, &tx.AmountSat, &tx.AmountUSD, &tx.FeeSat, &tx.FeeUSD, &tx.PriceUSD, &tx.Memo); err != nil {
+			return nil, fmt.Errorf("scan unsynced transaction: %w", err)
+		}
+		tx.Time = parseFlexibleTime(ts)
+		txns = append(txns, tx)
+	}
+	return txns, nil
+}
+
+// MarkTransactionSynced records that a transaction was synced to Monarch.
+func (d *DB) MarkTransactionSynced(ctx context.Context, sourceID, monarchTxID string) error {
+	_, err := d.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO monarch_tx_sync (source_id, monarch_tx_id) VALUES (?, ?)`,
+		sourceID, monarchTxID)
+	return err
+}
+
+// MonarchSyncedCount returns the number of transactions synced to Monarch.
+func (d *DB) MonarchSyncedCount(ctx context.Context) (int, error) {
+	var count int
+	err := d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM monarch_tx_sync`).Scan(&count)
+	return count, err
+}
+
+// ClearMonarchSyncState removes all Monarch sync tracking records.
+func (d *DB) ClearMonarchSyncState(ctx context.Context) error {
+	_, err := d.db.ExecContext(ctx, `DELETE FROM monarch_tx_sync`)
+	return err
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1332,6 +1332,37 @@ type UnifiedTransactionPage struct {
 	Total        int
 }
 
+// DistinctTransactionValues returns the distinct sources and tx_types from the unified view.
+func (d *DB) DistinctTransactionValues(ctx context.Context) (sources []string, txTypes []string, err error) {
+	rows, err := d.db.QueryContext(ctx, `SELECT DISTINCT source FROM btc_transactions_v WHERE source != '' ORDER BY source`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("distinct sources: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, nil, err
+		}
+		sources = append(sources, s)
+	}
+
+	rows2, err := d.db.QueryContext(ctx, `SELECT DISTINCT tx_type FROM btc_transactions_v WHERE tx_type != '' ORDER BY tx_type`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("distinct tx_types: %w", err)
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var t string
+		if err := rows2.Scan(&t); err != nil {
+			return nil, nil, err
+		}
+		txTypes = append(txTypes, t)
+	}
+
+	return sources, txTypes, nil
+}
+
 // TransactionFilter holds filter/sort parameters for the unified transaction query.
 type TransactionFilter struct {
 	DateFrom string // "YYYY-MM-DD" or empty

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1518,18 +1518,30 @@ func (d *DB) SetTransactionNote(ctx context.Context, sourceID, note string) erro
 	return err
 }
 
-// ListUnsyncedTransactions returns unified transactions of the given types that
-// have not yet been synced to Monarch Money.
-func (d *DB) ListUnsyncedTransactions(ctx context.Context, txTypes []string) ([]UnifiedTransaction, error) {
+// ListUnsyncedTransactions returns unified transactions of the given types and sources
+// that have not yet been synced to Monarch Money.
+// If sources is empty, all sources are included.
+func (d *DB) ListUnsyncedTransactions(ctx context.Context, txTypes []string, sources []string) ([]UnifiedTransaction, error) {
 	if len(txTypes) == 0 {
 		return nil, nil
 	}
 
-	placeholders := make([]string, len(txTypes))
+	typePH := make([]string, len(txTypes))
 	args := make([]interface{}, len(txTypes))
 	for i, t := range txTypes {
-		placeholders[i] = "?"
+		typePH[i] = "?"
 		args[i] = t
+	}
+
+	whereClause := fmt.Sprintf("v.tx_type IN (%s)", strings.Join(typePH, ","))
+
+	if len(sources) > 0 {
+		srcPH := make([]string, len(sources))
+		for i, s := range sources {
+			srcPH[i] = "?"
+			args = append(args, s)
+		}
+		whereClause += fmt.Sprintf(" AND v.source IN (%s)", strings.Join(srcPH, ","))
 	}
 
 	query := fmt.Sprintf(`
@@ -1537,9 +1549,8 @@ func (d *DB) ListUnsyncedTransactions(ctx context.Context, txTypes []string) ([]
 		       v.fee_sat, v.fee_usd, COALESCE(v.price_usd, 0), v.memo
 		FROM btc_transactions_v v
 		LEFT JOIN monarch_tx_sync m ON m.source_id = v.source_id
-		WHERE v.tx_type IN (%s) AND m.source_id IS NULL
-		ORDER BY v.ts ASC`,
-		strings.Join(placeholders, ","))
+		WHERE %s AND m.source_id IS NULL
+		ORDER BY v.ts ASC`, whereClause)
 
 	rows, err := d.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2451,7 +2451,7 @@ func TestListUnifiedTransactions(t *testing.T) {
 		t.Fatalf("seed data: %v", err)
 	}
 
-	page, err := d.ListUnifiedTransactions(ctx, 100, 0)
+	page, err := d.ListUnifiedTransactions(ctx, TransactionFilter{Limit: 100, Offset: 0})
 	if err != nil {
 		t.Fatalf("ListUnifiedTransactions: %v", err)
 	}
@@ -2506,6 +2506,85 @@ func TestListUnifiedTransactions(t *testing.T) {
 				t.Errorf("onchain: expected 100000 sat, got %d", tx.AmountSat)
 			}
 		}
+	}
+}
+
+func TestListUnifiedTransactionsFilters(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	// Seed diverse data
+	err := d.RunSync(ctx, func(tx SyncTx) error {
+		if err := tx.InsertForwardingEvents([]ForwardingEvent{{
+			Timestamp: time.Date(2024, 3, 10, 12, 0, 0, 0, time.UTC),
+			ChanIDIn: 1001, ChanIDOut: 1002,
+			AmtInMsat: 10000, AmtOutMsat: 9000, FeeMsat: 1000,
+		}}); err != nil {
+			return err
+		}
+		if err := tx.UpsertInvoices([]Invoice{{
+			PaymentHash: "inv-filter-1", AmtPaidMsat: 50_000_000,
+			CreatedAt: time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC),
+			SettledAt: func() *time.Time { t := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC); return &t }(),
+		}}); err != nil {
+			return err
+		}
+		return tx.UpsertPayments([]Payment{{
+			PaymentHash: "pay-filter-1", ValueMsat: 25_000_000, FeeMsat: 100,
+			CreatedAt: time.Date(2024, 6, 20, 12, 0, 0, 0, time.UTC),
+			Status: "SUCCEEDED",
+		}})
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Filter by type
+	page, err := d.ListUnifiedTransactions(ctx, TransactionFilter{TxType: "fee_income", Limit: 100})
+	if err != nil {
+		t.Fatalf("filter by type: %v", err)
+	}
+	if page.Total != 1 {
+		t.Errorf("type filter: expected 1, got %d", page.Total)
+	}
+
+	// Filter by source
+	page, err = d.ListUnifiedTransactions(ctx, TransactionFilter{Source: "lnd_invoice", Limit: 100})
+	if err != nil {
+		t.Fatalf("filter by source: %v", err)
+	}
+	if page.Total != 1 {
+		t.Errorf("source filter: expected 1, got %d", page.Total)
+	}
+
+	// Filter by date range
+	page, err = d.ListUnifiedTransactions(ctx, TransactionFilter{
+		DateFrom: "2024-06-01", DateTo: "2024-06-30", Limit: 100,
+	})
+	if err != nil {
+		t.Fatalf("filter by date: %v", err)
+	}
+	if page.Total != 2 { // invoice + payment
+		t.Errorf("date filter: expected 2, got %d", page.Total)
+	}
+
+	// Sort by amount ascending
+	page, err = d.ListUnifiedTransactions(ctx, TransactionFilter{SortCol: "amount_sat", SortDir: "asc", Limit: 100})
+	if err != nil {
+		t.Fatalf("sort: %v", err)
+	}
+	if len(page.Transactions) == 3 && page.Transactions[0].AmountSat > page.Transactions[2].AmountSat {
+		t.Errorf("expected ascending sort by amount")
+	}
+
+	// Search by memo
+	page, err = d.ListUnifiedTransactions(ctx, TransactionFilter{Search: "routing fee", Limit: 100})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if page.Total != 1 {
+		t.Errorf("search: expected 1, got %d", page.Total)
 	}
 }
 
@@ -2644,7 +2723,7 @@ func TestUnifiedTransactionsWithNotes(t *testing.T) {
 	}
 
 	// List should include the note
-	page, err := d.ListUnifiedTransactions(ctx, 50, 0)
+	page, err := d.ListUnifiedTransactions(ctx, TransactionFilter{Limit: 50, Offset: 0})
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2574,3 +2574,84 @@ func TestTotalPortfolioSats(t *testing.T) {
 		t.Errorf("expected 100000, got %d", total)
 	}
 }
+
+func TestTransactionNotes(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Get note for non-existent source ID returns empty
+	note, err := d.GetTransactionNote(ctx, "forward:1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note != "" {
+		t.Errorf("expected empty note, got %q", note)
+	}
+
+	// Set a note
+	if err := d.SetTransactionNote(ctx, "forward:1", "test routing fee"); err != nil {
+		t.Fatalf("set note: %v", err)
+	}
+
+	// Read it back
+	note, err = d.GetTransactionNote(ctx, "forward:1")
+	if err != nil {
+		t.Fatalf("get note: %v", err)
+	}
+	if note != "test routing fee" {
+		t.Errorf("expected 'test routing fee', got %q", note)
+	}
+
+	// Update the note
+	if err := d.SetTransactionNote(ctx, "forward:1", "updated note"); err != nil {
+		t.Fatalf("update note: %v", err)
+	}
+	note, err = d.GetTransactionNote(ctx, "forward:1")
+	if err != nil {
+		t.Fatalf("get updated note: %v", err)
+	}
+	if note != "updated note" {
+		t.Errorf("expected 'updated note', got %q", note)
+	}
+
+	// Delete note by setting empty
+	if err := d.SetTransactionNote(ctx, "forward:1", ""); err != nil {
+		t.Fatalf("delete note: %v", err)
+	}
+	note, err = d.GetTransactionNote(ctx, "forward:1")
+	if err != nil {
+		t.Fatalf("get deleted note: %v", err)
+	}
+	if note != "" {
+		t.Errorf("expected empty after delete, got %q", note)
+	}
+}
+
+func TestUnifiedTransactionsWithNotes(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Seed a forwarding event
+	seedForwardingEvents(t, d, []ForwardingEvent{{
+		Timestamp: time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC),
+		ChanIDIn:  1001, ChanIDOut: 1002,
+		AmtInMsat: 10000, AmtOutMsat: 9000, FeeMsat: 1000,
+	}})
+
+	// Add a note for it
+	if err := d.SetTransactionNote(ctx, "forward:1", "my routing note"); err != nil {
+		t.Fatalf("set note: %v", err)
+	}
+
+	// List should include the note
+	page, err := d.ListUnifiedTransactions(ctx, 50, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(page.Transactions))
+	}
+	if page.Transactions[0].Note != "my routing note" {
+		t.Errorf("expected note 'my routing note', got %q", page.Transactions[0].Note)
+	}
+}

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2361,6 +2361,185 @@ func TestBackfillPortfolioSnapshots_PreservesLiveSnapshots(t *testing.T) {
 	}
 }
 
+func TestListUnifiedTransactions(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Seed data from multiple sources
+	err := d.RunSync(ctx, func(tx SyncTx) error {
+		// Forwarding event (fee income)
+		if err := tx.InsertForwardingEvents([]ForwardingEvent{{
+			Timestamp:  now.Add(-4 * time.Hour),
+			ChanIDIn:   1001,
+			ChanIDOut:  1002,
+			AmtInMsat:  10_000_000,
+			AmtOutMsat: 9_500_000,
+			FeeMsat:    500_000,
+		}}); err != nil {
+			return err
+		}
+
+		// Invoice received
+		settled := now.Add(-3 * time.Hour)
+		if err := tx.UpsertInvoices([]Invoice{{
+			PaymentHash: "inv-hash-1",
+			AmtPaidMsat: 50_000_000,
+			CreatedAt:   now.Add(-4 * time.Hour),
+			SettledAt:   &settled,
+		}}); err != nil {
+			return err
+		}
+
+		// Unsettled invoice (should NOT appear)
+		if err := tx.UpsertInvoices([]Invoice{{
+			PaymentHash: "inv-hash-unsettled",
+			AmtPaidMsat: 10_000_000,
+			CreatedAt:   now.Add(-2 * time.Hour),
+		}}); err != nil {
+			return err
+		}
+
+		// Payment sent
+		if err := tx.UpsertPayments([]Payment{{
+			PaymentHash: "pay-hash-1",
+			ValueMsat:   25_000_000,
+			FeeMsat:     1_000,
+			CreatedAt:   now.Add(-2 * time.Hour),
+			Status:      "SUCCEEDED",
+		}}); err != nil {
+			return err
+		}
+
+		// Failed payment (should NOT appear)
+		if err := tx.UpsertPayments([]Payment{{
+			PaymentHash: "pay-hash-failed",
+			ValueMsat:   5_000_000,
+			FeeMsat:     500,
+			CreatedAt:   now.Add(-1 * time.Hour),
+			Status:      "FAILED",
+		}}); err != nil {
+			return err
+		}
+
+		// On-chain receive (confirmed)
+		if err := tx.UpsertOnchainTxns([]OnchainTx{{
+			TxHash:           "onchain-tx-1",
+			AmountSat:        100_000,
+			NumConfirmations: 6,
+			Timestamp:        now.Add(-1 * time.Hour),
+			Label:            "deposit",
+		}}); err != nil {
+			return err
+		}
+
+		// On-chain unconfirmed (should NOT appear)
+		if err := tx.UpsertOnchainTxns([]OnchainTx{{
+			TxHash:           "onchain-tx-unconfirmed",
+			AmountSat:        50_000,
+			NumConfirmations: 0,
+			Timestamp:        now,
+		}}); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed data: %v", err)
+	}
+
+	page, err := d.ListUnifiedTransactions(ctx, 100, 0)
+	if err != nil {
+		t.Fatalf("ListUnifiedTransactions: %v", err)
+	}
+
+	// Expect: forward + invoice + payment + onchain = 4
+	// (unsettled invoice, failed payment, unconfirmed onchain excluded)
+	if page.Total != 4 {
+		t.Errorf("expected 4 transactions, got %d", page.Total)
+		for _, tx := range page.Transactions {
+			t.Logf("  %s %s %s %d sat", tx.Source, tx.TxType, tx.SourceID, tx.AmountSat)
+		}
+	}
+
+	// Check that results are ordered by time DESC
+	for i := 1; i < len(page.Transactions); i++ {
+		if page.Transactions[i].Time.After(page.Transactions[i-1].Time) {
+			t.Errorf("transactions not in descending order at index %d", i)
+		}
+	}
+
+	// Verify types
+	typeMap := map[string]bool{}
+	for _, tx := range page.Transactions {
+		typeMap[tx.TxType] = true
+		switch tx.Source {
+		case "lnd_forward":
+			if tx.TxType != "fee_income" {
+				t.Errorf("forward should be fee_income, got %s", tx.TxType)
+			}
+			if tx.AmountSat != 500 { // 500_000 msat = 500 sat
+				t.Errorf("forward fee: expected 500 sat, got %d", tx.AmountSat)
+			}
+		case "lnd_invoice":
+			if tx.TxType != "receive" {
+				t.Errorf("invoice should be receive, got %s", tx.TxType)
+			}
+			if tx.AmountSat != 50_000 {
+				t.Errorf("invoice: expected 50000 sat, got %d", tx.AmountSat)
+			}
+		case "lnd_payment":
+			if tx.TxType != "send" {
+				t.Errorf("payment should be send, got %s", tx.TxType)
+			}
+			if tx.AmountSat != -25_000 {
+				t.Errorf("payment: expected -25000 sat, got %d", tx.AmountSat)
+			}
+		case "lnd_onchain":
+			if tx.TxType != "receive" {
+				t.Errorf("onchain should be receive, got %s", tx.TxType)
+			}
+			if tx.AmountSat != 100_000 {
+				t.Errorf("onchain: expected 100000 sat, got %d", tx.AmountSat)
+			}
+		}
+	}
+}
+
+func TestListUnifiedTransactionsSince(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	err := d.RunSync(ctx, func(tx SyncTx) error {
+		return tx.UpsertOnchainTxns([]OnchainTx{
+			{TxHash: "old-tx", AmountSat: 1000, NumConfirmations: 6, Timestamp: now.Add(-2 * time.Hour)},
+			{TxHash: "new-tx", AmountSat: 2000, NumConfirmations: 3, Timestamp: now.Add(-30 * time.Minute)},
+		})
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Only get transactions after 1 hour ago
+	txns, err := d.ListUnifiedTransactionsSince(ctx, now.Add(-1*time.Hour), 100)
+	if err != nil {
+		t.Fatalf("ListUnifiedTransactionsSince: %v", err)
+	}
+
+	if len(txns) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(txns))
+	}
+	if txns[0].SourceID != "new-tx" {
+		t.Errorf("expected new-tx, got %s", txns[0].SourceID)
+	}
+}
+
 func TestTotalPortfolioSats(t *testing.T) {
 	d := newTestDB(t)
 	defer d.Close()

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
+	"time"
 
 	mm "github.com/eshaffer321/monarchmoney-go/pkg/monarch"
 )
@@ -23,10 +25,33 @@ type AccountClient interface {
 	CreateHolding(ctx context.Context, params *mm.CreateHoldingParams) (*mm.Holding, error)
 }
 
+// TransactionClient creates transactions in Monarch.
+type TransactionClient interface {
+	Create(ctx context.Context, params *mm.CreateTransactionParams) (*mm.Transaction, error)
+}
+
+// TxToSync represents a satsbook transaction ready for Monarch export.
+type TxToSync struct {
+	SourceID  string
+	Source    string
+	TxType   string
+	Time      time.Time
+	AmountUSD float64
+	Memo      string
+}
+
+// TxSyncResult holds the outcome of a transaction sync batch.
+type TxSyncResult struct {
+	Created int
+	Skipped int
+	Errors  int
+}
+
 // Syncer pushes BTC balance to a Monarch Money manual account.
 type Syncer struct {
-	accounts  AccountClient
-	accountID string
+	accounts     AccountClient
+	transactions TransactionClient
+	accountID    string
 }
 
 // NewSyncer creates a Monarch syncer using a raw auth token.
@@ -35,7 +60,11 @@ func NewSyncer(token, accountID string) (*Syncer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create monarch client: %w", err)
 	}
-	return &Syncer{accounts: client.Accounts, accountID: accountID}, nil
+	return &Syncer{
+		accounts:     client.Accounts,
+		transactions: client.Transactions,
+		accountID:    accountID,
+	}, nil
 }
 
 // NewSyncerWithLogin creates a Monarch syncer by logging in with email/password.
@@ -56,7 +85,7 @@ func NewSyncerWithLogin(ctx context.Context, email, password, accountID string) 
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("get session: %w", err)
 	}
-	return &Syncer{accounts: client.Accounts, accountID: accountID}, sess.Token, nil, nil
+	return &Syncer{accounts: client.Accounts, transactions: client.Transactions, accountID: accountID}, sess.Token, nil, nil
 }
 
 // ErrOTPRequired indicates that a second factor is needed.
@@ -77,12 +106,17 @@ func (p *PendingClient) CompleteOTP(ctx context.Context, email, password, otpCod
 	if err != nil {
 		return nil, "", fmt.Errorf("get session: %w", err)
 	}
-	return &Syncer{accounts: p.Client.Accounts, accountID: p.AccountID}, sess.Token, nil
+	return &Syncer{accounts: p.Client.Accounts, transactions: p.Client.Transactions, accountID: p.AccountID}, sess.Token, nil
 }
 
 // NewSyncerWithClient creates a Syncer with a provided AccountClient (for testing).
 func NewSyncerWithClient(accounts AccountClient, accountID string) *Syncer {
 	return &Syncer{accounts: accounts, accountID: accountID}
+}
+
+// NewSyncerWithClients creates a Syncer with both account and transaction clients (for testing).
+func NewSyncerWithClients(accounts AccountClient, transactions TransactionClient, accountID string) *Syncer {
+	return &Syncer{accounts: accounts, transactions: transactions, accountID: accountID}
 }
 
 // findAccount looks for an existing satsbook account by name.
@@ -179,6 +213,86 @@ func (s *Syncer) SyncHolding(ctx context.Context, btcQuantity float64) error {
 	// No BTC holding found (shouldn't happen but handle it)
 	log.Printf("monarch: no BTC holding found, recreating account")
 	return s.recreateAccount(ctx, btcQuantity)
+}
+
+// SyncTransactions creates Monarch transactions for a batch of satsbook transactions.
+// It returns the result and a map of source_id -> monarch_tx_id for successful creates.
+// Transactions with zero USD amount are skipped.
+func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSyncResult, map[string]string, error) {
+	if s.transactions == nil {
+		return nil, nil, fmt.Errorf("transaction client not available")
+	}
+
+	// Ensure we have an account to post transactions to
+	accountID, err := s.ensureAccount(ctx, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ensure account: %w", err)
+	}
+
+	result := &TxSyncResult{}
+	synced := make(map[string]string)
+
+	for _, tx := range txns {
+		// Skip transactions with no USD value
+		if math.Abs(tx.AmountUSD) < 0.01 {
+			result.Skipped++
+			continue
+		}
+
+		merchantName := merchantForTx(tx)
+		notes := notesForTx(tx)
+
+		created, err := s.transactions.Create(ctx, &mm.CreateTransactionParams{
+			Date:      mm.Date{Time: tx.Time},
+			AccountID: accountID,
+			Amount:    tx.AmountUSD,
+			Merchant:  &mm.Merchant{Name: merchantName},
+			Notes:     notes,
+		})
+		if err != nil {
+			log.Printf("monarch: failed to create tx %s: %v", tx.SourceID, err)
+			result.Errors++
+			continue
+		}
+
+		synced[tx.SourceID] = created.ID
+		result.Created++
+	}
+
+	return result, synced, nil
+}
+
+// merchantForTx builds a merchant name for a Monarch transaction.
+func merchantForTx(tx TxToSync) string {
+	switch tx.Source {
+	case "strike":
+		return "Strike"
+	case "river":
+		return "River"
+	case "coinbase":
+		return "Coinbase"
+	case "swan":
+		return "Swan"
+	case "lnd_forward":
+		return "Lightning Routing"
+	case "lnd_invoice":
+		return "Lightning Invoice"
+	case "lnd_payment":
+		return "Lightning Payment"
+	case "lnd_onchain":
+		return "On-chain"
+	default:
+		return tx.Source
+	}
+}
+
+// notesForTx builds the notes string for a Monarch transaction.
+func notesForTx(tx TxToSync) string {
+	note := fmt.Sprintf("[%s] %s", tx.TxType, tx.SourceID)
+	if tx.Memo != "" {
+		note = tx.Memo + " | " + note
+	}
+	return note
 }
 
 // recreateAccount deletes the existing account and creates a fresh one.

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -317,6 +317,8 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 	s.txSyncMu.Lock()
 	defer s.txSyncMu.Unlock()
 
+	log.Printf("monarch tx sync: starting batch of %d transactions", len(txns))
+
 	if s.transactions == nil {
 		return nil, nil, fmt.Errorf("transaction client not available")
 	}
@@ -339,6 +341,7 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 
 	result := &TxSyncResult{}
 	synced := make(map[string]string)
+	dedupSkipped := 0
 
 	for i, tx := range txns {
 		// Skip transactions with no USD value
@@ -351,6 +354,7 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 		if monarchID, ok := existing[tx.SourceID]; ok {
 			synced[tx.SourceID] = monarchID
 			result.Skipped++
+			dedupSkipped++
 			continue
 		}
 
@@ -383,6 +387,8 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 		result.Created++
 	}
 
+	log.Printf("monarch tx sync: done — %d created, %d skipped (%d dedup), %d errors, %d total synced",
+		result.Created, result.Skipped, dedupSkipped, result.Errors, len(synced))
 	return result, synced, nil
 }
 
@@ -403,8 +409,11 @@ func (s *Syncer) fetchExistingSourceIDs(ctx context.Context, accountID string) m
 		return existing
 	}
 
+	noNotes := 0
+	noParse := 0
 	for _, tx := range txList.Transactions {
 		if tx.Notes == "" {
+			noNotes++
 			continue
 		}
 		// Notes format: "[tx_type] source_id"
@@ -412,10 +421,13 @@ func (s *Syncer) fetchExistingSourceIDs(ctx context.Context, accountID string) m
 		if idx := strings.LastIndex(tx.Notes, "] "); idx >= 0 {
 			sourceID := tx.Notes[idx+2:]
 			existing[sourceID] = tx.ID
+		} else {
+			noParse++
 		}
 	}
 
-	log.Printf("monarch: found %d existing transactions for dedup", len(existing))
+	log.Printf("monarch: dedup fetched %d monarch txns, matched %d source_ids (%d no notes, %d unparseable)",
+		len(txList.Transactions), len(existing), noNotes, noParse)
 	return existing
 }
 

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -368,9 +368,19 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 	return result, synced, nil
 }
 
-// merchantForTx builds a merchant name for a Monarch transaction.
+// merchantForTx builds a descriptive merchant name for a Monarch transaction.
+// When a memo is available it is appended: "Strike - Bill Pay to SOLAR CO".
 func merchantForTx(tx TxToSync) string {
-	switch tx.Source {
+	base := sourceLabel(tx.Source)
+	if tx.Memo != "" {
+		return base + " - " + tx.Memo
+	}
+	return base
+}
+
+// sourceLabel returns a human-readable label for a transaction source.
+func sourceLabel(source string) string {
+	switch source {
 	case "strike":
 		return "Strike"
 	case "river":
@@ -388,17 +398,13 @@ func merchantForTx(tx TxToSync) string {
 	case "lnd_onchain":
 		return "On-chain"
 	default:
-		return tx.Source
+		return source
 	}
 }
 
 // notesForTx builds the notes string for a Monarch transaction.
 func notesForTx(tx TxToSync) string {
-	note := fmt.Sprintf("[%s] %s", tx.TxType, tx.SourceID)
-	if tx.Memo != "" {
-		note = tx.Memo + " | " + note
-	}
-	return note
+	return fmt.Sprintf("[%s] %s", tx.TxType, tx.SourceID)
 }
 
 // recreateAccount deletes the existing account and creates a fresh one.

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -287,16 +287,25 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 		merchantName := merchantForTx(tx)
 		notes := notesForTx(tx)
 
-		created, err := s.transactions.Create(ctx, &mm.CreateTransactionParams{
+		params := &mm.CreateTransactionParams{
 			Date:      mm.Date{Time: tx.Time},
 			AccountID: accountID,
 			Amount:    tx.AmountUSD,
 			Merchant:  &mm.Merchant{Name: merchantName},
 			Notes:     notes,
-		})
+		}
+		log.Printf("monarch: creating tx: date=%s account=%s amount=%.2f merchant=%q notes=%q",
+			params.Date.Format("2006-01-02"), params.AccountID, params.Amount, merchantName, notes)
+
+		created, err := s.transactions.Create(ctx, params)
 		if err != nil {
 			log.Printf("monarch: failed to create tx %s: %v", tx.SourceID, err)
 			result.Errors++
+			if i == 0 {
+				// Log full error detail for first failure only
+				log.Printf("monarch: first failure detail — params: date=%s accountId=%s amount=%.2f merchant=%q notes=%q err=%#v",
+					params.Date.Format("2006-01-02"), params.AccountID, params.Amount, merchantName, notes, err)
+			}
 			continue
 		}
 

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"strings"
 	"time"
 
 	mm "github.com/eshaffer321/monarchmoney-go/pkg/monarch"
@@ -33,6 +34,20 @@ type TransactionClient interface {
 	Create(ctx context.Context, params *mm.CreateTransactionParams) (*mm.Transaction, error)
 }
 
+// CategoryLister lists Monarch transaction categories.
+type CategoryLister interface {
+	ListCategories(ctx context.Context) ([]*mm.TransactionCategory, error)
+}
+
+// monarchCategoryLister wraps the Monarch client's category service.
+type monarchCategoryLister struct {
+	svc mm.TransactionCategoryService
+}
+
+func (m *monarchCategoryLister) ListCategories(ctx context.Context) ([]*mm.TransactionCategory, error) {
+	return m.svc.List(ctx)
+}
+
 // TxToSync represents a satsbook transaction ready for Monarch export.
 type TxToSync struct {
 	SourceID  string
@@ -52,10 +67,12 @@ type TxSyncResult struct {
 
 // Syncer pushes BTC balance to a Monarch Money manual account.
 type Syncer struct {
-	accounts      AccountClient
-	transactions  TransactionClient
-	accountID     string // holdings account
-	txAccountID   string // transactions account (checking type)
+	accounts          AccountClient
+	transactions      TransactionClient
+	categories        CategoryLister
+	accountID         string // holdings account
+	txAccountID       string // transactions account (checking type)
+	defaultCategoryID string // cached "Uncategorized" category ID
 }
 
 // NewSyncer creates a Monarch syncer using a raw auth token.
@@ -67,6 +84,7 @@ func NewSyncer(token, accountID string) (*Syncer, error) {
 	return &Syncer{
 		accounts:     client.Accounts,
 		transactions: client.Transactions,
+		categories:   &monarchCategoryLister{svc: client.Transactions.Categories()},
 		accountID:    accountID,
 	}, nil
 }
@@ -89,7 +107,7 @@ func NewSyncerWithLogin(ctx context.Context, email, password, accountID string) 
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("get session: %w", err)
 	}
-	return &Syncer{accounts: client.Accounts, transactions: client.Transactions, accountID: accountID}, sess.Token, nil, nil
+	return &Syncer{accounts: client.Accounts, transactions: client.Transactions, categories: &monarchCategoryLister{svc: client.Transactions.Categories()}, accountID: accountID}, sess.Token, nil, nil
 }
 
 // ErrOTPRequired indicates that a second factor is needed.
@@ -110,7 +128,7 @@ func (p *PendingClient) CompleteOTP(ctx context.Context, email, password, otpCod
 	if err != nil {
 		return nil, "", fmt.Errorf("get session: %w", err)
 	}
-	return &Syncer{accounts: p.Client.Accounts, transactions: p.Client.Transactions, accountID: p.AccountID}, sess.Token, nil
+	return &Syncer{accounts: p.Client.Accounts, transactions: p.Client.Transactions, categories: &monarchCategoryLister{svc: p.Client.Transactions.Categories()}, accountID: p.AccountID}, sess.Token, nil
 }
 
 // NewSyncerWithClient creates a Syncer with a provided AccountClient (for testing).
@@ -255,6 +273,39 @@ func (s *Syncer) ensureTxAccount(ctx context.Context) (string, error) {
 	return acct.ID, nil
 }
 
+// ensureDefaultCategory finds the "Uncategorized" category ID (required by Monarch API).
+func (s *Syncer) ensureDefaultCategory(ctx context.Context) (string, error) {
+	if s.defaultCategoryID != "" {
+		return s.defaultCategoryID, nil
+	}
+	if s.categories == nil {
+		return "", fmt.Errorf("category lister not available")
+	}
+
+	cats, err := s.categories.ListCategories(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list categories: %w", err)
+	}
+
+	// Look for "Uncategorized" (case-insensitive)
+	for _, c := range cats {
+		if strings.EqualFold(c.Name, "uncategorized") {
+			s.defaultCategoryID = c.ID
+			log.Printf("monarch: using category %q (%s)", c.Name, c.ID)
+			return c.ID, nil
+		}
+	}
+
+	// Fallback: use the first category
+	if len(cats) > 0 {
+		s.defaultCategoryID = cats[0].ID
+		log.Printf("monarch: no 'Uncategorized' found, using %q (%s)", cats[0].Name, cats[0].ID)
+		return cats[0].ID, nil
+	}
+
+	return "", fmt.Errorf("no categories found in Monarch")
+}
+
 // SyncTransactions creates Monarch transactions for a batch of satsbook transactions.
 // It returns the result and a map of source_id -> monarch_tx_id for successful creates.
 // Transactions with zero USD amount are skipped. Rate-limited to avoid API throttling.
@@ -267,6 +318,12 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 	accountID, err := s.ensureTxAccount(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("ensure tx account: %w", err)
+	}
+
+	// Resolve the default category ID ("Uncategorized") — required by Monarch API
+	categoryID, err := s.ensureDefaultCategory(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve default category: %w", err)
 	}
 
 	result := &TxSyncResult{}
@@ -288,11 +345,12 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 		notes := notesForTx(tx)
 
 		params := &mm.CreateTransactionParams{
-			Date:      mm.Date{Time: tx.Time},
-			AccountID: accountID,
-			Amount:    tx.AmountUSD,
-			Merchant:  &mm.Merchant{Name: merchantName},
-			Notes:     notes,
+			Date:       mm.Date{Time: tx.Time},
+			AccountID:  accountID,
+			Amount:     tx.AmountUSD,
+			Merchant:   &mm.Merchant{Name: merchantName},
+			CategoryID: categoryID,
+			Notes:      notes,
 		}
 		log.Printf("monarch: creating tx: date=%s account=%s amount=%.2f merchant=%q notes=%q",
 			params.Date.Format("2006-01-02"), params.AccountID, params.Amount, merchantName, notes)

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -11,13 +11,16 @@ import (
 )
 
 const (
-	accountName   = "Bitcoin (Satsbook)"
-	btcSecurityID = "90020945152078462"
+	accountName      = "Bitcoin (Satsbook)"
+	txAccountName    = "Bitcoin Transactions (Satsbook)"
+	btcSecurityID    = "90020945152078462"
+	rateLimitDelay   = 500 * time.Millisecond // delay between API calls to avoid rate limiting
 )
 
 // AccountClient is the subset of the Monarch Money client used by Syncer.
 type AccountClient interface {
 	List(ctx context.Context) ([]*mm.Account, error)
+	Create(ctx context.Context, params *mm.CreateAccountParams) (*mm.Account, error)
 	Delete(ctx context.Context, accountID string) error
 	CreateInvestmentsAccount(ctx context.Context, params *mm.CreateInvestmentsAccountParams) (*mm.Account, error)
 	GetHoldings(ctx context.Context, accountID string) ([]*mm.Holding, error)
@@ -49,9 +52,10 @@ type TxSyncResult struct {
 
 // Syncer pushes BTC balance to a Monarch Money manual account.
 type Syncer struct {
-	accounts     AccountClient
-	transactions TransactionClient
-	accountID    string
+	accounts      AccountClient
+	transactions  TransactionClient
+	accountID     string // holdings account
+	txAccountID   string // transactions account (checking type)
 }
 
 // NewSyncer creates a Monarch syncer using a raw auth token.
@@ -215,28 +219,69 @@ func (s *Syncer) SyncHolding(ctx context.Context, btcQuantity float64) error {
 	return s.recreateAccount(ctx, btcQuantity)
 }
 
+// ensureTxAccount finds or creates the checking account used for transaction exports.
+func (s *Syncer) ensureTxAccount(ctx context.Context) (string, error) {
+	if s.txAccountID != "" {
+		return s.txAccountID, nil
+	}
+
+	// Look for existing tx account
+	accounts, err := s.accounts.List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list accounts: %w", err)
+	}
+	for _, a := range accounts {
+		if a.DisplayName == txAccountName {
+			s.txAccountID = a.ID
+			log.Printf("monarch: found existing tx account %s (%s)", txAccountName, a.ID)
+			return a.ID, nil
+		}
+	}
+
+	// Create a manual checking account for transactions
+	acct, err := s.accounts.Create(ctx, &mm.CreateAccountParams{
+		AccountType:       "depository",
+		AccountSubtype:    "checking",
+		IsAsset:           true,
+		AccountName:       txAccountName,
+		CurrentBalance:    0,
+		IncludeInNetWorth: false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("create tx account: %w", err)
+	}
+	s.txAccountID = acct.ID
+	log.Printf("monarch: created tx account %s (%s)", txAccountName, acct.ID)
+	return acct.ID, nil
+}
+
 // SyncTransactions creates Monarch transactions for a batch of satsbook transactions.
 // It returns the result and a map of source_id -> monarch_tx_id for successful creates.
-// Transactions with zero USD amount are skipped.
+// Transactions with zero USD amount are skipped. Rate-limited to avoid API throttling.
 func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSyncResult, map[string]string, error) {
 	if s.transactions == nil {
 		return nil, nil, fmt.Errorf("transaction client not available")
 	}
 
-	// Ensure we have an account to post transactions to
-	accountID, err := s.ensureAccount(ctx, 0)
+	// Use a separate checking account for transactions
+	accountID, err := s.ensureTxAccount(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("ensure account: %w", err)
+		return nil, nil, fmt.Errorf("ensure tx account: %w", err)
 	}
 
 	result := &TxSyncResult{}
 	synced := make(map[string]string)
 
-	for _, tx := range txns {
+	for i, tx := range txns {
 		// Skip transactions with no USD value
 		if math.Abs(tx.AmountUSD) < 0.01 {
 			result.Skipped++
 			continue
+		}
+
+		// Rate limit: pause between API calls
+		if i > 0 {
+			time.Sleep(rateLimitDelay)
 		}
 
 		merchantName := merchantForTx(tx)

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -29,9 +29,10 @@ type AccountClient interface {
 	CreateHolding(ctx context.Context, params *mm.CreateHoldingParams) (*mm.Holding, error)
 }
 
-// TransactionClient creates transactions in Monarch.
+// TransactionClient creates and queries transactions in Monarch.
 type TransactionClient interface {
 	Create(ctx context.Context, params *mm.CreateTransactionParams) (*mm.Transaction, error)
+	Query() mm.TransactionQueryBuilder
 }
 
 // CategoryLister lists Monarch transaction categories.
@@ -309,6 +310,7 @@ func (s *Syncer) ensureDefaultCategory(ctx context.Context) (string, error) {
 // SyncTransactions creates Monarch transactions for a batch of satsbook transactions.
 // It returns the result and a map of source_id -> monarch_tx_id for successful creates.
 // Transactions with zero USD amount are skipped. Rate-limited to avoid API throttling.
+// Existing transactions in Monarch are detected by notes and skipped to prevent duplicates.
 func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSyncResult, map[string]string, error) {
 	if s.transactions == nil {
 		return nil, nil, fmt.Errorf("transaction client not available")
@@ -326,12 +328,23 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 		return nil, nil, fmt.Errorf("resolve default category: %w", err)
 	}
 
+	// Fetch existing transactions from Monarch to detect duplicates.
+	// Notes contain source_id so we can match without creating duplicates.
+	existing := s.fetchExistingSourceIDs(ctx, accountID)
+
 	result := &TxSyncResult{}
 	synced := make(map[string]string)
 
 	for i, tx := range txns {
 		// Skip transactions with no USD value
 		if math.Abs(tx.AmountUSD) < 0.01 {
+			result.Skipped++
+			continue
+		}
+
+		// Skip if already in Monarch (dedup by source_id found in notes)
+		if monarchID, ok := existing[tx.SourceID]; ok {
+			synced[tx.SourceID] = monarchID
 			result.Skipped++
 			continue
 		}
@@ -366,6 +379,39 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 	}
 
 	return result, synced, nil
+}
+
+// fetchExistingSourceIDs queries Monarch for all transactions on the given account
+// and extracts source_ids from the notes field. Returns a map of source_id -> monarch_tx_id.
+func (s *Syncer) fetchExistingSourceIDs(ctx context.Context, accountID string) map[string]string {
+	existing := make(map[string]string)
+	if s.transactions == nil {
+		return existing
+	}
+
+	txList, err := s.transactions.Query().
+		WithAccounts(accountID).
+		Limit(10000).
+		Execute(ctx)
+	if err != nil {
+		log.Printf("monarch: dedup check failed (will create without dedup): %v", err)
+		return existing
+	}
+
+	for _, tx := range txList.Transactions {
+		if tx.Notes == "" {
+			continue
+		}
+		// Notes format: "[tx_type] source_id"
+		// Extract source_id after the last "] "
+		if idx := strings.LastIndex(tx.Notes, "] "); idx >= 0 {
+			sourceID := tx.Notes[idx+2:]
+			existing[sourceID] = tx.ID
+		}
+	}
+
+	log.Printf("monarch: found %d existing transactions for dedup", len(existing))
+	return existing
 }
 
 // merchantForTx builds a descriptive merchant name for a Monarch transaction.

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -344,13 +344,15 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 		merchantName := merchantForTx(tx)
 		notes := notesForTx(tx)
 
+		noBalance := false
 		params := &mm.CreateTransactionParams{
-			Date:       mm.Date{Time: tx.Time},
-			AccountID:  accountID,
-			Amount:     -tx.AmountUSD,
-			Merchant:   &mm.Merchant{Name: merchantName},
-			CategoryID: categoryID,
-			Notes:      notes,
+			Date:                mm.Date{Time: tx.Time},
+			AccountID:           accountID,
+			Amount:              tx.AmountUSD,
+			Merchant:            &mm.Merchant{Name: merchantName},
+			CategoryID:          categoryID,
+			Notes:               notes,
+			ShouldUpdateBalance: &noBalance,
 		}
 		created, err := s.transactions.Create(ctx, params)
 		if err != nil {

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -347,7 +347,7 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 		params := &mm.CreateTransactionParams{
 			Date:       mm.Date{Time: tx.Time},
 			AccountID:  accountID,
-			Amount:     tx.AmountUSD,
+			Amount:     -tx.AmountUSD,
 			Merchant:   &mm.Merchant{Name: merchantName},
 			CategoryID: categoryID,
 			Notes:      notes,

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
 	mm "github.com/eshaffer321/monarchmoney-go/pkg/monarch"
@@ -74,6 +75,7 @@ type Syncer struct {
 	accountID         string // holdings account
 	txAccountID       string // transactions account (checking type)
 	defaultCategoryID string // cached "Uncategorized" category ID
+	txSyncMu          sync.Mutex // prevents concurrent transaction syncs
 }
 
 // NewSyncer creates a Monarch syncer using a raw auth token.
@@ -312,6 +314,9 @@ func (s *Syncer) ensureDefaultCategory(ctx context.Context) (string, error) {
 // Transactions with zero USD amount are skipped. Rate-limited to avoid API throttling.
 // Existing transactions in Monarch are detected by notes and skipped to prevent duplicates.
 func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSyncResult, map[string]string, error) {
+	s.txSyncMu.Lock()
+	defer s.txSyncMu.Unlock()
+
 	if s.transactions == nil {
 		return nil, nil, fmt.Errorf("transaction client not available")
 	}

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -352,18 +352,10 @@ func (s *Syncer) SyncTransactions(ctx context.Context, txns []TxToSync) (*TxSync
 			CategoryID: categoryID,
 			Notes:      notes,
 		}
-		log.Printf("monarch: creating tx: date=%s account=%s amount=%.2f merchant=%q notes=%q",
-			params.Date.Format("2006-01-02"), params.AccountID, params.Amount, merchantName, notes)
-
 		created, err := s.transactions.Create(ctx, params)
 		if err != nil {
 			log.Printf("monarch: failed to create tx %s: %v", tx.SourceID, err)
 			result.Errors++
-			if i == 0 {
-				// Log full error detail for first failure only
-				log.Printf("monarch: first failure detail — params: date=%s accountId=%s amount=%.2f merchant=%q notes=%q err=%#v",
-					params.Date.Format("2006-01-02"), params.AccountID, params.Amount, merchantName, notes, err)
-			}
 			continue
 		}
 

--- a/internal/monarch/sync_test.go
+++ b/internal/monarch/sync_test.go
@@ -29,6 +29,10 @@ func (m *mockAccountClient) List(ctx context.Context) ([]*mm.Account, error) {
 	return m.accounts, m.listErr
 }
 
+func (m *mockAccountClient) Create(ctx context.Context, params *mm.CreateAccountParams) (*mm.Account, error) {
+	return &mm.Account{ID: "new-manual-id", DisplayName: params.AccountName}, nil
+}
+
 func (m *mockAccountClient) Delete(ctx context.Context, accountID string) error {
 	m.deletedAccountID = accountID
 	return m.deleteErr

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -3,10 +3,12 @@ package syncer
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/satsbook/satsbook/internal/db"
 	"github.com/satsbook/satsbook/internal/lnd"
+	"github.com/satsbook/satsbook/internal/monarch"
 )
 
 // LNDClient defines the interface for interacting with the LND node.
@@ -38,6 +40,18 @@ type PriceProvider interface {
 // MonarchSyncer pushes BTC holdings to Monarch Money.
 type MonarchSyncer interface {
 	SyncHolding(ctx context.Context, btcQuantity float64) error
+	SyncTransactions(ctx context.Context, txns []monarch.TxToSync) (*monarch.TxSyncResult, map[string]string, error)
+}
+
+// MonarchTxStore reads unsynced transactions and records synced ones.
+type MonarchTxStore interface {
+	ListUnsyncedTransactions(ctx context.Context, txTypes []string) ([]db.UnifiedTransaction, error)
+	MarkTransactionSynced(ctx context.Context, sourceID, monarchTxID string) error
+}
+
+// SettingsReader reads app settings.
+type SettingsReader interface {
+	GetSetting(ctx context.Context, key string) (string, error)
 }
 
 // Syncer orchestrates LND data synchronization.
@@ -47,6 +61,8 @@ type Syncer struct {
 	snapshot       SnapshotStore
 	price          PriceProvider
 	monarch        MonarchSyncer
+	monarchTxStore MonarchTxStore
+	settings       SettingsReader
 	logger         *log.Logger
 	syncInterval   time.Duration
 	maxHistoryDays int
@@ -72,6 +88,12 @@ func (s *Syncer) SetSnapshotStore(ss SnapshotStore, pp PriceProvider) {
 // SetMonarchSyncer sets the Monarch Money syncer for recurring holdings sync.
 func (s *Syncer) SetMonarchSyncer(ms MonarchSyncer) {
 	s.monarch = ms
+}
+
+// SetMonarchTxSync sets the stores needed for automatic Monarch transaction syncing.
+func (s *Syncer) SetMonarchTxSync(txStore MonarchTxStore, settings SettingsReader) {
+	s.monarchTxStore = txStore
+	s.settings = settings
 }
 
 // Run blocks until ctx is cancelled, syncing on startup and then on the configured interval.
@@ -110,6 +132,11 @@ func (s *Syncer) Sync(ctx context.Context) error {
 		s.captureSnapshot(ctx)
 	}
 
+	// Sync transactions to Monarch if configured
+	if s.monarch != nil && s.monarchTxStore != nil && s.settings != nil {
+		s.syncMonarchTransactions(ctx)
+	}
+
 	return nil
 }
 
@@ -138,6 +165,50 @@ func (s *Syncer) captureSnapshot(ctx context.Context) {
 			s.logger.Printf("monarch: sync failed: %v", err)
 		}
 	}
+}
+
+// syncMonarchTransactions syncs unsynced transactions to Monarch Money.
+func (s *Syncer) syncMonarchTransactions(ctx context.Context) {
+	syncTypes, err := s.settings.GetSetting(ctx, "monarch_sync_types")
+	if err != nil || syncTypes == "" {
+		return // no types configured, skip
+	}
+
+	types := strings.Split(syncTypes, ",")
+	txns, err := s.monarchTxStore.ListUnsyncedTransactions(ctx, types)
+	if err != nil {
+		s.logger.Printf("monarch tx sync: list unsynced: %v", err)
+		return
+	}
+	if len(txns) == 0 {
+		return
+	}
+
+	toSync := make([]monarch.TxToSync, len(txns))
+	for i, tx := range txns {
+		toSync[i] = monarch.TxToSync{
+			SourceID:  tx.SourceID,
+			Source:    tx.Source,
+			TxType:   tx.TxType,
+			Time:     tx.Time,
+			AmountUSD: tx.AmountUSD,
+			Memo:     tx.Memo,
+		}
+	}
+
+	result, synced, err := s.monarch.SyncTransactions(ctx, toSync)
+	if err != nil {
+		s.logger.Printf("monarch tx sync failed: %v", err)
+		return
+	}
+
+	for sourceID, monarchTxID := range synced {
+		if err := s.monarchTxStore.MarkTransactionSynced(ctx, sourceID, monarchTxID); err != nil {
+			s.logger.Printf("monarch: failed to mark %s synced: %v", sourceID, err)
+		}
+	}
+
+	s.logger.Printf("monarch tx sync: %d created, %d skipped, %d errors", result.Created, result.Skipped, result.Errors)
 }
 
 // syncCycle is the core sync logic, executed within a transaction.

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -45,7 +45,7 @@ type MonarchSyncer interface {
 
 // MonarchTxStore reads unsynced transactions and records synced ones.
 type MonarchTxStore interface {
-	ListUnsyncedTransactions(ctx context.Context, txTypes []string) ([]db.UnifiedTransaction, error)
+	ListUnsyncedTransactions(ctx context.Context, txTypes []string, sources []string) ([]db.UnifiedTransaction, error)
 	MarkTransactionSynced(ctx context.Context, sourceID, monarchTxID string) error
 }
 
@@ -175,7 +175,13 @@ func (s *Syncer) syncMonarchTransactions(ctx context.Context) {
 	}
 
 	types := strings.Split(syncTypes, ",")
-	txns, err := s.monarchTxStore.ListUnsyncedTransactions(ctx, types)
+
+	var sources []string
+	if v, err := s.settings.GetSetting(ctx, "monarch_sync_sources"); err == nil && v != "" {
+		sources = strings.Split(v, ",")
+	}
+
+	txns, err := s.monarchTxStore.ListUnsyncedTransactions(ctx, types, sources)
 	if err != nil {
 		s.logger.Printf("monarch tx sync: list unsynced: %v", err)
 		return

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/satsbook/satsbook/internal/db"
 	"github.com/satsbook/satsbook/internal/lnd"
+	"github.com/satsbook/satsbook/internal/monarch"
 )
 
 // mockLNDClient mocks the LNDClient interface with per-method error control.
@@ -75,6 +76,7 @@ func (m *mockLNDClient) WalletBalance(ctx context.Context) (*lnd.WalletBalance, 
 // mockStore mocks the Store interface.
 type mockStore struct {
 	syncState map[string]syncStateEntry
+	txConfig  *mockSyncTx // optional pre-configured tx for error injection
 }
 
 type syncStateEntry struct {
@@ -92,6 +94,16 @@ func (m *mockStore) RunSync(ctx context.Context, fn func(db.SyncTx) error) error
 	tx := &mockSyncTx{
 		store: m,
 	}
+	if m.txConfig != nil {
+		tx.insertForwardingErr = m.txConfig.insertForwardingErr
+		tx.upsertChannelsErr = m.txConfig.upsertChannelsErr
+		tx.upsertInvoicesErr = m.txConfig.upsertInvoicesErr
+		tx.upsertPaymentsErr = m.txConfig.upsertPaymentsErr
+		tx.upsertOnchainErr = m.txConfig.upsertOnchainErr
+		tx.insertBalanceErr = m.txConfig.insertBalanceErr
+		tx.setSyncStateErr = m.txConfig.setSyncStateErr
+		tx.getSyncStateErr = m.txConfig.getSyncStateErr
+	}
 	return fn(tx)
 }
 
@@ -104,9 +116,24 @@ type mockSyncTx struct {
 	paymentsUpserted         []db.Payment
 	onchainTxnsUpserted      []db.OnchainTx
 	balanceSnapshots         []db.WalletBalanceSnapshot
+
+	// Per-method errors for targeted failure testing
+	insertForwardingErr error
+	upsertChannelsErr   error
+	upsertInvoicesErr   error
+	upsertPaymentsErr   error
+	upsertOnchainErr    error
+	insertBalanceErr    error
+	setSyncStateErr     map[string]error // keyed by source
+	getSyncStateErr     map[string]error // keyed by source
 }
 
 func (m *mockSyncTx) GetSyncState(source string) (time.Time, int64, error) {
+	if m.getSyncStateErr != nil {
+		if err, ok := m.getSyncStateErr[source]; ok {
+			return time.Time{}, 0, err
+		}
+	}
 	if entry, ok := m.store.syncState[source]; ok {
 		return entry.lastSyncedAt, entry.lastOffset, nil
 	}
@@ -114,6 +141,11 @@ func (m *mockSyncTx) GetSyncState(source string) (time.Time, int64, error) {
 }
 
 func (m *mockSyncTx) SetSyncState(source string, syncedAt time.Time, offset int64) error {
+	if m.setSyncStateErr != nil {
+		if err, ok := m.setSyncStateErr[source]; ok {
+			return err
+		}
+	}
 	m.store.syncState[source] = syncStateEntry{
 		lastSyncedAt: syncedAt,
 		lastOffset:   offset,
@@ -122,31 +154,49 @@ func (m *mockSyncTx) SetSyncState(source string, syncedAt time.Time, offset int6
 }
 
 func (m *mockSyncTx) InsertForwardingEvents(events []db.ForwardingEvent) error {
+	if m.insertForwardingErr != nil {
+		return m.insertForwardingErr
+	}
 	m.forwardingEventsInserted = append(m.forwardingEventsInserted, events...)
 	return nil
 }
 
 func (m *mockSyncTx) UpsertChannels(channels []db.Channel) error {
+	if m.upsertChannelsErr != nil {
+		return m.upsertChannelsErr
+	}
 	m.channelsUpserted = append(m.channelsUpserted, channels...)
 	return nil
 }
 
 func (m *mockSyncTx) UpsertInvoices(invoices []db.Invoice) error {
+	if m.upsertInvoicesErr != nil {
+		return m.upsertInvoicesErr
+	}
 	m.invoicesUpserted = append(m.invoicesUpserted, invoices...)
 	return nil
 }
 
 func (m *mockSyncTx) UpsertPayments(payments []db.Payment) error {
+	if m.upsertPaymentsErr != nil {
+		return m.upsertPaymentsErr
+	}
 	m.paymentsUpserted = append(m.paymentsUpserted, payments...)
 	return nil
 }
 
 func (m *mockSyncTx) UpsertOnchainTxns(txns []db.OnchainTx) error {
+	if m.upsertOnchainErr != nil {
+		return m.upsertOnchainErr
+	}
 	m.onchainTxnsUpserted = append(m.onchainTxnsUpserted, txns...)
 	return nil
 }
 
 func (m *mockSyncTx) InsertWalletBalanceSnapshot(s db.WalletBalanceSnapshot) error {
+	if m.insertBalanceErr != nil {
+		return m.insertBalanceErr
+	}
 	m.balanceSnapshots = append(m.balanceSnapshots, s)
 	return nil
 }
@@ -570,6 +620,681 @@ func TestSync_NoSnapshotWithoutStore(t *testing.T) {
 		t.Fatalf("sync failed: %v", err)
 	}
 	// No panic, no snapshot — just passes
+}
+
+// --- Mock helpers for Monarch transaction sync ---
+
+// mockMonarchSyncer mocks the MonarchSyncer interface.
+type mockMonarchSyncer struct {
+	syncHoldingErr error
+	syncHoldingCalls []float64
+
+	syncTxResult *monarch.TxSyncResult
+	syncTxSynced map[string]string
+	syncTxErr    error
+	syncTxCalls  int
+}
+
+func (m *mockMonarchSyncer) SyncHolding(ctx context.Context, btcQuantity float64) error {
+	m.syncHoldingCalls = append(m.syncHoldingCalls, btcQuantity)
+	return m.syncHoldingErr
+}
+
+func (m *mockMonarchSyncer) SyncTransactions(ctx context.Context, txns []monarch.TxToSync) (*monarch.TxSyncResult, map[string]string, error) {
+	m.syncTxCalls++
+	if m.syncTxErr != nil {
+		return nil, nil, m.syncTxErr
+	}
+	return m.syncTxResult, m.syncTxSynced, nil
+}
+
+// mockMonarchTxStore mocks the MonarchTxStore interface.
+type mockMonarchTxStore struct {
+	unsyncedTxns    []db.UnifiedTransaction
+	unsyncedErr     error
+	markedSynced    map[string]string // sourceID -> monarchTxID
+	markSyncedErr   error
+}
+
+func newMockMonarchTxStore() *mockMonarchTxStore {
+	return &mockMonarchTxStore{
+		markedSynced: make(map[string]string),
+	}
+}
+
+func (m *mockMonarchTxStore) ListUnsyncedTransactions(ctx context.Context, txTypes []string, sources []string) ([]db.UnifiedTransaction, error) {
+	if m.unsyncedErr != nil {
+		return nil, m.unsyncedErr
+	}
+	return m.unsyncedTxns, nil
+}
+
+func (m *mockMonarchTxStore) MarkTransactionSynced(ctx context.Context, sourceID, monarchTxID string) error {
+	if m.markSyncedErr != nil {
+		return m.markSyncedErr
+	}
+	m.markedSynced[sourceID] = monarchTxID
+	return nil
+}
+
+// mockSettingsReader mocks the SettingsReader interface.
+type mockSettingsReader struct {
+	settings map[string]string
+	err      error
+}
+
+func (m *mockSettingsReader) GetSetting(ctx context.Context, key string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.settings[key], nil
+}
+
+// defaultEmptyLND creates a mock LND client with empty data and valid balance.
+func defaultEmptyLND() *mockLNDClient {
+	return &mockLNDClient{
+		channels:          []lnd.Channel{},
+		forwardingHistory: []lnd.ForwardingEvent{},
+		invoices:          []lnd.Invoice{},
+		payments:          []lnd.Payment{},
+		walletBalance:     defaultMockBalance(),
+	}
+}
+
+// --- Tests for SetMonarchSyncer / SetMonarchTxSync ---
+
+func TestSetMonarchSyncer(t *testing.T) {
+	s := newTestSyncer(defaultEmptyLND(), newMockStore())
+	ms := &mockMonarchSyncer{}
+	s.SetMonarchSyncer(ms)
+	if s.monarch == nil {
+		t.Error("expected monarch syncer to be set")
+	}
+}
+
+func TestSetMonarchTxSync(t *testing.T) {
+	s := newTestSyncer(defaultEmptyLND(), newMockStore())
+	txStore := newMockMonarchTxStore()
+	settings := &mockSettingsReader{settings: map[string]string{}}
+	s.SetMonarchTxSync(txStore, settings)
+	if s.monarchTxStore != txStore {
+		t.Error("expected monarchTxStore to be set")
+	}
+	if s.settings != settings {
+		t.Error("expected settings to be set")
+	}
+}
+
+// --- Tests for captureSnapshot edge cases ---
+
+func TestSync_SnapshotTotalSatsError(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	ss := &mockSnapshotStore{totalErr: errors.New("db error")}
+	pp := &mockPriceProvider{price: 65000.0}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetSnapshotStore(ss, pp)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync should not fail due to snapshot error: %v", err)
+	}
+	// No snapshot should be inserted
+	if len(ss.inserted) != 0 {
+		t.Errorf("expected 0 snapshots, got %d", len(ss.inserted))
+	}
+}
+
+func TestSync_SnapshotInsertError(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	ss := &mockSnapshotStore{totalSats: 1_000_000, insertErr: errors.New("insert failed")}
+	pp := &mockPriceProvider{price: 65000.0}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetSnapshotStore(ss, pp)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync should not fail due to snapshot insert error: %v", err)
+	}
+	// Insert was attempted but failed — that's logged, not returned
+}
+
+func TestSync_CaptureSnapshotWithMonarchHoldings(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	ss := &mockSnapshotStore{totalSats: 5_000_000}
+	pp := &mockPriceProvider{price: 65000.0}
+	ms := &mockMonarchSyncer{}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetSnapshotStore(ss, pp)
+	s.SetMonarchSyncer(ms)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	// Should have called SyncHolding with the correct BTC quantity
+	if len(ms.syncHoldingCalls) != 1 {
+		t.Fatalf("expected 1 SyncHolding call, got %d", len(ms.syncHoldingCalls))
+	}
+	expected := float64(5_000_000) / 1e8
+	if ms.syncHoldingCalls[0] != expected {
+		t.Errorf("expected BTC quantity %f, got %f", expected, ms.syncHoldingCalls[0])
+	}
+}
+
+func TestSync_CaptureSnapshotMonarchSyncError(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	ss := &mockSnapshotStore{totalSats: 5_000_000}
+	pp := &mockPriceProvider{price: 65000.0}
+	ms := &mockMonarchSyncer{syncHoldingErr: errors.New("monarch down")}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetSnapshotStore(ss, pp)
+	s.SetMonarchSyncer(ms)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync should not fail due to monarch error: %v", err)
+	}
+	// Snapshot should still be inserted
+	if len(ss.inserted) != 1 {
+		t.Errorf("expected 1 snapshot, got %d", len(ss.inserted))
+	}
+}
+
+// --- Tests for syncMonarchTransactions ---
+
+func TestSync_MonarchTxSync_NoTypesConfigured(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	ms := &mockMonarchSyncer{}
+	txStore := newMockMonarchTxStore()
+	settings := &mockSettingsReader{settings: map[string]string{}} // no monarch_sync_types
+
+	s := newTestSyncer(mockLND, store)
+	s.SetMonarchSyncer(ms)
+	s.SetMonarchTxSync(txStore, settings)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	// No SyncTransactions call should happen
+	if ms.syncTxCalls != 0 {
+		t.Errorf("expected 0 SyncTransactions calls, got %d", ms.syncTxCalls)
+	}
+}
+
+func TestSync_MonarchTxSync_SettingsError(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	ms := &mockMonarchSyncer{}
+	txStore := newMockMonarchTxStore()
+	settings := &mockSettingsReader{err: errors.New("db error")}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetMonarchSyncer(ms)
+	s.SetMonarchTxSync(txStore, settings)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if ms.syncTxCalls != 0 {
+		t.Errorf("expected 0 SyncTransactions calls, got %d", ms.syncTxCalls)
+	}
+}
+
+func TestSync_MonarchTxSync_ListUnsyncedError(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	ms := &mockMonarchSyncer{}
+	txStore := newMockMonarchTxStore()
+	txStore.unsyncedErr = errors.New("db error")
+	settings := &mockSettingsReader{settings: map[string]string{
+		"monarch_sync_types": "buy,sell",
+	}}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetMonarchSyncer(ms)
+	s.SetMonarchTxSync(txStore, settings)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync should not fail due to tx list error: %v", err)
+	}
+	if ms.syncTxCalls != 0 {
+		t.Errorf("expected 0 SyncTransactions calls, got %d", ms.syncTxCalls)
+	}
+}
+
+func TestSync_MonarchTxSync_NoUnsyncedTxns(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	ms := &mockMonarchSyncer{}
+	txStore := newMockMonarchTxStore()
+	txStore.unsyncedTxns = []db.UnifiedTransaction{} // empty
+	settings := &mockSettingsReader{settings: map[string]string{
+		"monarch_sync_types": "buy,sell",
+	}}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetMonarchSyncer(ms)
+	s.SetMonarchTxSync(txStore, settings)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if ms.syncTxCalls != 0 {
+		t.Errorf("expected 0 SyncTransactions calls for empty list, got %d", ms.syncTxCalls)
+	}
+}
+
+func TestSync_MonarchTxSync_Success(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	now := time.Now()
+	txStore := newMockMonarchTxStore()
+	txStore.unsyncedTxns = []db.UnifiedTransaction{
+		{SourceID: "strike:123", Source: "strike", TxType: "buy", Time: now, AmountUSD: 100.50, Memo: "DCA"},
+		{SourceID: "strike:456", Source: "strike", TxType: "buy", Time: now, AmountUSD: 200.00, Memo: "Purchase"},
+	}
+
+	ms := &mockMonarchSyncer{
+		syncTxResult: &monarch.TxSyncResult{Created: 2, Skipped: 0, Errors: 0},
+		syncTxSynced: map[string]string{
+			"strike:123": "monarch-tx-1",
+			"strike:456": "monarch-tx-2",
+		},
+	}
+
+	settings := &mockSettingsReader{settings: map[string]string{
+		"monarch_sync_types": "buy,sell",
+	}}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetMonarchSyncer(ms)
+	s.SetMonarchTxSync(txStore, settings)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	if ms.syncTxCalls != 1 {
+		t.Fatalf("expected 1 SyncTransactions call, got %d", ms.syncTxCalls)
+	}
+
+	// Both transactions should be marked synced
+	if len(txStore.markedSynced) != 2 {
+		t.Fatalf("expected 2 marked synced, got %d", len(txStore.markedSynced))
+	}
+	if txStore.markedSynced["strike:123"] != "monarch-tx-1" {
+		t.Errorf("expected monarch-tx-1 for strike:123, got %s", txStore.markedSynced["strike:123"])
+	}
+	if txStore.markedSynced["strike:456"] != "monarch-tx-2" {
+		t.Errorf("expected monarch-tx-2 for strike:456, got %s", txStore.markedSynced["strike:456"])
+	}
+}
+
+func TestSync_MonarchTxSync_WithSources(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	txStore := newMockMonarchTxStore()
+	txStore.unsyncedTxns = []db.UnifiedTransaction{
+		{SourceID: "river:1", Source: "river", TxType: "buy", Time: time.Now(), AmountUSD: 50.0},
+	}
+
+	ms := &mockMonarchSyncer{
+		syncTxResult: &monarch.TxSyncResult{Created: 1},
+		syncTxSynced: map[string]string{"river:1": "mtx-1"},
+	}
+
+	settings := &mockSettingsReader{settings: map[string]string{
+		"monarch_sync_types":   "buy",
+		"monarch_sync_sources": "river,strike",
+	}}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetMonarchSyncer(ms)
+	s.SetMonarchTxSync(txStore, settings)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if ms.syncTxCalls != 1 {
+		t.Errorf("expected 1 SyncTransactions call, got %d", ms.syncTxCalls)
+	}
+}
+
+func TestSync_MonarchTxSync_SyncError(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	txStore := newMockMonarchTxStore()
+	txStore.unsyncedTxns = []db.UnifiedTransaction{
+		{SourceID: "s:1", Source: "strike", TxType: "buy", Time: time.Now(), AmountUSD: 10.0},
+	}
+
+	ms := &mockMonarchSyncer{syncTxErr: errors.New("monarch API error")}
+	settings := &mockSettingsReader{settings: map[string]string{
+		"monarch_sync_types": "buy",
+	}}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetMonarchSyncer(ms)
+	s.SetMonarchTxSync(txStore, settings)
+
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync should not fail due to monarch tx error: %v", err)
+	}
+	// Nothing should be marked synced
+	if len(txStore.markedSynced) != 0 {
+		t.Errorf("expected 0 marked synced on error, got %d", len(txStore.markedSynced))
+	}
+}
+
+func TestSync_MonarchTxSync_MarkSyncedError(t *testing.T) {
+	store := newMockStore()
+	mockLND := defaultEmptyLND()
+
+	txStore := newMockMonarchTxStore()
+	txStore.unsyncedTxns = []db.UnifiedTransaction{
+		{SourceID: "s:1", Source: "strike", TxType: "buy", Time: time.Now(), AmountUSD: 10.0},
+	}
+	txStore.markSyncedErr = errors.New("db write error")
+
+	ms := &mockMonarchSyncer{
+		syncTxResult: &monarch.TxSyncResult{Created: 1},
+		syncTxSynced: map[string]string{"s:1": "mtx-1"},
+	}
+	settings := &mockSettingsReader{settings: map[string]string{
+		"monarch_sync_types": "buy",
+	}}
+
+	s := newTestSyncer(mockLND, store)
+	s.SetMonarchSyncer(ms)
+	s.SetMonarchTxSync(txStore, settings)
+
+	// Should not fail — mark error is logged, not returned
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync should not fail due to mark synced error: %v", err)
+	}
+}
+
+// --- Tests for insert/upsert and SetSyncState error paths ---
+
+func TestSync_InsertForwardingEventsError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{insertForwardingErr: errors.New("insert failed")}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from InsertForwardingEvents failure")
+	}
+}
+
+func TestSync_SetSyncStateForwardingError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{setSyncStateErr: map[string]error{"forwarding": errors.New("state error")}}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from SetSyncState forwarding failure")
+	}
+}
+
+func TestSync_UpsertChannelsError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{upsertChannelsErr: errors.New("upsert failed")}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from UpsertChannels failure")
+	}
+}
+
+func TestSync_UpsertInvoicesError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{upsertInvoicesErr: errors.New("upsert failed")}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from UpsertInvoices failure")
+	}
+}
+
+func TestSync_SetSyncStateInvoicesError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{setSyncStateErr: map[string]error{"invoices": errors.New("state error")}}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from SetSyncState invoices failure")
+	}
+}
+
+func TestSync_UpsertPaymentsError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{upsertPaymentsErr: errors.New("upsert failed")}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from UpsertPayments failure")
+	}
+}
+
+func TestSync_SetSyncStatePaymentsError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{setSyncStateErr: map[string]error{"payments": errors.New("state error")}}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from SetSyncState payments failure")
+	}
+}
+
+func TestSync_UpsertOnchainTxnsError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{upsertOnchainErr: errors.New("upsert failed")}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from UpsertOnchainTxns failure")
+	}
+}
+
+func TestSync_SetSyncStateOnchainError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{setSyncStateErr: map[string]error{"onchain": errors.New("state error")}}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from SetSyncState onchain failure")
+	}
+}
+
+func TestSync_InsertWalletBalanceSnapshotError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{insertBalanceErr: errors.New("insert failed")}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from InsertWalletBalanceSnapshot failure")
+	}
+}
+
+func TestSync_GetSyncStateForwardingError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{getSyncStateErr: map[string]error{"forwarding": errors.New("state read error")}}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GetSyncState forwarding failure")
+	}
+}
+
+func TestSync_GetSyncStateInvoicesError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{getSyncStateErr: map[string]error{"invoices": errors.New("state read error")}}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GetSyncState invoices failure")
+	}
+}
+
+func TestSync_GetSyncStatePaymentsError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{getSyncStateErr: map[string]error{"payments": errors.New("state read error")}}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GetSyncState payments failure")
+	}
+}
+
+func TestSync_WithOnchainTransactions(t *testing.T) {
+	store := newMockStore()
+	now := time.Now()
+	mockLND := &mockLNDClient{
+		channels:          []lnd.Channel{},
+		forwardingHistory: []lnd.ForwardingEvent{},
+		invoices:          []lnd.Invoice{},
+		payments:          []lnd.Payment{},
+		onchainTxns: []lnd.OnchainTx{
+			{
+				TxHash:           "abc123",
+				Amount:           50000,
+				NumConfirmations: 6,
+				Timestamp:        now,
+				Label:            "channel open",
+			},
+		},
+		walletBalance: defaultMockBalance(),
+	}
+
+	s := newTestSyncer(mockLND, store)
+	err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+}
+
+func TestSync_SetSyncStateWalletError(t *testing.T) {
+	store := newMockStore()
+	store.txConfig = &mockSyncTx{setSyncStateErr: map[string]error{"wallet": errors.New("state error")}}
+	s := newTestSyncer(defaultEmptyLND(), store)
+	err := s.Sync(context.Background())
+	if err == nil {
+		t.Fatal("expected error from SetSyncState wallet failure")
+	}
+}
+
+// --- Tests for Run error logging paths ---
+
+func TestRun_InitialSyncError(t *testing.T) {
+	store := newMockStore()
+	mockLND := &mockLNDClient{
+		forwardingHistoryErr: errors.New("lnd down"),
+		walletBalance:        defaultMockBalance(),
+	}
+
+	logger := log.New(os.Stderr, "[syncer-test] ", 0)
+	s := New(mockLND, store, logger, 1*time.Hour, 90)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	// Give Run time to attempt the initial sync (which will fail)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Success — Run logged the error and continued to wait
+	case <-time.After(2 * time.Second):
+		t.Error("Run did not stop within timeout")
+	}
+}
+
+func TestRun_TickerSyncError(t *testing.T) {
+	// Use a failing store that errors on the second call onward
+	store := &countingMockStore{
+		inner:    newMockStore(),
+		failFrom: 2, // first call (initial sync) succeeds, second (ticker) fails
+	}
+
+	mockLND := &mockLNDClient{
+		channels:          []lnd.Channel{},
+		forwardingHistory: []lnd.ForwardingEvent{},
+		invoices:          []lnd.Invoice{},
+		payments:          []lnd.Payment{},
+		walletBalance:     defaultMockBalance(),
+	}
+
+	logger := log.New(os.Stderr, "[syncer-test] ", 0)
+	s := New(mockLND, store, logger, 50*time.Millisecond, 90)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for initial sync + at least one ticker sync (which will fail)
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Success — Run logged the ticker error and continued
+	case <-time.After(2 * time.Second):
+		t.Error("Run did not stop within timeout")
+	}
+}
+
+// countingMockStore wraps mockStore but fails RunSync from the Nth call onward.
+type countingMockStore struct {
+	inner    *mockStore
+	failFrom int
+	calls    int
+}
+
+func (c *countingMockStore) RunSync(ctx context.Context, fn func(db.SyncTx) error) error {
+	c.calls++
+	if c.calls >= c.failFrom {
+		return errors.New("deliberate sync failure")
+	}
+	return c.inner.RunSync(ctx, fn)
 }
 
 func TestRun_StopsOnCancel(t *testing.T) {

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -85,6 +85,15 @@ type TransactionStore interface {
 // MonarchSyncer syncs BTC holdings to Monarch Money.
 type MonarchSyncer interface {
 	SyncHolding(ctx context.Context, btcQuantity float64) error
+	SyncTransactions(ctx context.Context, txns []monarch.TxToSync) (*monarch.TxSyncResult, map[string]string, error)
+}
+
+// MonarchTxStore defines DB operations for Monarch transaction sync tracking.
+type MonarchTxStore interface {
+	ListUnsyncedTransactions(ctx context.Context, txTypes []string) ([]db.UnifiedTransaction, error)
+	MarkTransactionSynced(ctx context.Context, sourceID, monarchTxID string) error
+	MonarchSyncedCount(ctx context.Context) (int, error)
+	DistinctTransactionValues(ctx context.Context) (sources []string, txTypes []string, err error)
 }
 
 // Handler serves dashboard API and HTML endpoints.
@@ -98,6 +107,7 @@ type Handler struct {
 	settingsStore    SettingsStore
 	txStore          TransactionStore
 	monarchSyncer    MonarchSyncer
+	monarchTxStore   MonarchTxStore
 	onMonarchChange  func(MonarchSyncer)
 	pendingMonarch   *monarch.PendingClient
 	logger           *log.Logger
@@ -146,6 +156,11 @@ func (h *Handler) SetSettingsStore(ss SettingsStore) {
 // SetTransactionStore sets the transaction store for the unified ledger.
 func (h *Handler) SetTransactionStore(ts TransactionStore) {
 	h.txStore = ts
+}
+
+// SetMonarchTxStore sets the store for Monarch transaction sync tracking.
+func (h *Handler) SetMonarchTxStore(ts MonarchTxStore) {
+	h.monarchTxStore = ts
 }
 
 // SetMonarchSyncer sets the Monarch syncer and notifies any registered listener.

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -90,7 +90,7 @@ type MonarchSyncer interface {
 
 // MonarchTxStore defines DB operations for Monarch transaction sync tracking.
 type MonarchTxStore interface {
-	ListUnsyncedTransactions(ctx context.Context, txTypes []string) ([]db.UnifiedTransaction, error)
+	ListUnsyncedTransactions(ctx context.Context, txTypes []string, sources []string) ([]db.UnifiedTransaction, error)
 	MarkTransactionSynced(ctx context.Context, sourceID, monarchTxID string) error
 	MonarchSyncedCount(ctx context.Context) (int, error)
 	DistinctTransactionValues(ctx context.Context) (sources []string, txTypes []string, err error)

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -77,7 +77,7 @@ type SettingsStore interface {
 
 // TransactionStore defines operations for the unified transaction ledger.
 type TransactionStore interface {
-	ListUnifiedTransactions(ctx context.Context, limit, offset int) (*db.UnifiedTransactionPage, error)
+	ListUnifiedTransactions(ctx context.Context, f db.TransactionFilter) (*db.UnifiedTransactionPage, error)
 	SetTransactionNote(ctx context.Context, sourceID, note string) error
 }
 

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -75,6 +75,12 @@ type SettingsStore interface {
 	SetSetting(ctx context.Context, key, value string) error
 }
 
+// TransactionStore defines operations for the unified transaction ledger.
+type TransactionStore interface {
+	ListUnifiedTransactions(ctx context.Context, limit, offset int) (*db.UnifiedTransactionPage, error)
+	SetTransactionNote(ctx context.Context, sourceID, note string) error
+}
+
 // MonarchSyncer syncs BTC holdings to Monarch Money.
 type MonarchSyncer interface {
 	SyncHolding(ctx context.Context, btcQuantity float64) error
@@ -82,13 +88,14 @@ type MonarchSyncer interface {
 
 // Handler serves dashboard API and HTML endpoints.
 type Handler struct {
-	store          DashboardStore
-	node           NodeInfoProvider
-	price          PriceProvider
-	importStore    ImportStore
-	walletStore    WalletStore
-	walletScanner  WalletScanner
-	settingsStore  SettingsStore
+	store            DashboardStore
+	node             NodeInfoProvider
+	price            PriceProvider
+	importStore      ImportStore
+	walletStore      WalletStore
+	walletScanner    WalletScanner
+	settingsStore    SettingsStore
+	txStore          TransactionStore
 	monarchSyncer    MonarchSyncer
 	onMonarchChange  func(MonarchSyncer)
 	pendingMonarch   *monarch.PendingClient
@@ -133,6 +140,11 @@ func (h *Handler) SetWalletScanner(ws WalletScanner) {
 // SetSettingsStore sets the settings store.
 func (h *Handler) SetSettingsStore(ss SettingsStore) {
 	h.settingsStore = ss
+}
+
+// SetTransactionStore sets the transaction store for the unified ledger.
+func (h *Handler) SetTransactionStore(ts TransactionStore) {
+	h.txStore = ts
 }
 
 // SetMonarchSyncer sets the Monarch syncer and notifies any registered listener.

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -79,6 +79,7 @@ type SettingsStore interface {
 type TransactionStore interface {
 	ListUnifiedTransactions(ctx context.Context, f db.TransactionFilter) (*db.UnifiedTransactionPage, error)
 	SetTransactionNote(ctx context.Context, sourceID, note string) error
+	DistinctTransactionValues(ctx context.Context) (sources []string, txTypes []string, err error)
 }
 
 // MonarchSyncer syncs BTC holdings to Monarch Money.

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -1733,24 +1733,31 @@ func (h *Handler) HandleMonarchTxSync(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result, synced, err := h.monarchSyncer.SyncTransactions(r.Context(), toSync)
-	if err != nil {
-		h.logger.Printf("monarch tx sync failed: %v", err)
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprintf(w, `<div style="color:var(--red);">Sync failed: %s</div>`, err.Error())
-		return
-	}
-
-	// Record synced transactions
-	for sourceID, monarchTxID := range synced {
-		if err := h.monarchTxStore.MarkTransactionSynced(r.Context(), sourceID, monarchTxID); err != nil {
-			h.logger.Printf("monarch: failed to mark %s synced: %v", sourceID, err)
-		}
-	}
-
+	// Respond immediately — sync runs in the background
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, `<div style="color:var(--green);">Synced %d transactions to Monarch (%d skipped, %d errors).</div>`,
-		result.Created, result.Skipped, result.Errors)
+	fmt.Fprintf(w, `<div style="color:var(--accent);">Syncing %d transactions to Monarch in the background. You can leave this page.</div>`, len(toSync))
+
+	// Capture references for the goroutine
+	syncer := h.monarchSyncer
+	txStore := h.monarchTxStore
+	logger := h.logger
+
+	go func() {
+		ctx := context.Background()
+		result, synced, err := syncer.SyncTransactions(ctx, toSync)
+		if err != nil {
+			logger.Printf("monarch tx sync failed: %v", err)
+			return
+		}
+
+		for sourceID, monarchTxID := range synced {
+			if err := txStore.MarkTransactionSynced(ctx, sourceID, monarchTxID); err != nil {
+				logger.Printf("monarch: failed to mark %s synced: %v", sourceID, err)
+			}
+		}
+
+		logger.Printf("monarch tx sync complete: %d created, %d skipped, %d errors", result.Created, result.Skipped, result.Errors)
+	}()
 }
 
 // TransactionsPageData holds data for the /transactions page.

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -1613,6 +1613,108 @@ func (h *Handler) getTotalSats(ctx context.Context) (int64, error) {
 	return total, nil
 }
 
+// TransactionsPageData holds data for the /transactions page.
+type TransactionsPageData struct {
+	Transactions []db.UnifiedTransaction
+	Total        int
+	Page         int
+	Limit        int
+	TotalPages   int
+	BTCPriceUSD  float64
+}
+
+// HandleTransactionsPage serves GET /transactions.
+func (h *Handler) HandleTransactionsPage(w http.ResponseWriter, r *http.Request) {
+	if h.txStore == nil {
+		http.Error(w, "transaction store not available", http.StatusInternalServerError)
+		return
+	}
+
+	page := parseIntParam(r, "page", 1)
+	if page < 1 {
+		page = 1
+	}
+	limit := 50
+	offset := (page - 1) * limit
+
+	result, err := h.txStore.ListUnifiedTransactions(r.Context(), limit, offset)
+	if err != nil {
+		h.logger.Printf("transactions page: %v", err)
+		http.Error(w, "failed to load transactions", http.StatusInternalServerError)
+		return
+	}
+
+	data := TransactionsPageData{
+		Transactions: result.Transactions,
+		Total:        result.Total,
+		Page:         page,
+		Limit:        limit,
+	}
+	if result.Total > 0 {
+		data.TotalPages = (result.Total + limit - 1) / limit
+	}
+
+	if price, err := h.price.GetBTCPrice(r.Context()); err == nil {
+		data.BTCPriceUSD = price
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "transactions_layout", data); err != nil {
+		h.logger.Printf("failed to render transactions page: %v", err)
+	}
+}
+
+// txNoteData is passed to the transaction_note_display and _edit partials.
+type txNoteData struct {
+	SourceID string
+	Note     string
+}
+
+// HandleTransactionNoteEdit serves GET /api/transactions/note/edit — returns edit form partial.
+func (h *Handler) HandleTransactionNoteEdit(w http.ResponseWriter, r *http.Request) {
+	sourceID := r.URL.Query().Get("source_id")
+	note := r.URL.Query().Get("note")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "transaction_note_edit", txNoteData{SourceID: sourceID, Note: note}); err != nil {
+		h.logger.Printf("render note edit: %v", err)
+	}
+}
+
+// HandleTransactionNoteSave serves POST /api/transactions/note — saves and returns display partial.
+func (h *Handler) HandleTransactionNoteSave(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if h.txStore == nil {
+		h.writeError(w, http.StatusInternalServerError, "transaction store not available")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid form")
+		return
+	}
+
+	sourceID := r.FormValue("source_id")
+	note := r.FormValue("note")
+	if sourceID == "" {
+		h.writeError(w, http.StatusBadRequest, "source_id required")
+		return
+	}
+
+	if err := h.txStore.SetTransactionNote(r.Context(), sourceID, note); err != nil {
+		h.logger.Printf("set transaction note: %v", err)
+		h.writeError(w, http.StatusInternalServerError, "failed to save note")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "transaction_note_display", txNoteData{SourceID: sourceID, Note: strings.TrimSpace(note)}); err != nil {
+		h.logger.Printf("render note display: %v", err)
+	}
+}
+
 // maskToken shows only the last 4 characters of a token.
 func maskToken(token string) string {
 	if len(token) <= 4 {

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -1636,17 +1636,6 @@ type TransactionsPageData struct {
 	TxTypes []string
 }
 
-// txSources is the list of available transaction sources for the filter dropdown.
-var txSources = []string{
-	"lnd_forward", "lnd_invoice", "lnd_payment", "lnd_onchain",
-	"strike", "river", "coinbase", "swan",
-}
-
-// txTypes is the list of available transaction types for the filter dropdown.
-var txTypes = []string{
-	"buy", "sell", "send", "receive", "fee_income",
-}
-
 // HandleTransactionsPage serves GET /transactions.
 func (h *Handler) HandleTransactionsPage(w http.ResponseWriter, r *http.Request) {
 	if h.txStore == nil {
@@ -1654,6 +1643,7 @@ func (h *Handler) HandleTransactionsPage(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	ctx := r.Context()
 	page := parseIntParam(r, "page", 1)
 	if page < 1 {
 		page = 1
@@ -1680,12 +1670,15 @@ func (h *Handler) HandleTransactionsPage(w http.ResponseWriter, r *http.Request)
 		Offset:   offset,
 	}
 
-	result, err := h.txStore.ListUnifiedTransactions(r.Context(), f)
+	result, err := h.txStore.ListUnifiedTransactions(ctx, f)
 	if err != nil {
 		h.logger.Printf("transactions page: %v", err)
 		http.Error(w, "failed to load transactions", http.StatusInternalServerError)
 		return
 	}
+
+	// Pull actual sources and types from the data
+	sources, txTypes, _ := h.txStore.DistinctTransactionValues(ctx)
 
 	data := TransactionsPageData{
 		Transactions: result.Transactions,
@@ -1699,14 +1692,14 @@ func (h *Handler) HandleTransactionsPage(w http.ResponseWriter, r *http.Request)
 		Search:       f.Search,
 		SortCol:      sortCol,
 		SortDir:      sortDir,
-		Sources:      txSources,
+		Sources:      sources,
 		TxTypes:      txTypes,
 	}
 	if result.Total > 0 {
 		data.TotalPages = (result.Total + limit - 1) / limit
 	}
 
-	if price, err := h.price.GetBTCPrice(r.Context()); err == nil {
+	if price, err := h.price.GetBTCPrice(ctx); err == nil {
 		data.BTCPriceUSD = price
 	}
 

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -1377,7 +1377,9 @@ type SettingsPageData struct {
 	Error            string
 	// Monarch transaction sync
 	MonarchSyncTypes    []string // currently selected tx types
+	MonarchSyncSources  []string // currently selected sources
 	AvailableTxTypes    []string // all tx types from data
+	AvailableSources    []string // all sources from data
 	MonarchSyncedCount  int      // how many transactions have been synced
 }
 
@@ -1400,11 +1402,16 @@ func (h *Handler) HandleSettingsPage(w http.ResponseWriter, r *http.Request) {
 		if syncTypes != "" {
 			data.MonarchSyncTypes = strings.Split(syncTypes, ",")
 		}
+		syncSources, _ := h.settingsStore.GetSetting(r.Context(), "monarch_sync_sources")
+		if syncSources != "" {
+			data.MonarchSyncSources = strings.Split(syncSources, ",")
+		}
 
-		// Load available tx types from data
+		// Load available tx types and sources from data
 		if h.monarchTxStore != nil {
-			_, txTypes, _ := h.monarchTxStore.DistinctTransactionValues(r.Context())
+			sources, txTypes, _ := h.monarchTxStore.DistinctTransactionValues(r.Context())
 			data.AvailableTxTypes = txTypes
+			data.AvailableSources = sources
 			count, _ := h.monarchTxStore.MonarchSyncedCount(r.Context())
 			data.MonarchSyncedCount = count
 		}
@@ -1649,20 +1656,26 @@ func (h *Handler) HandleMonarchSyncTypes(w http.ResponseWriter, r *http.Request)
 	}
 
 	selectedTypes := r.Form["sync_types"]
-	value := strings.Join(selectedTypes, ",")
+	selectedSources := r.Form["sync_sources"]
 
-	if err := h.settingsStore.SetSetting(r.Context(), "monarch_sync_types", value); err != nil {
+	if err := h.settingsStore.SetSetting(r.Context(), "monarch_sync_types", strings.Join(selectedTypes, ",")); err != nil {
 		h.logger.Printf("monarch: failed to save sync types: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div style="color:var(--red);">Failed to save preferences.</div>`)
+		return
+	}
+	if err := h.settingsStore.SetSetting(r.Context(), "monarch_sync_sources", strings.Join(selectedSources, ",")); err != nil {
+		h.logger.Printf("monarch: failed to save sync sources: %v", err)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		fmt.Fprint(w, `<div style="color:var(--red);">Failed to save preferences.</div>`)
 		return
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if len(selectedTypes) == 0 {
-		fmt.Fprint(w, `<div style="color:var(--green);">Transaction sync disabled — no types selected.</div>`)
+	if len(selectedTypes) == 0 && len(selectedSources) == 0 {
+		fmt.Fprint(w, `<div style="color:var(--green);">Transaction sync disabled — no filters selected.</div>`)
 	} else {
-		fmt.Fprintf(w, `<div style="color:var(--green);">Saved %d transaction type(s) for sync.</div>`, len(selectedTypes))
+		fmt.Fprintf(w, `<div style="color:var(--green);">Saved preferences: %d type(s), %d source(s).</div>`, len(selectedTypes), len(selectedSources))
 	}
 }
 
@@ -1695,7 +1708,7 @@ func (h *Handler) HandleMonarchTxSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read selected sync types
+	// Read selected sync types and sources
 	syncTypes, _ := h.settingsStore.GetSetting(r.Context(), "monarch_sync_types")
 	if syncTypes == "" {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -1704,9 +1717,13 @@ func (h *Handler) HandleMonarchTxSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	types := strings.Split(syncTypes, ",")
+	var sources []string
+	if v, _ := h.settingsStore.GetSetting(r.Context(), "monarch_sync_sources"); v != "" {
+		sources = strings.Split(v, ",")
+	}
 
 	// Get unsynced transactions
-	txns, err := h.monarchTxStore.ListUnsyncedTransactions(r.Context(), types)
+	txns, err := h.monarchTxStore.ListUnsyncedTransactions(r.Context(), types, sources)
 	if err != nil {
 		h.logger.Printf("monarch tx sync: list unsynced: %v", err)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -1621,6 +1621,30 @@ type TransactionsPageData struct {
 	Limit        int
 	TotalPages   int
 	BTCPriceUSD  float64
+
+	// Current filter/sort state (for preserving in links and form)
+	DateFrom string
+	DateTo   string
+	TxType   string
+	Source   string
+	Search   string
+	SortCol  string
+	SortDir  string
+
+	// Available filter options
+	Sources []string
+	TxTypes []string
+}
+
+// txSources is the list of available transaction sources for the filter dropdown.
+var txSources = []string{
+	"lnd_forward", "lnd_invoice", "lnd_payment", "lnd_onchain",
+	"strike", "river", "coinbase", "swan",
+}
+
+// txTypes is the list of available transaction types for the filter dropdown.
+var txTypes = []string{
+	"buy", "sell", "send", "receive", "fee_income",
 }
 
 // HandleTransactionsPage serves GET /transactions.
@@ -1637,7 +1661,26 @@ func (h *Handler) HandleTransactionsPage(w http.ResponseWriter, r *http.Request)
 	limit := 50
 	offset := (page - 1) * limit
 
-	result, err := h.txStore.ListUnifiedTransactions(r.Context(), limit, offset)
+	q := r.URL.Query()
+	sortCol := q.Get("sort")
+	sortDir := q.Get("dir")
+	if sortDir == "" {
+		sortDir = "desc"
+	}
+
+	f := db.TransactionFilter{
+		DateFrom: q.Get("from"),
+		DateTo:   q.Get("to"),
+		TxType:   q.Get("type"),
+		Source:   q.Get("source"),
+		Search:   q.Get("q"),
+		SortCol:  sortCol,
+		SortDir:  sortDir,
+		Limit:    limit,
+		Offset:   offset,
+	}
+
+	result, err := h.txStore.ListUnifiedTransactions(r.Context(), f)
 	if err != nil {
 		h.logger.Printf("transactions page: %v", err)
 		http.Error(w, "failed to load transactions", http.StatusInternalServerError)
@@ -1649,6 +1692,15 @@ func (h *Handler) HandleTransactionsPage(w http.ResponseWriter, r *http.Request)
 		Total:        result.Total,
 		Page:         page,
 		Limit:        limit,
+		DateFrom:     f.DateFrom,
+		DateTo:       f.DateTo,
+		TxType:       f.TxType,
+		Source:       f.Source,
+		Search:       f.Search,
+		SortCol:      sortCol,
+		SortDir:      sortDir,
+		Sources:      txSources,
+		TxTypes:      txTypes,
 	}
 	if result.Total > 0 {
 		data.TotalPages = (result.Total + limit - 1) / limit

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -1375,6 +1375,10 @@ type SettingsPageData struct {
 	MonarchUnlocked  bool
 	Message          string
 	Error            string
+	// Monarch transaction sync
+	MonarchSyncTypes    []string // currently selected tx types
+	AvailableTxTypes    []string // all tx types from data
+	MonarchSyncedCount  int      // how many transactions have been synced
 }
 
 // HandleSettingsPage serves GET /settings.
@@ -1389,6 +1393,20 @@ func (h *Handler) HandleSettingsPage(w http.ResponseWriter, r *http.Request) {
 		if token != "" {
 			data.MonarchToken = maskToken(token)
 			data.MonarchConnected = true
+		}
+
+		// Load tx sync preferences
+		syncTypes, _ := h.settingsStore.GetSetting(r.Context(), "monarch_sync_types")
+		if syncTypes != "" {
+			data.MonarchSyncTypes = strings.Split(syncTypes, ",")
+		}
+
+		// Load available tx types from data
+		if h.monarchTxStore != nil {
+			_, txTypes, _ := h.monarchTxStore.DistinctTransactionValues(r.Context())
+			data.AvailableTxTypes = txTypes
+			count, _ := h.monarchTxStore.MonarchSyncedCount(r.Context())
+			data.MonarchSyncedCount = count
 		}
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -1611,6 +1629,128 @@ func (h *Handler) getTotalSats(ctx context.Context) (int64, error) {
 	}
 
 	return total, nil
+}
+
+// HandleMonarchSyncTypes handles POST /api/monarch/sync-types — saves which tx types to sync.
+func (h *Handler) HandleMonarchSyncTypes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if h.settingsStore == nil {
+		http.Error(w, "settings not available", http.StatusInternalServerError)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div style="color:var(--red);">Failed to parse form.</div>`)
+		return
+	}
+
+	selectedTypes := r.Form["sync_types"]
+	value := strings.Join(selectedTypes, ",")
+
+	if err := h.settingsStore.SetSetting(r.Context(), "monarch_sync_types", value); err != nil {
+		h.logger.Printf("monarch: failed to save sync types: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div style="color:var(--red);">Failed to save preferences.</div>`)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if len(selectedTypes) == 0 {
+		fmt.Fprint(w, `<div style="color:var(--green);">Transaction sync disabled — no types selected.</div>`)
+	} else {
+		fmt.Fprintf(w, `<div style="color:var(--green);">Saved %d transaction type(s) for sync.</div>`, len(selectedTypes))
+	}
+}
+
+// HandleMonarchTxSync handles POST /api/monarch/tx-sync — syncs transactions to Monarch.
+func (h *Handler) HandleMonarchTxSync(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Ensure Monarch syncer is available
+	if h.monarchSyncer == nil && h.settingsStore != nil {
+		token, _ := h.settingsStore.GetSetting(r.Context(), "monarch_token")
+		if token != "" {
+			syncer, err := monarch.NewSyncer(token, "")
+			if err == nil {
+				h.monarchSyncer = syncer
+			}
+		}
+	}
+	if h.monarchSyncer == nil {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div style="color:var(--red);">Monarch not connected. Log in first.</div>`)
+		return
+	}
+
+	if h.settingsStore == nil || h.monarchTxStore == nil {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div style="color:var(--red);">Transaction sync not available.</div>`)
+		return
+	}
+
+	// Read selected sync types
+	syncTypes, _ := h.settingsStore.GetSetting(r.Context(), "monarch_sync_types")
+	if syncTypes == "" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div style="color:var(--red);">No transaction types selected. Save preferences first.</div>`)
+		return
+	}
+
+	types := strings.Split(syncTypes, ",")
+
+	// Get unsynced transactions
+	txns, err := h.monarchTxStore.ListUnsyncedTransactions(r.Context(), types)
+	if err != nil {
+		h.logger.Printf("monarch tx sync: list unsynced: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div style="color:var(--red);">Failed to query transactions.</div>`)
+		return
+	}
+
+	if len(txns) == 0 {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div style="color:var(--green);">All transactions are already synced.</div>`)
+		return
+	}
+
+	// Convert to TxToSync
+	toSync := make([]monarch.TxToSync, len(txns))
+	for i, tx := range txns {
+		toSync[i] = monarch.TxToSync{
+			SourceID:  tx.SourceID,
+			Source:    tx.Source,
+			TxType:   tx.TxType,
+			Time:     tx.Time,
+			AmountUSD: tx.AmountUSD,
+			Memo:     tx.Memo,
+		}
+	}
+
+	result, synced, err := h.monarchSyncer.SyncTransactions(r.Context(), toSync)
+	if err != nil {
+		h.logger.Printf("monarch tx sync failed: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<div style="color:var(--red);">Sync failed: %s</div>`, err.Error())
+		return
+	}
+
+	// Record synced transactions
+	for sourceID, monarchTxID := range synced {
+		if err := h.monarchTxStore.MarkTransactionSynced(r.Context(), sourceID, monarchTxID); err != nil {
+			h.logger.Printf("monarch: failed to mark %s synced: %v", sourceID, err)
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<div style="color:var(--green);">Synced %d transactions to Monarch (%d skipped, %d errors).</div>`,
+		result.Created, result.Skipped, result.Errors)
 }
 
 // TransactionsPageData holds data for the /transactions page.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -63,6 +63,8 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/api/monarch/token", monarchGate(handler.HandleMonarchToken))
 	mux.HandleFunc("/api/monarch/disconnect", monarchGate(handler.HandleMonarchDisconnect))
 	mux.HandleFunc("/api/monarch/sync", monarchGate(handler.HandleMonarchSync))
+	mux.HandleFunc("/api/monarch/sync-types", monarchGate(handler.HandleMonarchSyncTypes))
+	mux.HandleFunc("/api/monarch/tx-sync", monarchGate(handler.HandleMonarchTxSync))
 
 	return &Server{
 		httpServer: &http.Server{

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -32,6 +32,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/partials/forwarding", handler.HandleForwardingPartial)
 	mux.HandleFunc("/partials/portfolio-chart", handler.HandlePortfolioChartPartial)
 	mux.HandleFunc("/settings", handler.HandleSettingsPage)
+	mux.HandleFunc("/transactions", handler.HandleTransactionsPage)
 
 	// Static assets (embedded)
 	staticSub, _ := fs.Sub(staticFS, "static")
@@ -51,6 +52,8 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/api/wallets/refresh", handler.HandleRefreshWallet)
 	mux.HandleFunc("/api/wallets/refresh-all", handler.HandleRefreshAll)
 	mux.HandleFunc("/api/portfolio/backfill", handler.HandlePortfolioBackfill)
+	mux.HandleFunc("/api/transactions/note", handler.HandleTransactionNoteSave)
+	mux.HandleFunc("/api/transactions/note/edit", handler.HandleTransactionNoteEdit)
 	mux.Handle("/api/import/strike/clear", handler.HandleClearImport("strike"))
 	mux.Handle("/api/import/river/clear", handler.HandleClearImport("river"))
 	mux.Handle("/api/import/coinbase/clear", handler.HandleClearImport("coinbase"))

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -37,9 +37,54 @@ header {
   align-items: center;
   justify-content: space-between;
 }
+.header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
 .logo { font-size: 1.25rem; font-weight: 700; color: var(--accent); text-decoration: none; }
-.nav-link { color: var(--text-muted); text-decoration: none; margin-right: 16px; }
-.nav-link:last-child { margin-right: 0; }
+
+/* Hamburger button */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  width: 32px;
+  height: 32px;
+}
+.hamburger span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--text-muted);
+  border-radius: 1px;
+  transition: transform 0.2s, opacity 0.2s;
+}
+.hamburger-open span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+.hamburger-open span:nth-child(2) { opacity: 0; }
+.hamburger-open span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+
+/* Nav */
+.main-nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+}
+.nav-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  padding: 4px 10px;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+.nav-link:hover { background: var(--bg-hover); }
 .nav-link.nav-active { color: var(--text); font-weight: 600; }
 .node-info-bar { font-size: 0.8rem; color: var(--text-muted); }
 .node-info-bar .synced { color: var(--green); }
@@ -278,6 +323,23 @@ tr:hover { background: var(--bg-hover); }
   .cards { grid-template-columns: 1fr 1fr; }
   .card-value { font-size: 1.25rem; }
   .header-inner { flex-direction: column; gap: 8px; align-items: flex-start; }
+  .hamburger { display: flex; }
+  .main-nav {
+    display: none;
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: 0;
+    border-top: 1px solid var(--border);
+    padding-top: 8px;
+    margin-top: 8px;
+  }
+  .main-nav.nav-open { display: flex; }
+  .main-nav .nav-link {
+    padding: 8px 12px;
+    border-radius: 4px;
+  }
+  .main-nav .nav-link:hover { background: var(--bg-hover); }
   .footer-inner { flex-direction: column; }
   .truncate { max-width: 80px; }
 }

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -61,6 +61,24 @@ func NewRenderer() *Renderer {
 		"tierAtLeast": func(current, required string) bool {
 			return license.TierAtLeast(license.Tier(current), license.Tier(required))
 		},
+		"sortIndicator": func(col, currentCol, currentDir string) template.HTML {
+			if col != currentCol {
+				return template.HTML(`<span style="opacity:0.3">&#x21C5;</span>`)
+			}
+			if currentDir == "asc" {
+				return template.HTML(`<span>&#x25B2;</span>`)
+			}
+			return template.HTML(`<span>&#x25BC;</span>`)
+		},
+		"flipDir": func(col, currentCol, currentDir string) string {
+			if col != currentCol {
+				return "asc"
+			}
+			if currentDir == "asc" {
+				return "desc"
+			}
+			return "asc"
+		},
 		"dict": func(kv ...interface{}) (map[string]interface{}, error) {
 			if len(kv)%2 != 0 {
 				return nil, fmt.Errorf("dict requires even number of args")

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -97,6 +97,8 @@ func NewRenderer() *Renderer {
 			"templates/exchange_detail.html",
 			"templates/wallet_detail.html",
 			"templates/settings_layout.html",
+			"templates/transactions_layout.html",
+			"templates/partials/transaction_note.html",
 			"templates/partials/upgrade_required.html",
 		),
 	)

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -87,6 +87,7 @@ func NewRenderer() *Renderer {
 			}
 			return false
 		},
+		"sourceLabel": templateSourceLabel,
 		"dict": func(kv ...interface{}) (map[string]interface{}, error) {
 			if len(kv)%2 != 0 {
 				return nil, fmt.Errorf("dict requires even number of args")
@@ -245,6 +246,30 @@ func seq(n int) []int {
 		s[i] = i
 	}
 	return s
+}
+
+// templateSourceLabel returns a human-readable label for a transaction source.
+func templateSourceLabel(source string) string {
+	switch source {
+	case "strike":
+		return "Strike"
+	case "river":
+		return "River"
+	case "coinbase":
+		return "Coinbase"
+	case "swan":
+		return "Swan"
+	case "lnd_forward":
+		return "Lightning Routing"
+	case "lnd_invoice":
+		return "Lightning Invoice"
+	case "lnd_payment":
+		return "Lightning Payment"
+	case "lnd_onchain":
+		return "On-chain"
+	default:
+		return source
+	}
 }
 
 // portfolioChart generates an inline SVG line chart from portfolio snapshots.

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -79,6 +79,14 @@ func NewRenderer() *Renderer {
 			}
 			return "asc"
 		},
+		"contains": func(slice []string, val string) bool {
+			for _, s := range slice {
+				if s == val {
+					return true
+				}
+			}
+			return false
+		},
 		"dict": func(kv ...interface{}) (map[string]interface{}, error) {
 			if len(kv)%2 != 0 {
 				return nil, fmt.Errorf("dict requires even number of args")

--- a/internal/web/templates/exchange_detail.html
+++ b/internal/web/templates/exchange_detail.html
@@ -9,10 +9,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "exchange"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "exchange"}}
     </div>
   </header>
 

--- a/internal/web/templates/import_layout.html
+++ b/internal/web/templates/import_layout.html
@@ -10,10 +10,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "import"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "import"}}
     </div>
   </header>
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -10,10 +10,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "dashboard"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "dashboard"}}
       <div class="node-info-bar">
         {{if .NodeAlias}}
           <strong>{{.NodeAlias}}</strong> &middot;

--- a/internal/web/templates/lightning_layout.html
+++ b/internal/web/templates/lightning_layout.html
@@ -10,10 +10,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "lightning"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "lightning"}}
       <div class="node-info-bar">
         {{if .NodeAlias}}
           <strong>{{.NodeAlias}}</strong> &middot;

--- a/internal/web/templates/partials/nav.html
+++ b/internal/web/templates/partials/nav.html
@@ -1,11 +1,11 @@
 {{define "nav"}}
-<nav style="font-size: 0.85rem;">
+<nav class="main-nav" id="main-nav">
   <a href="/" class="nav-link{{if eq . "dashboard"}} nav-active{{end}}">Dashboard</a>
   <a href="/lightning" class="nav-link{{if eq . "lightning"}} nav-active{{end}}">Lightning</a>
   <a href="/transactions" class="nav-link{{if eq . "transactions"}} nav-active{{end}}">Transactions</a>
   <a href="/import" class="nav-link{{if eq . "import"}} nav-active{{end}}">Import</a>
   <a href="/wallets" class="nav-link{{if eq . "wallets"}} nav-active{{end}}">Wallets</a>
-  <a href="/pl" class="nav-link{{if eq . "pl"}} nav-active{{end}}">P&L</a>
+  <a href="/pl" class="nav-link{{if eq . "pl"}} nav-active{{end}}">P&amp;L</a>
   <a href="/settings" class="nav-link{{if eq . "settings"}} nav-active{{end}}">Settings</a>
 </nav>
 {{end}}

--- a/internal/web/templates/partials/nav.html
+++ b/internal/web/templates/partials/nav.html
@@ -2,6 +2,7 @@
 <nav style="font-size: 0.85rem;">
   <a href="/" class="nav-link{{if eq . "dashboard"}} nav-active{{end}}">Dashboard</a>
   <a href="/lightning" class="nav-link{{if eq . "lightning"}} nav-active{{end}}">Lightning</a>
+  <a href="/transactions" class="nav-link{{if eq . "transactions"}} nav-active{{end}}">Transactions</a>
   <a href="/import" class="nav-link{{if eq . "import"}} nav-active{{end}}">Import</a>
   <a href="/wallets" class="nav-link{{if eq . "wallets"}} nav-active{{end}}">Wallets</a>
   <a href="/pl" class="nav-link{{if eq . "pl"}} nav-active{{end}}">P&L</a>

--- a/internal/web/templates/partials/transaction_note.html
+++ b/internal/web/templates/partials/transaction_note.html
@@ -1,0 +1,23 @@
+{{define "transaction_note_display"}}
+{{- if .Note -}}
+<span style="font-size: 0.8rem; cursor: pointer;" title="Click to edit"
+  hx-get="/api/transactions/note/edit?source_id={{.SourceID}}&note={{.Note}}"
+  hx-target="closest .note-cell"
+  hx-swap="innerHTML">{{.Note}}</span>
+{{- else -}}
+<span style="color: var(--text-muted); cursor: pointer; font-size: 0.8rem;"
+  hx-get="/api/transactions/note/edit?source_id={{.SourceID}}&note="
+  hx-target="closest .note-cell"
+  hx-swap="innerHTML">+ note</span>
+{{- end -}}
+{{end}}
+
+{{define "transaction_note_edit"}}
+<form hx-post="/api/transactions/note" hx-target="closest .note-cell" hx-swap="innerHTML"
+  style="display: flex; gap: 4px; align-items: center;">
+  <input type="hidden" name="source_id" value="{{.SourceID}}">
+  <input type="text" name="note" value="{{.Note}}" placeholder="Add note..."
+    style="font-size: 0.8rem; width: 120px; padding: 2px 6px;" autofocus>
+  <button type="submit" style="font-size: 0.75rem; padding: 2px 6px;">Save</button>
+</form>
+{{end}}

--- a/internal/web/templates/pl_layout.html
+++ b/internal/web/templates/pl_layout.html
@@ -10,10 +10,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "pl"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "pl"}}
       <div class="node-info-bar">
         {{if .NodeAlias}}
           <strong>{{.NodeAlias}}</strong> &middot;

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -98,7 +98,20 @@
       {{end}}
 
       <form hx-post="/api/monarch/sync-types" hx-target="#monarch-tx-result" style="margin-bottom: 12px;">
-        <div style="display: flex; flex-wrap: wrap; gap: 8px 16px; margin-bottom: 12px;">
+        <p style="font-size: 0.8rem; color: #aaa; margin-bottom: 6px; font-weight: 600;">Sources</p>
+        <div style="display: flex; flex-wrap: wrap; gap: 8px 16px; margin-bottom: 16px;">
+          {{range .AvailableSources}}
+          <label style="display: flex; align-items: center; gap: 6px; font-size: 0.85rem; cursor: pointer;">
+            <input type="checkbox" name="sync_sources" value="{{.}}"
+              {{if contains $.MonarchSyncSources .}}checked{{end}}
+              style="accent-color: var(--accent);">
+            {{sourceLabel .}}
+          </label>
+          {{end}}
+        </div>
+
+        <p style="font-size: 0.8rem; color: #aaa; margin-bottom: 6px; font-weight: 600;">Transaction Types</p>
+        <div style="display: flex; flex-wrap: wrap; gap: 8px 16px; margin-bottom: 16px;">
           {{range .AvailableTxTypes}}
           <label style="display: flex; align-items: center; gap: 6px; font-size: 0.85rem; cursor: pointer;">
             <input type="checkbox" name="sync_types" value="{{.}}"

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -10,10 +10,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "settings"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "settings"}}
     </div>
   </header>
 

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -82,6 +82,46 @@
 
       <div id="monarch-result" style="margin-top: 12px;"></div>
     </section>
+
+    {{if and .MonarchUnlocked .MonarchConnected}}
+    <section class="card" style="margin-top: 16px;">
+      <h3>Transaction Export to Monarch</h3>
+      <p style="color: #999; font-size: 0.85rem; margin-bottom: 12px;">
+        Select which transaction types to export as Monarch transactions.
+        Each transaction is synced once — duplicates are automatically skipped.
+      </p>
+
+      {{if .MonarchSyncedCount}}
+      <p style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 12px;">
+        {{.MonarchSyncedCount}} transaction(s) already synced.
+      </p>
+      {{end}}
+
+      <form hx-post="/api/monarch/sync-types" hx-target="#monarch-tx-result" style="margin-bottom: 12px;">
+        <div style="display: flex; flex-wrap: wrap; gap: 8px 16px; margin-bottom: 12px;">
+          {{range .AvailableTxTypes}}
+          <label style="display: flex; align-items: center; gap: 6px; font-size: 0.85rem; cursor: pointer;">
+            <input type="checkbox" name="sync_types" value="{{.}}"
+              {{if contains $.MonarchSyncTypes .}}checked{{end}}
+              style="accent-color: var(--accent);">
+            {{.}}
+          </label>
+          {{end}}
+        </div>
+        <div style="display: flex; gap: 8px;">
+          <button type="submit" style="background: var(--accent); color: #000; border: none; border-radius: 4px; padding: 6px 14px; font-size: 0.85rem; font-weight: 600; cursor: pointer;">
+            Save Preferences
+          </button>
+          <button type="button" hx-post="/api/monarch/tx-sync" hx-target="#monarch-tx-result"
+            style="background: var(--bg-hover); color: var(--text); border: 1px solid var(--border); border-radius: 4px; padding: 6px 14px; font-size: 0.85rem; cursor: pointer;">
+            Sync Transactions Now
+          </button>
+        </div>
+      </form>
+
+      <div id="monarch-tx-result"></div>
+    </section>
+    {{end}}
   </main>
 
   <footer>

--- a/internal/web/templates/transactions_layout.html
+++ b/internal/web/templates/transactions_layout.html
@@ -1,0 +1,99 @@
+{{define "transactions_layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Satsbook — Transactions</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="/static/htmx.min.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <a class="logo" href="/">Satsbook</a>
+        {{template "nav" "transactions"}}
+      </div>
+    </div>
+  </header>
+
+  <main class="container" style="padding: 24px 16px;">
+    <h1 style="margin: 0 0 16px; font-size: 1.25rem;">All Transactions</h1>
+
+    {{if .Transactions}}
+    <div style="overflow-x: auto;">
+      <table class="data-table" style="width: 100%; border-collapse: collapse; font-size: 0.85rem;">
+        <thead>
+          <tr style="border-bottom: 2px solid var(--border); text-align: left;">
+            <th style="padding: 8px 12px;">Date</th>
+            <th style="padding: 8px 12px;">Source</th>
+            <th style="padding: 8px 12px;">Type</th>
+            <th style="padding: 8px 12px; text-align: right;">Amount (sats)</th>
+            <th style="padding: 8px 12px; text-align: right;">USD</th>
+            <th style="padding: 8px 12px; text-align: right;">Fee</th>
+            <th style="padding: 8px 12px;">Memo</th>
+            <th style="padding: 8px 12px;">Note</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range .Transactions}}
+          <tr style="border-bottom: 1px solid var(--border);">
+            <td style="padding: 8px 12px; white-space: nowrap;">{{formatDate .Time}}</td>
+            <td style="padding: 8px 12px;">
+              <span style="background: var(--border); border-radius: 4px; padding: 1px 6px; font-size: 0.75rem;">{{.Source}}</span>
+            </td>
+            <td style="padding: 8px 12px;">
+              <span style="border-radius: 4px; padding: 1px 6px; font-size: 0.75rem;
+                {{if eq .TxType "buy"}}background: #166534; color: #bbf7d0;
+                {{else if eq .TxType "receive"}}background: #1e3a5f; color: #93c5fd;
+                {{else if eq .TxType "fee_income"}}background: #713f12; color: #fde68a;
+                {{else if eq .TxType "sell"}}background: #7f1d1d; color: #fecaca;
+                {{else if eq .TxType "send"}}background: #4a1d6a; color: #e9d5ff;
+                {{else}}background: var(--border);
+                {{end}}">{{.TxType}}</span>
+            </td>
+            <td style="padding: 8px 12px; text-align: right; font-family: monospace;
+              {{if gt .AmountSat 0}}color: var(--success, #4ade80);{{else if lt .AmountSat 0}}color: var(--danger, #ef4444);{{end}}">
+              {{formatSats .AmountSat}}
+            </td>
+            <td style="padding: 8px 12px; text-align: right;">{{if .AmountUSD}}{{formatUSD .AmountUSD}}{{else}}-{{end}}</td>
+            <td style="padding: 8px 12px; text-align: right;">
+              {{if .FeeSat}}{{formatSats .FeeSat}} sat{{else if .FeeUSD}}{{formatUSD .FeeUSD}}{{else}}-{{end}}
+            </td>
+            <td style="padding: 8px 12px; max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="{{.Memo}}">{{if .Memo}}{{truncate .Memo 30}}{{else}}-{{end}}</td>
+            <td class="note-cell" style="padding: 8px 12px; min-width: 120px;">
+              {{template "transaction_note_display" (dict "SourceID" .SourceID "Note" .Note)}}
+            </td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+
+    {{if gt .TotalPages 1}}
+    <div style="display: flex; justify-content: center; gap: 8px; margin-top: 16px; font-size: 0.85rem;">
+      {{if gt .Page 1}}
+      <a href="/transactions?page={{subtract .Page 1}}" style="color: var(--text-muted); text-decoration: none;">&larr; Prev</a>
+      {{end}}
+      <span style="color: var(--text-muted);">Page {{.Page}} of {{.TotalPages}} ({{.Total}} total)</span>
+      {{if lt .Page .TotalPages}}
+      <a href="/transactions?page={{add .Page 1}}" style="color: var(--text-muted); text-decoration: none;">Next &rarr;</a>
+      {{end}}
+    </div>
+    {{end}}
+
+    {{else}}
+    <div style="text-align: center; padding: 40px 16px; color: var(--text-muted);">
+      No transactions yet. <a href="/import" style="color: var(--accent);">Import exchange CSVs</a> or connect an LND node to see transactions here.
+    </div>
+    {{end}}
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Satsbook</span>
+      {{if .BTCPriceUSD}}<span>BTC {{formatUSD .BTCPriceUSD}}</span>{{end}}
+    </div>
+  </footer>
+</body>
+</html>{{end}}

--- a/internal/web/templates/transactions_layout.html
+++ b/internal/web/templates/transactions_layout.html
@@ -23,10 +23,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "transactions"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "transactions"}}
     </div>
   </header>
 

--- a/internal/web/templates/transactions_layout.html
+++ b/internal/web/templates/transactions_layout.html
@@ -6,6 +6,19 @@
   <title>Satsbook — Transactions</title>
   <link rel="stylesheet" href="/static/style.css">
   <script src="/static/htmx.min.js"></script>
+  <style>
+    .tx-filters { display: flex; flex-wrap: wrap; gap: 8px; align-items: flex-end; margin-bottom: 16px; }
+    .tx-filters label { font-size: 0.75rem; color: var(--text-muted); display: block; margin-bottom: 2px; }
+    .tx-filters input, .tx-filters select { font-size: 0.8rem; padding: 4px 8px; background: var(--bg-card, #1a1a2e); color: var(--text, #e0e0e0); border: 1px solid var(--border); border-radius: 4px; }
+    .tx-filters input[type="date"] { width: 130px; }
+    .tx-filters select { min-width: 100px; }
+    .tx-filters input[type="search"] { width: 180px; }
+    .tx-filters .btn-filter { font-size: 0.8rem; padding: 5px 12px; background: var(--accent, #f7931a); color: #000; border: none; border-radius: 4px; cursor: pointer; }
+    .tx-filters .btn-clear { font-size: 0.8rem; padding: 5px 12px; background: transparent; color: var(--text-muted); border: 1px solid var(--border); border-radius: 4px; cursor: pointer; text-decoration: none; }
+    th.sortable { cursor: pointer; user-select: none; white-space: nowrap; }
+    th.sortable:hover { color: var(--accent, #f7931a); }
+    .tx-summary { display: flex; gap: 16px; margin-bottom: 12px; font-size: 0.8rem; color: var(--text-muted); }
+  </style>
 </head>
 <body>
   <header>
@@ -20,17 +33,82 @@
   <main class="container" style="padding: 24px 16px;">
     <h1 style="margin: 0 0 16px; font-size: 1.25rem;">All Transactions</h1>
 
+    <!-- Filters -->
+    <form method="GET" action="/transactions" class="tx-filters">
+      <div>
+        <label>From</label>
+        <input type="date" name="from" value="{{.DateFrom}}">
+      </div>
+      <div>
+        <label>To</label>
+        <input type="date" name="to" value="{{.DateTo}}">
+      </div>
+      <div>
+        <label>Type</label>
+        <select name="type">
+          <option value="">All types</option>
+          {{range .TxTypes}}
+          <option value="{{.}}"{{if eq . $.TxType}} selected{{end}}>{{.}}</option>
+          {{end}}
+        </select>
+      </div>
+      <div>
+        <label>Source</label>
+        <select name="source">
+          <option value="">All sources</option>
+          {{range .Sources}}
+          <option value="{{.}}"{{if eq . $.Source}} selected{{end}}>{{.}}</option>
+          {{end}}
+        </select>
+      </div>
+      <div>
+        <label>Search</label>
+        <input type="search" name="q" value="{{.Search}}" placeholder="memo, note, ID...">
+      </div>
+      {{if .SortCol}}<input type="hidden" name="sort" value="{{.SortCol}}">{{end}}
+      {{if .SortDir}}<input type="hidden" name="dir" value="{{.SortDir}}">{{end}}
+      <div style="display: flex; gap: 6px; align-items: flex-end;">
+        <button type="submit" class="btn-filter">Filter</button>
+        <a href="/transactions" class="btn-clear">Clear</a>
+      </div>
+    </form>
+
+    {{if .Total}}
+    <div class="tx-summary">
+      <span>{{.Total}} transactions</span>
+      {{if or .DateFrom .DateTo .TxType .Source .Search}}<span>(filtered)</span>{{end}}
+    </div>
+    {{end}}
+
     {{if .Transactions}}
     <div style="overflow-x: auto;">
       <table class="data-table" style="width: 100%; border-collapse: collapse; font-size: 0.85rem;">
         <thead>
           <tr style="border-bottom: 2px solid var(--border); text-align: left;">
-            <th style="padding: 8px 12px;">Date</th>
-            <th style="padding: 8px 12px;">Source</th>
-            <th style="padding: 8px 12px;">Type</th>
-            <th style="padding: 8px 12px; text-align: right;">Amount (sats)</th>
-            <th style="padding: 8px 12px; text-align: right;">USD</th>
-            <th style="padding: 8px 12px; text-align: right;">Fee</th>
+            <th class="sortable" style="padding: 8px 12px;"
+              onclick="window.location='/transactions?{{template "filter_params" .}}&sort=ts&dir={{flipDir "ts" .SortCol .SortDir}}&page=1'">
+              Date {{sortIndicator "ts" .SortCol .SortDir}}
+            </th>
+            <th class="sortable" style="padding: 8px 12px;"
+              onclick="window.location='/transactions?{{template "filter_params" .}}&sort=source&dir={{flipDir "source" .SortCol .SortDir}}&page=1'">
+              Source {{sortIndicator "source" .SortCol .SortDir}}
+            </th>
+            <th class="sortable" style="padding: 8px 12px;"
+              onclick="window.location='/transactions?{{template "filter_params" .}}&sort=tx_type&dir={{flipDir "tx_type" .SortCol .SortDir}}&page=1'">
+              Type {{sortIndicator "tx_type" .SortCol .SortDir}}
+            </th>
+            <th class="sortable" style="padding: 8px 12px; text-align: right;"
+              onclick="window.location='/transactions?{{template "filter_params" .}}&sort=amount_sat&dir={{flipDir "amount_sat" .SortCol .SortDir}}&page=1'">
+              Amount (sats) {{sortIndicator "amount_sat" .SortCol .SortDir}}
+            </th>
+            <th class="sortable" style="padding: 8px 12px; text-align: right;"
+              onclick="window.location='/transactions?{{template "filter_params" .}}&sort=amount_usd&dir={{flipDir "amount_usd" .SortCol .SortDir}}&page=1'">
+              USD {{sortIndicator "amount_usd" .SortCol .SortDir}}
+            </th>
+            <th class="sortable" style="padding: 8px 12px; text-align: right;"
+              onclick="window.location='/transactions?{{template "filter_params" .}}&sort=fee&dir={{flipDir "fee" .SortCol .SortDir}}&page=1'">
+              Fee {{sortIndicator "fee" .SortCol .SortDir}}
+            </th>
             <th style="padding: 8px 12px;">Memo</th>
             <th style="padding: 8px 12px;">Note</th>
           </tr>
@@ -73,18 +151,22 @@
     {{if gt .TotalPages 1}}
     <div style="display: flex; justify-content: center; gap: 8px; margin-top: 16px; font-size: 0.85rem;">
       {{if gt .Page 1}}
-      <a href="/transactions?page={{subtract .Page 1}}" style="color: var(--text-muted); text-decoration: none;">&larr; Prev</a>
+      <a href="/transactions?{{template "filter_params" .}}&sort={{.SortCol}}&dir={{.SortDir}}&page={{subtract .Page 1}}" style="color: var(--text-muted); text-decoration: none;">&larr; Prev</a>
       {{end}}
       <span style="color: var(--text-muted);">Page {{.Page}} of {{.TotalPages}} ({{.Total}} total)</span>
       {{if lt .Page .TotalPages}}
-      <a href="/transactions?page={{add .Page 1}}" style="color: var(--text-muted); text-decoration: none;">Next &rarr;</a>
+      <a href="/transactions?{{template "filter_params" .}}&sort={{.SortCol}}&dir={{.SortDir}}&page={{add .Page 1}}" style="color: var(--text-muted); text-decoration: none;">Next &rarr;</a>
       {{end}}
     </div>
     {{end}}
 
     {{else}}
     <div style="text-align: center; padding: 40px 16px; color: var(--text-muted);">
-      No transactions yet. <a href="/import" style="color: var(--accent);">Import exchange CSVs</a> or connect an LND node to see transactions here.
+      {{if or .DateFrom .DateTo .TxType .Source .Search}}
+        No transactions match your filters. <a href="/transactions" style="color: var(--accent);">Clear filters</a>
+      {{else}}
+        No transactions yet. <a href="/import" style="color: var(--accent);">Import exchange CSVs</a> or connect an LND node to see transactions here.
+      {{end}}
     </div>
     {{end}}
   </main>
@@ -97,3 +179,5 @@
   </footer>
 </body>
 </html>{{end}}
+
+{{define "filter_params"}}from={{.DateFrom}}&to={{.DateTo}}&type={{.TxType}}&source={{.Source}}&q={{.Search}}{{end}}

--- a/internal/web/templates/wallet_detail.html
+++ b/internal/web/templates/wallet_detail.html
@@ -9,10 +9,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "wallets"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "wallets"}}
     </div>
   </header>
 

--- a/internal/web/templates/wallets_layout.html
+++ b/internal/web/templates/wallets_layout.html
@@ -10,10 +10,13 @@
 <body>
   <header>
     <div class="container header-inner">
-      <div style="display: flex; align-items: center; gap: 24px;">
+      <div class="header-top">
         <a class="logo" href="/">Satsbook</a>
-        {{template "nav" "wallets"}}
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
       </div>
+      {{template "nav" "wallets"}}
     </div>
   </header>
 


### PR DESCRIPTION
## Summary

Adds a unified Bitcoin transaction ledger that aggregates all sources (exchanges, Lightning, on-chain) into a single view, with the ability to sync transactions to Monarch Money for consolidated financial tracking.

### Unified Transaction View
- New `v_unified_transactions` SQLite view joining Strike, River, Coinbase, Swan, and Lightning transactions
- Transactions page with filtering by source, type, and date range
- Full-text search across transaction memos and notes
- Sortable columns and editable per-transaction notes
- Responsive hamburger nav menu for mobile

### Monarch Money Transaction Sync
- Export Bitcoin transactions to a Monarch Money checking account
- Configurable transaction type and source filtering (settings page)
- Background sync with immediate UI feedback
- Deduplication logic to prevent duplicate imports on re-sync
- Mutex-based concurrency protection (manual sync vs background syncer)
- Descriptive merchant names using memo field (e.g., "Strike - Bill Pay to DIVIDEND SOLAR")
- Auto-sync on each sync cycle via background syncer

### Database Changes
- Migration 10: unified transaction view
- Migration 11: view recreation (moved from initial migration)
- `monarch_tx_sync` tracking table for sync state
- `ListUnsyncedTransactions` with source/type filtering

## Test plan
- [ ] Transactions page loads with all sources visible
- [ ] Filtering by source and type works correctly
- [ ] Search filters transactions by memo content
- [ ] Sorting by date, amount, source works
- [ ] Transaction notes can be edited inline
- [ ] Monarch sync exports selected transaction types/sources
- [ ] Re-sync does not create duplicates
- [ ] Background syncer and manual sync don't race
- [ ] Mobile nav menu works on small viewports