### PR TITLE
feat(stripe): Stripe Checkout and webhook integration for paid tiers

### DIFF
--- a/cmd/licenseserver/main.go
+++ b/cmd/licenseserver/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/satsbook/satsbook/internal/license"
 	"github.com/satsbook/satsbook/internal/licensedb"
+	stripeutil "github.com/satsbook/satsbook/internal/stripe"
 )
 
 func main() {
@@ -99,6 +101,17 @@ func cmdServe(args []string) {
 	})
 	mux.HandleFunc("/v1/license/validate", validateHandler(store, priv))
 
+	// Stripe integration (optional — only enabled if STRIPE_SECRET_KEY is set)
+	if sc := loadStripeConfig(); sc != nil {
+		client := &stripeutil.Client{SecretKey: sc.secretKey}
+		mux.HandleFunc("/v1/checkout", checkoutHandler(client, sc))
+		mux.HandleFunc("/v1/stripe/webhook", webhookHandler(store, client, sc))
+		mux.HandleFunc("/v1/checkout/success", successHandler(store, client))
+		log.Printf("stripe integration enabled")
+	} else {
+		log.Printf("stripe integration disabled (STRIPE_SECRET_KEY not set)")
+	}
+
 	addr := ":" + p
 	log.Printf("license server listening on %s (db=%s)", addr, getDBPath())
 	log.Fatal(http.ListenAndServe(addr, mux))
@@ -168,16 +181,16 @@ func cmdCreate(args []string) {
 	days := fs.Int("days", 0, "days until expiry (0 = no expiry)")
 	fs.Parse(args)
 
-	var expiresAt *time.Time
+	var params *licensedb.CreateParams
 	if *days > 0 {
 		t := time.Now().Add(time.Duration(*days) * 24 * time.Hour)
-		expiresAt = &t
+		params = &licensedb.CreateParams{ExpiresAt: &t}
 	}
 
 	store := openStore()
 	defer store.Close()
 
-	lic, err := store.Create(*email, *tier, expiresAt)
+	lic, err := store.Create(*email, *tier, params)
 	if err != nil {
 		log.Fatalf("create: %v", err)
 	}
@@ -225,6 +238,296 @@ func cmdUpgrade(args []string) {
 		log.Fatalf("upgrade: %v", err)
 	}
 	fmt.Printf("Upgraded %s to %s\n", fs.Arg(0), *tier)
+}
+
+// --- Stripe integration ---
+
+type stripeConfig struct {
+	secretKey     string
+	webhookSecret string
+	pricePro      string
+	pricePower    string
+	baseURL       string
+}
+
+func loadStripeConfig() *stripeConfig {
+	sk := os.Getenv("STRIPE_SECRET_KEY")
+	if sk == "" {
+		return nil
+	}
+	return &stripeConfig{
+		secretKey:     sk,
+		webhookSecret: os.Getenv("STRIPE_WEBHOOK_SECRET"),
+		pricePro:      os.Getenv("STRIPE_PRICE_PRO"),
+		pricePower:    os.Getenv("STRIPE_PRICE_POWER"),
+		baseURL:       os.Getenv("SATSBOOK_BASE_URL"),
+	}
+}
+
+func (sc *stripeConfig) priceForTier(tier string) string {
+	switch tier {
+	case "pro":
+		return sc.pricePro
+	case "power":
+		return sc.pricePower
+	default:
+		return ""
+	}
+}
+
+func (sc *stripeConfig) tierForPrice(priceID string) string {
+	switch priceID {
+	case sc.pricePro:
+		return "pro"
+	case sc.pricePower:
+		return "power"
+	default:
+		return ""
+	}
+}
+
+func checkoutHandler(client *stripeutil.Client, sc *stripeConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req struct {
+			Tier string `json:"tier"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+		priceID := sc.priceForTier(req.Tier)
+		if priceID == "" {
+			http.Error(w, "invalid tier", http.StatusBadRequest)
+			return
+		}
+
+		session, err := client.CreateCheckoutSession(stripeutil.CheckoutParams{
+			PriceID:    priceID,
+			SuccessURL: sc.baseURL + "/v1/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			CancelURL:  sc.baseURL + "/v1/checkout/cancel",
+			Tier:       req.Tier,
+		})
+		if err != nil {
+			log.Printf("create checkout: %v", err)
+			http.Error(w, "failed to create checkout session", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"url": session.URL})
+	}
+}
+
+func webhookHandler(store *licensedb.Store, client *stripeutil.Client, sc *stripeConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(io.LimitReader(r.Body, 65536))
+		if err != nil {
+			http.Error(w, "read error", http.StatusBadRequest)
+			return
+		}
+
+		event, err := stripeutil.VerifyWebhookSignature(body, r.Header.Get("Stripe-Signature"), sc.webhookSecret)
+		if err != nil {
+			log.Printf("webhook signature error: %v", err)
+			http.Error(w, "invalid signature", http.StatusBadRequest)
+			return
+		}
+
+		switch event.Type {
+		case "checkout.session.completed":
+			handleCheckoutCompleted(store, client, sc, event)
+		case "customer.subscription.deleted":
+			handleSubscriptionDeleted(store, event)
+		case "customer.subscription.updated":
+			handleSubscriptionUpdated(store, client, sc, event)
+		default:
+			log.Printf("webhook: ignoring event type %s", event.Type)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func handleCheckoutCompleted(store *licensedb.Store, client *stripeutil.Client, sc *stripeConfig, event *stripeutil.WebhookEvent) {
+	var session stripeutil.CheckoutSession
+	if err := json.Unmarshal(event.ObjectRaw(), &session); err != nil {
+		log.Printf("webhook: decode session: %v", err)
+		return
+	}
+
+	tier := session.Metadata["tier"]
+	if tier == "" {
+		// Try to determine from subscription
+		if session.SubscriptionID != "" {
+			sub, err := client.GetSubscription(session.SubscriptionID)
+			if err == nil && len(sub.Items.Data) > 0 {
+				tier = sc.tierForPrice(sub.Items.Data[0].Price.ID)
+			}
+			if tier == "" {
+				tier = sub.Metadata["tier"]
+			}
+		}
+	}
+	if tier == "" {
+		tier = "pro" // default
+	}
+
+	email := session.Email()
+	customerID := session.CustomerID
+
+	// Check if we already created a license for this subscription (idempotent).
+	if session.SubscriptionID != "" {
+		existing, _ := store.LookupByStripeSubscription(session.SubscriptionID)
+		if existing != nil {
+			log.Printf("webhook: license already exists for subscription %s", session.SubscriptionID)
+			return
+		}
+	}
+
+	lic, err := store.Create(email, tier, &licensedb.CreateParams{
+		StripeCustomerID:     customerID,
+		StripeSubscriptionID: session.SubscriptionID,
+	})
+	if err != nil {
+		log.Printf("webhook: create license: %v", err)
+		return
+	}
+
+	log.Printf("webhook: created license %s (tier=%s, email=%s, sub=%s)", lic.LicenseKey, tier, email, session.SubscriptionID)
+}
+
+func handleSubscriptionDeleted(store *licensedb.Store, event *stripeutil.WebhookEvent) {
+	var sub struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(event.ObjectRaw(), &sub); err != nil {
+		log.Printf("webhook: decode subscription: %v", err)
+		return
+	}
+
+	lic, err := store.LookupByStripeSubscription(sub.ID)
+	if err != nil || lic == nil {
+		log.Printf("webhook: no license for subscription %s", sub.ID)
+		return
+	}
+
+	if err := store.Revoke(lic.LicenseKey); err != nil {
+		log.Printf("webhook: revoke license %s: %v", lic.LicenseKey, err)
+		return
+	}
+	log.Printf("webhook: revoked license %s (sub=%s cancelled)", lic.LicenseKey, sub.ID)
+}
+
+func handleSubscriptionUpdated(store *licensedb.Store, client *stripeutil.Client, sc *stripeConfig, event *stripeutil.WebhookEvent) {
+	var sub stripeutil.Subscription
+	if err := json.Unmarshal(event.ObjectRaw(), &sub); err != nil {
+		log.Printf("webhook: decode subscription: %v", err)
+		return
+	}
+
+	lic, err := store.LookupByStripeSubscription(sub.ID)
+	if err != nil || lic == nil {
+		log.Printf("webhook: no license for subscription %s (update ignored)", sub.ID)
+		return
+	}
+
+	// Determine new tier from the subscription's current price.
+	newTier := ""
+	if len(sub.Items.Data) > 0 {
+		newTier = sc.tierForPrice(sub.Items.Data[0].Price.ID)
+	}
+	if newTier == "" {
+		newTier = sub.Metadata["tier"]
+	}
+	if newTier == "" || newTier == lic.Tier {
+		return // no tier change
+	}
+
+	if err := store.Upgrade(lic.LicenseKey, newTier); err != nil {
+		log.Printf("webhook: upgrade license %s to %s: %v", lic.LicenseKey, newTier, err)
+		return
+	}
+	log.Printf("webhook: upgraded license %s from %s to %s", lic.LicenseKey, lic.Tier, newTier)
+}
+
+func successHandler(store *licensedb.Store, client *stripeutil.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sessionID := r.URL.Query().Get("session_id")
+		if sessionID == "" {
+			http.Error(w, "missing session_id", http.StatusBadRequest)
+			return
+		}
+
+		// Fetch the checkout session from Stripe to get the subscription ID.
+		session, err := client.GetCheckoutSession(sessionID)
+		if err != nil {
+			log.Printf("success: get session %s: %v", sessionID, err)
+			http.Error(w, "could not retrieve session", http.StatusInternalServerError)
+			return
+		}
+
+		if session.PaymentStatus != "paid" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write([]byte(successPage("", "Payment is still processing. Please check back shortly.")))
+			return
+		}
+
+		// Look up the license by subscription ID.
+		var lic *licensedb.License
+		if session.SubscriptionID != "" {
+			lic, _ = store.LookupByStripeSubscription(session.SubscriptionID)
+		}
+
+		if lic == nil {
+			// Webhook may not have arrived yet — show a waiting message.
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write([]byte(successPage("", "Your payment was successful! Your license key is being generated. Please refresh this page in a few seconds.")))
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(successPage(lic.LicenseKey, "")))
+	}
+}
+
+func successPage(licenseKey, message string) string {
+	content := ""
+	if licenseKey != "" {
+		content = `
+		<h2>Thank you for subscribing!</h2>
+		<p>Your license key:</p>
+		<div style="background:#1a1a2e;border:1px solid #444;border-radius:8px;padding:16px;margin:16px 0;font-family:monospace;font-size:1.2rem;word-break:break-all;user-select:all;">` + licenseKey + `</div>
+		<p>Copy this key and set it in your Satsbook settings:</p>
+		<pre style="background:#1a1a2e;border:1px solid #444;border-radius:8px;padding:12px;overflow-x:auto;">SATSBOOK_LICENSE_KEY=` + licenseKey + `</pre>
+		<p style="color:#999;margin-top:16px;font-size:0.85rem;">Save this key — you will need it if you reinstall Satsbook.</p>`
+	} else {
+		content = `<h2>` + message + `</h2>`
+	}
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Satsbook — License</title>
+	<style>
+		body { font-family: -apple-system, sans-serif; background: #0d1117; color: #e6e6e6; max-width: 600px; margin: 40px auto; padding: 0 20px; }
+		h2 { color: #f7931a; }
+		a { color: #4fc3f7; }
+	</style>
+</head>
+<body>` + content + `</body></html>`
 }
 
 func cmdList(args []string) {

--- a/internal/licensedb/integration_test.go
+++ b/internal/licensedb/integration_test.go
@@ -21,7 +21,7 @@ func TestValidateFlow(t *testing.T) {
 	}
 	defer store.Close()
 
-	// Create a license
+	// Create a license (nil params = no expiry, no Stripe IDs)
 	lic, err := store.Create("user@test.com", "pro", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/licensedb/store.go
+++ b/internal/licensedb/store.go
@@ -10,7 +10,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const migration = `
+const migrationV1 = `
 CREATE TABLE IF NOT EXISTS licenses (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     license_key TEXT NOT NULL UNIQUE,
@@ -22,14 +22,22 @@ CREATE TABLE IF NOT EXISTS licenses (
 );
 `
 
+const migrationV2 = `
+ALTER TABLE licenses ADD COLUMN stripe_customer_id TEXT;
+ALTER TABLE licenses ADD COLUMN stripe_subscription_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_licenses_stripe_sub ON licenses(stripe_subscription_id);
+`
+
 type License struct {
-	ID         int64
-	LicenseKey string
-	Email      string
-	Tier       string
-	Status     string
-	ExpiresAt  *time.Time
-	CreatedAt  time.Time
+	ID                   int64
+	LicenseKey           string
+	Email                string
+	Tier                 string
+	Status               string
+	StripeCustomerID     string
+	StripeSubscriptionID string
+	ExpiresAt            *time.Time
+	CreatedAt            time.Time
 }
 
 type Store struct {
@@ -41,36 +49,70 @@ func Open(dsn string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
-	if _, err := db.Exec(migration); err != nil {
+	if _, err := db.Exec(migrationV1); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("migrate: %w", err)
+		return nil, fmt.Errorf("migrate v1: %w", err)
+	}
+	if err := migrateV2(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate v2: %w", err)
 	}
 	return &Store{db: db}, nil
+}
+
+// migrateV2 adds Stripe columns if they don't exist yet.
+func migrateV2(db *sql.DB) error {
+	var count int
+	err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('licenses') WHERE name = 'stripe_customer_id'`).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check schema: %w", err)
+	}
+	if count == 0 {
+		if _, err := db.Exec(migrationV2); err != nil {
+			return fmt.Errorf("apply v2: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *Store) Close() error {
 	return s.db.Close()
 }
 
-// Lookup finds a license by key. Returns nil if not found.
-func (s *Store) Lookup(key string) (*License, error) {
-	row := s.db.QueryRow(
-		`SELECT id, license_key, email, tier, status, expires_at, created_at FROM licenses WHERE license_key = ?`,
-		key,
-	)
+const licenseColumns = `id, license_key, email, tier, status, expires_at, created_at, COALESCE(stripe_customer_id,''), COALESCE(stripe_subscription_id,'')`
+
+func scanLicense(row interface{ Scan(...any) error }) (*License, error) {
 	var l License
 	var expiresAt sql.NullTime
-	err := row.Scan(&l.ID, &l.LicenseKey, &l.Email, &l.Tier, &l.Status, &expiresAt, &l.CreatedAt)
+	err := row.Scan(&l.ID, &l.LicenseKey, &l.Email, &l.Tier, &l.Status, &expiresAt, &l.CreatedAt, &l.StripeCustomerID, &l.StripeSubscriptionID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("lookup: %w", err)
+		return nil, err
 	}
 	if expiresAt.Valid {
 		l.ExpiresAt = &expiresAt.Time
 	}
 	return &l, nil
+}
+
+// Lookup finds a license by key. Returns nil if not found.
+func (s *Store) Lookup(key string) (*License, error) {
+	l, err := scanLicense(s.db.QueryRow(`SELECT `+licenseColumns+` FROM licenses WHERE license_key = ?`, key))
+	if err != nil {
+		return nil, fmt.Errorf("lookup: %w", err)
+	}
+	return l, nil
+}
+
+// LookupByStripeSubscription finds a license by Stripe subscription ID.
+func (s *Store) LookupByStripeSubscription(subID string) (*License, error) {
+	l, err := scanLicense(s.db.QueryRow(`SELECT `+licenseColumns+` FROM licenses WHERE stripe_subscription_id = ?`, subID))
+	if err != nil {
+		return nil, fmt.Errorf("lookup by subscription: %w", err)
+	}
+	return l, nil
 }
 
 // IsValid returns true if the license exists, is active, and not expired.
@@ -87,36 +129,56 @@ func (l *License) IsValid() bool {
 	return true
 }
 
+// CreateParams holds optional parameters for license creation.
+type CreateParams struct {
+	ExpiresAt            *time.Time
+	StripeCustomerID     string
+	StripeSubscriptionID string
+}
+
 // Create inserts a new license with a generated key.
-func (s *Store) Create(email, tier string, expiresAt *time.Time) (*License, error) {
+func (s *Store) Create(email, tier string, params *CreateParams) (*License, error) {
 	key, err := generateKey()
 	if err != nil {
 		return nil, fmt.Errorf("generate key: %w", err)
 	}
 
-	var expVal any
-	if expiresAt != nil {
-		expVal = *expiresAt
+	var expVal, custVal, subVal any
+	if params != nil {
+		if params.ExpiresAt != nil {
+			expVal = *params.ExpiresAt
+		}
+		if params.StripeCustomerID != "" {
+			custVal = params.StripeCustomerID
+		}
+		if params.StripeSubscriptionID != "" {
+			subVal = params.StripeSubscriptionID
+		}
 	}
 
 	res, err := s.db.Exec(
-		`INSERT INTO licenses (license_key, email, tier, expires_at) VALUES (?, ?, ?, ?)`,
-		key, email, tier, expVal,
+		`INSERT INTO licenses (license_key, email, tier, expires_at, stripe_customer_id, stripe_subscription_id) VALUES (?, ?, ?, ?, ?, ?)`,
+		key, email, tier, expVal, custVal, subVal,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert: %w", err)
 	}
 
-	id, _ := res.LastInsertId()
-	return &License{
-		ID:         id,
+	lic := &License{
+		ID:         0,
 		LicenseKey: key,
 		Email:      email,
 		Tier:       tier,
 		Status:     "active",
-		ExpiresAt:  expiresAt,
 		CreatedAt:  time.Now(),
-	}, nil
+	}
+	lic.ID, _ = res.LastInsertId()
+	if params != nil {
+		lic.ExpiresAt = params.ExpiresAt
+		lic.StripeCustomerID = params.StripeCustomerID
+		lic.StripeSubscriptionID = params.StripeSubscriptionID
+	}
+	return lic, nil
 }
 
 // Revoke sets a license's status to "cancelled".
@@ -147,9 +209,7 @@ func (s *Store) Upgrade(key, tier string) error {
 
 // List returns all licenses.
 func (s *Store) List() ([]License, error) {
-	rows, err := s.db.Query(
-		`SELECT id, license_key, email, tier, status, expires_at, created_at FROM licenses ORDER BY created_at DESC`,
-	)
+	rows, err := s.db.Query(`SELECT ` + licenseColumns + ` FROM licenses ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("list: %w", err)
 	}
@@ -157,15 +217,11 @@ func (s *Store) List() ([]License, error) {
 
 	var licenses []License
 	for rows.Next() {
-		var l License
-		var expiresAt sql.NullTime
-		if err := rows.Scan(&l.ID, &l.LicenseKey, &l.Email, &l.Tier, &l.Status, &expiresAt, &l.CreatedAt); err != nil {
+		l, err := scanLicense(rows)
+		if err != nil {
 			return nil, fmt.Errorf("scan: %w", err)
 		}
-		if expiresAt.Valid {
-			l.ExpiresAt = &expiresAt.Time
-		}
-		licenses = append(licenses, l)
+		licenses = append(licenses, *l)
 	}
 	return licenses, rows.Err()
 }

--- a/internal/licensedb/store_test.go
+++ b/internal/licensedb/store_test.go
@@ -51,6 +51,57 @@ func TestCreateAndLookup(t *testing.T) {
 	}
 }
 
+func TestCreateWithStripeParams(t *testing.T) {
+	s := testStore(t)
+
+	lic, err := s.Create("stripe@test.com", "pro", &CreateParams{
+		StripeCustomerID:     "cus_test123",
+		StripeSubscriptionID: "sub_test456",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	found, err := s.Lookup(lic.LicenseKey)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if found.StripeCustomerID != "cus_test123" {
+		t.Errorf("stripe customer id: got %q", found.StripeCustomerID)
+	}
+	if found.StripeSubscriptionID != "sub_test456" {
+		t.Errorf("stripe subscription id: got %q", found.StripeSubscriptionID)
+	}
+}
+
+func TestLookupByStripeSubscription(t *testing.T) {
+	s := testStore(t)
+
+	lic, _ := s.Create("sub@test.com", "power", &CreateParams{
+		StripeSubscriptionID: "sub_lookup789",
+	})
+
+	found, err := s.LookupByStripeSubscription("sub_lookup789")
+	if err != nil {
+		t.Fatalf("lookup by sub: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected license, got nil")
+	}
+	if found.LicenseKey != lic.LicenseKey {
+		t.Errorf("key mismatch: %s vs %s", found.LicenseKey, lic.LicenseKey)
+	}
+
+	// Not found case
+	notFound, err := s.LookupByStripeSubscription("sub_nonexistent")
+	if err != nil {
+		t.Fatalf("lookup by sub: %v", err)
+	}
+	if notFound != nil {
+		t.Errorf("expected nil, got %+v", notFound)
+	}
+}
+
 func TestLookupNotFound(t *testing.T) {
 	s := testStore(t)
 
@@ -87,7 +138,7 @@ func TestIsValid_Cancelled(t *testing.T) {
 func TestIsValid_Expired(t *testing.T) {
 	s := testStore(t)
 	past := time.Now().Add(-24 * time.Hour)
-	lic, _ := s.Create("a@b.com", "pro", &past)
+	lic, _ := s.Create("a@b.com", "pro", &CreateParams{ExpiresAt: &past})
 
 	found, _ := s.Lookup(lic.LicenseKey)
 	if found.IsValid() {
@@ -98,7 +149,7 @@ func TestIsValid_Expired(t *testing.T) {
 func TestIsValid_FutureExpiry(t *testing.T) {
 	s := testStore(t)
 	future := time.Now().Add(30 * 24 * time.Hour)
-	lic, _ := s.Create("a@b.com", "pro", &future)
+	lic, _ := s.Create("a@b.com", "pro", &CreateParams{ExpiresAt: &future})
 
 	found, _ := s.Lookup(lic.LicenseKey)
 	if !found.IsValid() {

--- a/internal/stripe/stripe.go
+++ b/internal/stripe/stripe.go
@@ -1,0 +1,229 @@
+package stripe
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Client makes raw HTTP calls to the Stripe API.
+type Client struct {
+	SecretKey  string
+	HTTPClient *http.Client
+}
+
+// CheckoutParams holds the parameters for creating a Checkout Session.
+type CheckoutParams struct {
+	PriceID    string
+	SuccessURL string
+	CancelURL  string
+	Tier       string // stored as metadata
+}
+
+// CheckoutSession is the response from Stripe's create session endpoint.
+type CheckoutSession struct {
+	ID                 string `json:"id"`
+	URL                string `json:"url"`
+	PaymentStatus      string `json:"payment_status"`
+	CustomerEmail      string `json:"customer_email"`
+	CustomerID         string `json:"customer"`
+	SubscriptionID     string `json:"subscription"`
+	Metadata           map[string]string `json:"metadata"`
+	CustomerDetailsRaw json.RawMessage   `json:"customer_details"`
+}
+
+// CustomerDetails returns the email from customer_details if present.
+func (cs *CheckoutSession) Email() string {
+	if cs.CustomerEmail != "" {
+		return cs.CustomerEmail
+	}
+	var details struct {
+		Email string `json:"email"`
+	}
+	if len(cs.CustomerDetailsRaw) > 0 {
+		json.Unmarshal(cs.CustomerDetailsRaw, &details)
+	}
+	return details.Email
+}
+
+// CreateCheckoutSession creates a Stripe Checkout Session.
+func (c *Client) CreateCheckoutSession(params CheckoutParams) (*CheckoutSession, error) {
+	form := url.Values{
+		"mode":                            {"subscription"},
+		"line_items[0][price]":            {params.PriceID},
+		"line_items[0][quantity]":         {"1"},
+		"success_url":                     {params.SuccessURL},
+		"cancel_url":                      {params.CancelURL},
+		"metadata[tier]":                  {params.Tier},
+		"subscription_data[metadata][tier]": {params.Tier},
+	}
+
+	var session CheckoutSession
+	if err := c.post("/v1/checkout/sessions", form, &session); err != nil {
+		return nil, fmt.Errorf("create checkout session: %w", err)
+	}
+	return &session, nil
+}
+
+// GetCheckoutSession retrieves a Checkout Session by ID.
+func (c *Client) GetCheckoutSession(sessionID string) (*CheckoutSession, error) {
+	var session CheckoutSession
+	if err := c.get("/v1/checkout/sessions/"+sessionID, &session); err != nil {
+		return nil, fmt.Errorf("get checkout session: %w", err)
+	}
+	return &session, nil
+}
+
+// Subscription represents a Stripe subscription object (partial).
+type Subscription struct {
+	ID       string            `json:"id"`
+	Status   string            `json:"status"`
+	Customer string            `json:"customer"`
+	Metadata map[string]string `json:"metadata"`
+	Items    struct {
+		Data []struct {
+			Price struct {
+				ID string `json:"id"`
+			} `json:"price"`
+		} `json:"data"`
+	} `json:"items"`
+}
+
+// GetSubscription retrieves a subscription by ID.
+func (c *Client) GetSubscription(subID string) (*Subscription, error) {
+	var sub Subscription
+	if err := c.get("/v1/subscriptions/"+subID, &sub); err != nil {
+		return nil, fmt.Errorf("get subscription: %w", err)
+	}
+	return &sub, nil
+}
+
+func (c *Client) post(path string, form url.Values, result any) error {
+	req, err := http.NewRequest(http.MethodPost, "https://api.stripe.com"+path, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(c.SecretKey, "")
+	return c.do(req, result)
+}
+
+func (c *Client) get(path string, result any) error {
+	req, err := http.NewRequest(http.MethodGet, "https://api.stripe.com"+path, nil)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(c.SecretKey, "")
+	return c.do(req, result)
+}
+
+func (c *Client) do(req *http.Request, result any) error {
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("stripe API error (status %d): %s", resp.StatusCode, body)
+	}
+
+	if result != nil {
+		if err := json.Unmarshal(body, result); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+// WebhookEvent represents a Stripe webhook event.
+type WebhookEvent struct {
+	ID   string          `json:"id"`
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+// ObjectRaw returns the data.object field as raw JSON.
+func (e *WebhookEvent) ObjectRaw() json.RawMessage {
+	var wrapper struct {
+		Object json.RawMessage `json:"object"`
+	}
+	json.Unmarshal(e.Data, &wrapper)
+	return wrapper.Object
+}
+
+// VerifyWebhookSignature verifies a Stripe webhook signature.
+// Returns the parsed event if valid.
+func VerifyWebhookSignature(payload []byte, sigHeader, secret string) (*WebhookEvent, error) {
+	// Parse the Stripe-Signature header: t=timestamp,v1=signature
+	parts := strings.Split(sigHeader, ",")
+	var timestamp string
+	var signatures []string
+	for _, part := range parts {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "t":
+			timestamp = kv[1]
+		case "v1":
+			signatures = append(signatures, kv[1])
+		}
+	}
+
+	if timestamp == "" || len(signatures) == 0 {
+		return nil, fmt.Errorf("invalid signature header")
+	}
+
+	// Check timestamp is within tolerance (5 minutes).
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timestamp: %w", err)
+	}
+	if abs(time.Now().Unix()-ts) > 300 {
+		return nil, fmt.Errorf("timestamp too old")
+	}
+
+	// Compute expected signature: HMAC-SHA256(secret, "timestamp.payload")
+	signed := timestamp + "." + string(payload)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signed))
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	for _, sig := range signatures {
+		if hmac.Equal([]byte(sig), []byte(expected)) {
+			var event WebhookEvent
+			if err := json.Unmarshal(payload, &event); err != nil {
+				return nil, fmt.Errorf("decode event: %w", err)
+			}
+			return &event, nil
+		}
+	}
+
+	return nil, fmt.Errorf("signature mismatch")
+}
+
+func abs(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/stripe/stripe_test.go
+++ b/internal/stripe/stripe_test.go
@@ -1,0 +1,236 @@
+package stripe
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestVerifyWebhookSignature_Valid(t *testing.T) {
+	secret := "whsec_test_secret"
+	payload := []byte(`{"id":"evt_123","type":"checkout.session.completed","data":{"object":{"id":"cs_123"}}}`)
+	ts := fmt.Sprintf("%d", time.Now().Unix())
+
+	sig := computeSignature(ts, payload, secret)
+	header := fmt.Sprintf("t=%s,v1=%s", ts, sig)
+
+	event, err := VerifyWebhookSignature(payload, header, secret)
+	if err != nil {
+		t.Fatalf("expected valid signature: %v", err)
+	}
+	if event.ID != "evt_123" {
+		t.Errorf("event ID: got %q", event.ID)
+	}
+	if event.Type != "checkout.session.completed" {
+		t.Errorf("event type: got %q", event.Type)
+	}
+}
+
+func TestVerifyWebhookSignature_Invalid(t *testing.T) {
+	secret := "whsec_test_secret"
+	payload := []byte(`{"id":"evt_123","type":"test"}`)
+	ts := fmt.Sprintf("%d", time.Now().Unix())
+
+	header := fmt.Sprintf("t=%s,v1=%s", ts, "badsignature")
+
+	_, err := VerifyWebhookSignature(payload, header, secret)
+	if err == nil {
+		t.Fatal("expected error for invalid signature")
+	}
+}
+
+func TestVerifyWebhookSignature_Expired(t *testing.T) {
+	secret := "whsec_test_secret"
+	payload := []byte(`{"id":"evt_123","type":"test"}`)
+	ts := fmt.Sprintf("%d", time.Now().Add(-10*time.Minute).Unix())
+
+	sig := computeSignature(ts, payload, secret)
+	header := fmt.Sprintf("t=%s,v1=%s", ts, sig)
+
+	_, err := VerifyWebhookSignature(payload, header, secret)
+	if err == nil {
+		t.Fatal("expected error for expired timestamp")
+	}
+}
+
+func TestVerifyWebhookSignature_MissingHeader(t *testing.T) {
+	_, err := VerifyWebhookSignature([]byte(`{}`), "", "secret")
+	if err == nil {
+		t.Fatal("expected error for empty header")
+	}
+}
+
+func TestObjectRaw(t *testing.T) {
+	event := &WebhookEvent{
+		Data: json.RawMessage(`{"object":{"id":"cs_test","customer":"cus_abc"}}`),
+	}
+	raw := event.ObjectRaw()
+
+	var obj struct {
+		ID       string `json:"id"`
+		Customer string `json:"customer"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if obj.ID != "cs_test" {
+		t.Errorf("id: got %q", obj.ID)
+	}
+	if obj.Customer != "cus_abc" {
+		t.Errorf("customer: got %q", obj.Customer)
+	}
+}
+
+func TestCheckoutSessionEmail(t *testing.T) {
+	t.Run("from customer_email field", func(t *testing.T) {
+		cs := &CheckoutSession{CustomerEmail: "direct@test.com"}
+		if cs.Email() != "direct@test.com" {
+			t.Errorf("got %q", cs.Email())
+		}
+	})
+
+	t.Run("from customer_details", func(t *testing.T) {
+		cs := &CheckoutSession{
+			CustomerDetailsRaw: json.RawMessage(`{"email":"details@test.com"}`),
+		}
+		if cs.Email() != "details@test.com" {
+			t.Errorf("got %q", cs.Email())
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		cs := &CheckoutSession{}
+		if cs.Email() != "" {
+			t.Errorf("got %q", cs.Email())
+		}
+	})
+}
+
+func TestCreateCheckoutSession(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/checkout/sessions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+
+		user, _, ok := r.BasicAuth()
+		if !ok || user != "sk_test_key" {
+			t.Errorf("bad auth: %q", user)
+		}
+
+		r.ParseForm()
+		if r.FormValue("mode") != "subscription" {
+			t.Errorf("mode: %q", r.FormValue("mode"))
+		}
+		if r.FormValue("metadata[tier]") != "pro" {
+			t.Errorf("metadata[tier]: %q", r.FormValue("metadata[tier]"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(CheckoutSession{
+			ID:  "cs_test_session",
+			URL: "https://checkout.stripe.com/test",
+		})
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		SecretKey:  "sk_test_key",
+		HTTPClient: srv.Client(),
+	}
+	// Override the Stripe API URL by using a custom transport
+	c.HTTPClient.Transport = rewriteTransport{base: srv.Client().Transport, target: srv.URL}
+
+	session, err := c.CreateCheckoutSession(CheckoutParams{
+		PriceID:    "price_test",
+		SuccessURL: "https://example.com/success",
+		CancelURL:  "https://example.com/cancel",
+		Tier:       "pro",
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if session.ID != "cs_test_session" {
+		t.Errorf("session ID: %q", session.ID)
+	}
+}
+
+func TestGetCheckoutSession(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/checkout/sessions/cs_abc" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(CheckoutSession{
+			ID:             "cs_abc",
+			PaymentStatus:  "paid",
+			SubscriptionID: "sub_xyz",
+			Metadata:       map[string]string{"tier": "power"},
+		})
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		SecretKey:  "sk_test_key",
+		HTTPClient: &http.Client{Transport: rewriteTransport{base: srv.Client().Transport, target: srv.URL}},
+	}
+
+	session, err := c.GetCheckoutSession("cs_abc")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if session.PaymentStatus != "paid" {
+		t.Errorf("payment status: %q", session.PaymentStatus)
+	}
+	if session.SubscriptionID != "sub_xyz" {
+		t.Errorf("subscription id: %q", session.SubscriptionID)
+	}
+}
+
+func TestClientAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"error":{"message":"bad request"}}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		SecretKey:  "sk_test",
+		HTTPClient: &http.Client{Transport: rewriteTransport{base: srv.Client().Transport, target: srv.URL}},
+	}
+
+	_, err := c.GetCheckoutSession("cs_bad")
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+}
+
+// rewriteTransport redirects requests from api.stripe.com to the test server.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = t.target[len("http://"):]
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+func computeSignature(ts string, payload []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts + "." + string(payload)))
+	return hex.EncodeToString(mac.Sum(nil))
+}


### PR DESCRIPTION
## Summary
- Adds Stripe Checkout subscription flow to the license server (`cmd/licenseserver`)
- `POST /v1/checkout` — creates a Stripe Checkout Session and returns the redirect URL
- `POST /v1/stripe/webhook` — handles `checkout.session.completed` (create license), `customer.subscription.deleted` (revoke), `customer.subscription.updated` (upgrade/downgrade)
- `GET /v1/checkout/success` — displays the license key after successful payment
- New `internal/stripe` package — raw `net/http` Stripe API client with HMAC-SHA256 webhook signature verification (no SDK dependency)
- DB migration adds `stripe_customer_id` and `stripe_subscription_id` columns (safe for existing databases)
- Stripe integration is optional — only active when `STRIPE_SECRET_KEY` is set

## Env vars (set via `fly secrets set`)
- `STRIPE_SECRET_KEY` — Stripe API secret key
- `STRIPE_WEBHOOK_SECRET` — webhook endpoint signing secret
- `STRIPE_PRICE_PRO` — Stripe Price ID for Pro tier ($9/mo)
- `STRIPE_PRICE_POWER` — Stripe Price ID for Power tier ($19/mo)
- `SATSBOOK_BASE_URL` — base URL for redirects (e.g. `https://api.satsbook.io`)

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet` clean
- [x] New `internal/stripe` tests: webhook signature verification (valid, invalid, expired), checkout session create/get, API error handling
- [x] New `internal/licensedb` tests: Stripe params on create, lookup by subscription ID
- [ ] End-to-end test with Stripe test mode after deploy

Closes #14