### PR TITLE
feat(tax): FIFO/LIFO cost basis engine + Form 8949 CSV export

### DIFF
--- a/cmd/licenseserver/main.go
+++ b/cmd/licenseserver/main.go
@@ -294,7 +294,8 @@ func checkoutHandler(client *stripeutil.Client, sc *stripeConfig) http.HandlerFu
 		}
 
 		var req struct {
-			Tier string `json:"tier"`
+			Tier      string `json:"tier"`
+			ReturnURL string `json:"return_url"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", http.StatusBadRequest)
@@ -307,9 +308,14 @@ func checkoutHandler(client *stripeutil.Client, sc *stripeConfig) http.HandlerFu
 			return
 		}
 
+		successURL := sc.baseURL + "/v1/checkout/success?session_id={CHECKOUT_SESSION_ID}"
+		if req.ReturnURL != "" {
+			successURL += "&return_url=" + req.ReturnURL
+		}
+
 		session, err := client.CreateCheckoutSession(stripeutil.CheckoutParams{
 			PriceID:    priceID,
-			SuccessURL: sc.baseURL + "/v1/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			SuccessURL: successURL,
 			CancelURL:  sc.baseURL + "/v1/checkout/cancel",
 			Tier:       req.Tier,
 		})
@@ -496,9 +502,29 @@ func successHandler(store *licensedb.Store, client *stripeutil.Client) http.Hand
 			return
 		}
 
+		// If a return_url was provided, redirect back to the app with the key.
+		returnURL := r.URL.Query().Get("return_url")
+		if returnURL != "" && lic.LicenseKey != "" {
+			sep := "?"
+			if len(returnURL) > 0 && containsChar(returnURL, '?') {
+				sep = "&"
+			}
+			http.Redirect(w, r, returnURL+sep+"license_key="+lic.LicenseKey, http.StatusFound)
+			return
+		}
+
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Write([]byte(successPage(lic.LicenseKey, "")))
 	}
+}
+
+func containsChar(s string, c byte) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return true
+		}
+	}
+	return false
 }
 
 func successPage(licenseKey, message string) string {

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -114,6 +115,9 @@ func main() {
 	handler.SetMonarchTxStore(database)
 	handler.SetTaxStore(database)
 	handler.SetLicenseChecker(lc)
+	// Derive checkout base URL from the validation URL (strip /v1/license/validate)
+	checkoutBase := strings.TrimSuffix(cfg.LicenseValidationURL, "/v1/license/validate")
+	handler.SetCheckoutBaseURL(checkoutBase)
 	monarchToken, _ := database.GetSetting(context.Background(), "monarch_token")
 	if monarchToken == "" {
 		monarchToken = cfg.MonarchToken // fall back to env var

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -50,26 +50,33 @@ func main() {
 	defer database.Close()
 	log.Printf("database initialized at %s", cfg.DatabasePath)
 
-	// Initialize license checker
-	var licenseChecker license.Checker
-	if cfg.LicenseKey != "" {
-		licenseLogger := log.New(os.Stdout, "[license] ", log.LstdFlags)
-		lc := license.NewChecker(
-			&licenseStoreAdapter{db: database},
-			cfg.LicenseKey,
-			license.WithValidationURL(cfg.LicenseValidationURL),
-			license.WithLogger(licenseLogger),
-		)
+	// Initialize license checker — always use DefaultChecker so keys can be
+	// activated at runtime from the settings page without restarting.
+	licenseKey := cfg.LicenseKey
+	if licenseKey == "" {
+		// Fall back to license key stored in the settings DB.
+		if dbKey, _ := database.GetSetting(context.Background(), "license_key"); dbKey != "" {
+			licenseKey = dbKey
+			log.Printf("License key loaded from database settings")
+		}
+	}
+	licenseLogger := log.New(os.Stdout, "[license] ", log.LstdFlags)
+	lc := license.NewChecker(
+		&licenseStoreAdapter{db: database},
+		licenseKey,
+		license.WithValidationURL(cfg.LicenseValidationURL),
+		license.WithLogger(licenseLogger),
+	)
+	if licenseKey != "" {
 		if err := lc.Verify(context.Background()); err != nil {
 			log.Printf("WARNING: license verification failed: %v — defaulting to free tier", err)
 		} else {
 			log.Printf("License tier: %s", lc.CurrentTier())
 		}
-		licenseChecker = lc
 	} else {
-		licenseChecker = license.FreeChecker{}
 		log.Printf("No license key configured — running free tier")
 	}
+	var licenseChecker license.Checker = lc
 
 	// Initialize price cache
 	priceCache := price.NewCache(price.WithAPIURL(cfg.PriceAPIURL))
@@ -106,6 +113,7 @@ func main() {
 	handler.SetTransactionStore(database)
 	handler.SetMonarchTxStore(database)
 	handler.SetTaxStore(database)
+	handler.SetLicenseChecker(lc)
 	monarchToken, _ := database.GetSetting(context.Background(), "monarch_token")
 	if monarchToken == "" {
 		monarchToken = cfg.MonarchToken // fall back to env var

--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -105,6 +105,7 @@ func main() {
 	handler.SetSettingsStore(database)
 	handler.SetTransactionStore(database)
 	handler.SetMonarchTxStore(database)
+	handler.SetTaxStore(database)
 	monarchToken, _ := database.GetSetting(context.Background(), "monarch_token")
 	if monarchToken == "" {
 		monarchToken = cfg.MonarchToken // fall back to env var

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1649,7 +1649,7 @@ func (d *DB) ListDisposals(ctx context.Context) ([]DisposalRow, error) {
 			source,
 			external_id
 		 FROM exchange_imports
-		 WHERE tx_type IN ('sale', 'sell')
+		 WHERE LOWER(tx_type) IN ('sale', 'sell')
 		   AND COALESCE(json_extract(raw_data, '$.AmountBTC'), 0) != 0
 		 ORDER BY tx_date ASC`)
 	if err != nil {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1636,18 +1636,20 @@ type DisposalRow struct {
 	ExternalID  string
 }
 
-// ListDisposals returns all disposal events (sales, sends) from exchange_imports.
+// ListDisposals returns disposal events (sales only) from exchange_imports.
+// Sends and withdrawals are excluded because they are typically self-transfers
+// (e.g. exchange → personal wallet) and not taxable events.
 func (d *DB) ListDisposals(ctx context.Context) ([]DisposalRow, error) {
 	rows, err := d.db.QueryContext(ctx,
 		`SELECT
 			COALESCE(json_extract(raw_data, '$.Date'), imported_at) as tx_date,
 			ABS(COALESCE(json_extract(raw_data, '$.AmountBTC'), 0)) as abs_btc,
-			COALESCE(json_extract(raw_data, '$.AmountUSD'), 0) as amount_usd,
+			ABS(COALESCE(json_extract(raw_data, '$.AmountUSD'), 0)) as amount_usd,
 			tx_type,
 			source,
 			external_id
 		 FROM exchange_imports
-		 WHERE tx_type IN ('sale', 'sell', 'send', 'withdrawal')
+		 WHERE tx_type IN ('sale', 'sell')
 		   AND COALESCE(json_extract(raw_data, '$.AmountBTC'), 0) != 0
 		 ORDER BY tx_date ASC`)
 	if err != nil {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1591,3 +1591,121 @@ func (d *DB) ClearMonarchSyncState(ctx context.Context) error {
 	_, err := d.db.ExecContext(ctx, `DELETE FROM monarch_tx_sync`)
 	return err
 }
+
+// --- Tax / Cost Basis Queries ---
+
+// BTCLot represents a row from the btc_lots table.
+type BTCLot struct {
+	ID         int64
+	AcquiredAt time.Time
+	AmountSat  int64
+	PriceUSD   float64
+	Source     string
+	ExternalID string
+}
+
+// ListBTCLots returns all BTC acquisition lots, ordered by acquisition date.
+func (d *DB) ListBTCLots(ctx context.Context) ([]BTCLot, error) {
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT id, acquired_at, amount_sat, price_usd, source, COALESCE(external_id, '')
+		 FROM btc_lots
+		 ORDER BY acquired_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list btc lots: %w", err)
+	}
+	defer rows.Close()
+
+	var lots []BTCLot
+	for rows.Next() {
+		var l BTCLot
+		if err := rows.Scan(&l.ID, &l.AcquiredAt, &l.AmountSat, &l.PriceUSD, &l.Source, &l.ExternalID); err != nil {
+			return nil, fmt.Errorf("scan btc lot: %w", err)
+		}
+		lots = append(lots, l)
+	}
+	return lots, rows.Err()
+}
+
+// DisposalRow represents a sale or send from exchange_imports.
+type DisposalRow struct {
+	DisposedAt  time.Time
+	AmountSat   int64
+	ProceedsUSD float64
+	TxType      string
+	Source      string
+	ExternalID  string
+}
+
+// ListDisposals returns all disposal events (sales, sends) from exchange_imports.
+func (d *DB) ListDisposals(ctx context.Context) ([]DisposalRow, error) {
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT
+			COALESCE(json_extract(raw_data, '$.Date'), imported_at) as tx_date,
+			ABS(COALESCE(json_extract(raw_data, '$.AmountBTC'), 0)) as abs_btc,
+			COALESCE(json_extract(raw_data, '$.AmountUSD'), 0) as amount_usd,
+			tx_type,
+			source,
+			external_id
+		 FROM exchange_imports
+		 WHERE tx_type IN ('sale', 'sell', 'send', 'withdrawal')
+		   AND COALESCE(json_extract(raw_data, '$.AmountBTC'), 0) != 0
+		 ORDER BY tx_date ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list disposals: %w", err)
+	}
+	defer rows.Close()
+
+	var disposals []DisposalRow
+	for rows.Next() {
+		var d DisposalRow
+		var dateStr string
+		var absBTC float64
+		if err := rows.Scan(&dateStr, &absBTC, &d.ProceedsUSD, &d.TxType, &d.Source, &d.ExternalID); err != nil {
+			return nil, fmt.Errorf("scan disposal: %w", err)
+		}
+		d.DisposedAt, _ = time.Parse(time.RFC3339, dateStr)
+		if d.DisposedAt.IsZero() {
+			d.DisposedAt, _ = time.Parse("2006-01-02T15:04:05Z", dateStr)
+		}
+		d.AmountSat = int64(math.Round(absBTC * 1e8))
+		if d.ProceedsUSD < 0 {
+			d.ProceedsUSD = -d.ProceedsUSD
+		}
+		disposals = append(disposals, d)
+	}
+	return disposals, rows.Err()
+}
+
+// SaveDisposals writes matched disposal events to the disposals table.
+// It clears existing disposals first (full recalculation).
+func (d *DB) SaveDisposals(ctx context.Context, events []struct {
+	DisposedAt  time.Time
+	AmountSat   int64
+	ProceedsUSD float64
+	LotID       int64
+}) error {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM disposals`); err != nil {
+		return fmt.Errorf("clear disposals: %w", err)
+	}
+
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO disposals (disposed_at, amount_sat, proceeds_usd, lot_id) VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, e := range events {
+		if _, err := stmt.ExecContext(ctx, e.DisposedAt, e.AmountSat, e.ProceedsUSD, e.LotID); err != nil {
+			return fmt.Errorf("insert disposal: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2890,3 +2890,229 @@ func TestSaveDisposals_Empty(t *testing.T) {
 		t.Errorf("expected 0, got %d", count)
 	}
 }
+
+// --- Settings tests ---
+
+func TestGetSetting_NotFound(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	val, err := d.GetSetting(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != "" {
+		t.Errorf("expected empty string, got %q", val)
+	}
+}
+
+func TestSetAndGetSetting(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	if err := d.SetSetting(ctx, "theme", "dark"); err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := d.GetSetting(ctx, "theme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != "dark" {
+		t.Errorf("expected %q, got %q", "dark", val)
+	}
+
+	// Upsert: overwrite same key
+	if err := d.SetSetting(ctx, "theme", "light"); err != nil {
+		t.Fatal(err)
+	}
+	val, err = d.GetSetting(ctx, "theme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != "light" {
+		t.Errorf("expected %q after upsert, got %q", "light", val)
+	}
+}
+
+// --- Monarch sync tests ---
+
+func seedExchangeImport(t *testing.T, d *DB, source, externalID, txType string, amountBTC, amountUSD float64, date string) {
+	t.Helper()
+	raw := fmt.Sprintf(`{"AmountBTC": %f, "AmountUSD": %f, "Date": %q}`, amountBTC, amountUSD, date)
+	_, err := d.db.ExecContext(context.Background(),
+		`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data) VALUES (?, ?, ?, ?)`,
+		source, externalID, txType, raw)
+	if err != nil {
+		t.Fatalf("seed exchange import: %v", err)
+	}
+}
+
+func TestMarkTransactionSynced(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	if err := d.MarkTransactionSynced(ctx, "strike:1:buy", "monarch_abc"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Duplicate insert should be ignored
+	if err := d.MarkTransactionSynced(ctx, "strike:1:buy", "monarch_abc"); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := d.MonarchSyncedCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1, got %d", count)
+	}
+}
+
+func TestMonarchSyncedCount_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	count, err := d.MonarchSyncedCount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0, got %d", count)
+	}
+}
+
+func TestClearMonarchSyncState(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	// Seed some synced records
+	for i := range 3 {
+		if err := d.MarkTransactionSynced(ctx, fmt.Sprintf("src:%d:buy", i), fmt.Sprintf("m_%d", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	count, _ := d.MonarchSyncedCount(ctx)
+	if count != 3 {
+		t.Fatalf("expected 3 before clear, got %d", count)
+	}
+
+	if err := d.ClearMonarchSyncState(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	count, _ = d.MonarchSyncedCount(ctx)
+	if count != 0 {
+		t.Errorf("expected 0 after clear, got %d", count)
+	}
+}
+
+func TestListUnsyncedTransactions(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	// Seed exchange imports (these feed btc_transactions_v)
+	seedExchangeImport(t, d, "strike", "tx1", "Purchase", 0.001, 50.00, "2024-01-01T12:00:00Z")
+	seedExchangeImport(t, d, "strike", "tx2", "Sale", 0.002, 100.00, "2024-01-02T12:00:00Z")
+	seedExchangeImport(t, d, "strike", "tx3", "Purchase", 0.003, 150.00, "2024-01-03T12:00:00Z")
+
+	// All should be unsynced initially
+	txns, err := d.ListUnsyncedTransactions(ctx, []string{"buy", "sell"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(txns) != 3 {
+		t.Fatalf("expected 3 unsynced, got %d", len(txns))
+	}
+
+	// Mark one as synced
+	if err := d.MarkTransactionSynced(ctx, txns[0].SourceID, "monarch_1"); err != nil {
+		t.Fatal(err)
+	}
+
+	txns, err = d.ListUnsyncedTransactions(ctx, []string{"buy", "sell"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(txns) != 2 {
+		t.Errorf("expected 2 unsynced after marking one, got %d", len(txns))
+	}
+
+	// Filter by source
+	txns, err = d.ListUnsyncedTransactions(ctx, []string{"buy"}, []string{"strike"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// tx1 was synced, tx3 is a buy from strike
+	if len(txns) != 1 {
+		t.Errorf("expected 1 unsynced buy from strike, got %d", len(txns))
+	}
+}
+
+func TestListUnsyncedTransactions_EmptyTypes(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	txns, err := d.ListUnsyncedTransactions(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if txns != nil {
+		t.Errorf("expected nil for empty txTypes, got %v", txns)
+	}
+}
+
+// --- DistinctTransactionValues tests ---
+
+func TestDistinctTransactionValues_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	sources, txTypes, err := d.DistinctTransactionValues(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 0 {
+		t.Errorf("expected no sources, got %v", sources)
+	}
+	if len(txTypes) != 0 {
+		t.Errorf("expected no txTypes, got %v", txTypes)
+	}
+}
+
+func TestDistinctTransactionValues(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	seedExchangeImport(t, d, "strike", "a1", "Purchase", 0.001, 50.0, "2024-01-01T12:00:00Z")
+	seedExchangeImport(t, d, "strike", "a2", "Sale", 0.002, 100.0, "2024-01-02T12:00:00Z")
+	seedExchangeImport(t, d, "river", "b1", "Purchase", 0.003, 150.0, "2024-01-03T12:00:00Z")
+
+	sources, txTypes, err := d.DistinctTransactionValues(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sources: river, strike (alphabetical)
+	if len(sources) != 2 {
+		t.Fatalf("expected 2 sources, got %d: %v", len(sources), sources)
+	}
+	if sources[0] != "river" || sources[1] != "strike" {
+		t.Errorf("unexpected sources: %v", sources)
+	}
+
+	// TxTypes: buy, sell (the view normalizes Purchase→buy, Sale→sell)
+	if len(txTypes) != 2 {
+		t.Fatalf("expected 2 txTypes, got %d: %v", len(txTypes), txTypes)
+	}
+	if txTypes[0] != "buy" || txTypes[1] != "sell" {
+		t.Errorf("unexpected txTypes: %v", txTypes)
+	}
+}
+

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2734,3 +2734,159 @@ func TestUnifiedTransactionsWithNotes(t *testing.T) {
 		t.Errorf("expected note 'my routing note', got %q", page.Transactions[0].Note)
 	}
 }
+
+func TestListBTCLots(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	// Insert lots directly
+	_, err := d.db.ExecContext(ctx,
+		`INSERT INTO btc_lots (acquired_at, amount_sat, price_usd, source, external_id) VALUES
+		 (?, 100000, 50.00, 'strike', 'tx1'),
+		 (?, 200000, 120.00, 'river', 'tx2')`,
+		time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lots, err := d.ListBTCLots(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lots) != 2 {
+		t.Fatalf("expected 2 lots, got %d", len(lots))
+	}
+	// Should be ordered by acquired_at ASC
+	if lots[0].Source != "strike" || lots[0].AmountSat != 100000 {
+		t.Errorf("lot 0: source=%s amount=%d", lots[0].Source, lots[0].AmountSat)
+	}
+	if lots[1].Source != "river" || lots[1].AmountSat != 200000 {
+		t.Errorf("lot 1: source=%s amount=%d", lots[1].Source, lots[1].AmountSat)
+	}
+	if lots[0].PriceUSD != 50.00 {
+		t.Errorf("lot 0 price: %f", lots[0].PriceUSD)
+	}
+}
+
+func TestListBTCLots_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	lots, err := d.ListBTCLots(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lots) != 0 {
+		t.Errorf("expected 0 lots, got %d", len(lots))
+	}
+}
+
+func TestListDisposals(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	// Insert exchange_imports with sale and non-sale types
+	for _, tc := range []struct {
+		txType string
+		extID  string
+		raw    string
+	}{
+		{"Sale", "s1", `{"Date":"2024-06-01T10:00:00Z","AmountBTC":-0.01,"AmountUSD":500}`},
+		{"sell", "s2", `{"Date":"2024-07-01T10:00:00Z","AmountBTC":-0.02,"AmountUSD":1200}`},
+		{"send", "s3", `{"Date":"2024-08-01T10:00:00Z","AmountBTC":-0.005,"AmountUSD":0}`},
+		{"Purchase", "p1", `{"Date":"2024-01-01T10:00:00Z","AmountBTC":0.05,"AmountUSD":2000}`},
+	} {
+		_, err := d.db.ExecContext(ctx,
+			`INSERT INTO exchange_imports (source, external_id, tx_type, raw_data) VALUES ('strike', ?, ?, ?)`,
+			tc.extID, tc.txType, tc.raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	disposals, err := d.ListDisposals(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only Sale and sell should be included (not send, not Purchase)
+	if len(disposals) != 2 {
+		t.Fatalf("expected 2 disposals, got %d", len(disposals))
+	}
+	// Ordered by date ASC
+	if disposals[0].AmountSat != 1_000_000 { // 0.01 BTC
+		t.Errorf("disposal 0 amount: %d", disposals[0].AmountSat)
+	}
+	if disposals[0].ProceedsUSD != 500 {
+		t.Errorf("disposal 0 proceeds: %f", disposals[0].ProceedsUSD)
+	}
+	if disposals[1].AmountSat != 2_000_000 { // 0.02 BTC
+		t.Errorf("disposal 1 amount: %d", disposals[1].AmountSat)
+	}
+}
+
+func TestListDisposals_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	disposals, err := d.ListDisposals(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(disposals) != 0 {
+		t.Errorf("expected 0 disposals, got %d", len(disposals))
+	}
+}
+
+func TestSaveDisposals(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+	ctx := context.Background()
+
+	events := []struct {
+		DisposedAt  time.Time
+		AmountSat   int64
+		ProceedsUSD float64
+		LotID       int64
+	}{
+		{time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC), 500_000, 300.00, 1},
+		{time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC), 200_000, 150.00, 2},
+	}
+
+	if err := d.SaveDisposals(ctx, events); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify rows were inserted
+	var count int
+	d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM disposals`).Scan(&count)
+	if count != 2 {
+		t.Errorf("expected 2 disposals, got %d", count)
+	}
+
+	// Save again — should clear and rewrite
+	if err := d.SaveDisposals(ctx, events[:1]); err != nil {
+		t.Fatal(err)
+	}
+	d.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM disposals`).Scan(&count)
+	if count != 1 {
+		t.Errorf("expected 1 disposal after re-save, got %d", count)
+	}
+}
+
+func TestSaveDisposals_Empty(t *testing.T) {
+	d := newTestDB(t)
+	defer d.Close()
+
+	if err := d.SaveDisposals(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var count int
+	d.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM disposals`).Scan(&count)
+	if count != 0 {
+		t.Errorf("expected 0, got %d", count)
+	}
+}

--- a/internal/license/checker.go
+++ b/internal/license/checker.go
@@ -105,6 +105,18 @@ func (c *DefaultChecker) CurrentTier() Tier {
 	return c.currentTier.Load().(Tier)
 }
 
+// SetKeyAndVerify updates the license key at runtime and re-verifies.
+// This allows activating a license without restarting the app.
+func (c *DefaultChecker) SetKeyAndVerify(ctx context.Context, key string) error {
+	c.licenseKey = key
+	return c.Verify(ctx)
+}
+
+// LicenseKey returns the currently configured license key.
+func (c *DefaultChecker) LicenseKey() string {
+	return c.licenseKey
+}
+
 func (c *DefaultChecker) setTier(t Tier) {
 	c.currentTier.Store(t)
 }

--- a/internal/tax/costbasis.go
+++ b/internal/tax/costbasis.go
@@ -1,0 +1,167 @@
+package tax
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Method represents a cost basis accounting method.
+type Method string
+
+const (
+	FIFO Method = "fifo"
+	LIFO Method = "lifo"
+)
+
+// Lot represents a BTC acquisition lot.
+type Lot struct {
+	ID          int64
+	AcquiredAt  time.Time
+	AmountSat   int64   // original amount
+	PriceUSD    float64 // total USD cost for this lot
+	Source      string
+	ExternalID  string
+	RemainSat   int64 // remaining unmatched sats (computed during matching)
+}
+
+// CostPerSat returns the per-satoshi cost for this lot.
+func (l *Lot) CostPerSat() float64 {
+	if l.AmountSat == 0 {
+		return 0
+	}
+	return l.PriceUSD / float64(l.AmountSat)
+}
+
+// Disposal represents a BTC disposal event (sale, send, spend).
+type Disposal struct {
+	DisposedAt  time.Time
+	AmountSat   int64
+	ProceedsUSD float64 // USD received (0 for sends/gifts)
+	TxType      string  // "sale", "send", "spend"
+	Source      string
+	ExternalID  string
+}
+
+// TaxableEvent represents a matched disposal-to-lot pair.
+type TaxableEvent struct {
+	DisposedAt    time.Time
+	AcquiredAt    time.Time
+	AmountSat     int64
+	CostBasisUSD  float64
+	ProceedsUSD   float64
+	GainLossUSD   float64
+	IsLongTerm    bool // held > 1 year
+	LotID         int64
+	DisposalSource string
+	DisposalExtID  string
+}
+
+// MatchResult holds the output of matching disposals to lots.
+type MatchResult struct {
+	Events        []TaxableEvent
+	UnmatchedSat  int64 // disposal sats that couldn't be matched to lots
+}
+
+// Match pairs disposals against lots using the specified accounting method.
+// Lots and disposals are processed in chronological order. For FIFO, the earliest
+// lots are consumed first; for LIFO, the most recent lots (acquired before the
+// disposal date) are consumed first.
+func Match(lots []Lot, disposals []Disposal, method Method) (*MatchResult, error) {
+	if method != FIFO && method != LIFO {
+		return nil, fmt.Errorf("unsupported method: %s", method)
+	}
+
+	// Sort lots by acquisition date ascending.
+	sortedLots := make([]Lot, len(lots))
+	copy(sortedLots, lots)
+	sort.Slice(sortedLots, func(i, j int) bool {
+		return sortedLots[i].AcquiredAt.Before(sortedLots[j].AcquiredAt)
+	})
+
+	// Initialize remaining sats.
+	for i := range sortedLots {
+		sortedLots[i].RemainSat = sortedLots[i].AmountSat
+	}
+
+	// Sort disposals chronologically.
+	sortedDisposals := make([]Disposal, len(disposals))
+	copy(sortedDisposals, disposals)
+	sort.Slice(sortedDisposals, func(i, j int) bool {
+		return sortedDisposals[i].DisposedAt.Before(sortedDisposals[j].DisposedAt)
+	})
+
+	result := &MatchResult{}
+
+	for _, d := range sortedDisposals {
+		remaining := d.AmountSat
+		proceedsPerSat := float64(0)
+		if d.AmountSat > 0 {
+			proceedsPerSat = d.ProceedsUSD / float64(d.AmountSat)
+		}
+
+		// Build candidate lots (acquired before or on disposal date).
+		candidates := candidateLots(sortedLots, d.DisposedAt, method)
+
+		for _, idx := range candidates {
+			if remaining <= 0 {
+				break
+			}
+			lot := &sortedLots[idx]
+			if lot.RemainSat <= 0 {
+				continue
+			}
+
+			consumed := lot.RemainSat
+			if consumed > remaining {
+				consumed = remaining
+			}
+
+			costBasis := lot.CostPerSat() * float64(consumed)
+			proceeds := proceedsPerSat * float64(consumed)
+
+			event := TaxableEvent{
+				DisposedAt:     d.DisposedAt,
+				AcquiredAt:     lot.AcquiredAt,
+				AmountSat:      consumed,
+				CostBasisUSD:   costBasis,
+				ProceedsUSD:    proceeds,
+				GainLossUSD:    proceeds - costBasis,
+				IsLongTerm:     d.DisposedAt.Sub(lot.AcquiredAt) > 365*24*time.Hour,
+				LotID:          lot.ID,
+				DisposalSource: d.Source,
+				DisposalExtID:  d.ExternalID,
+			}
+
+			result.Events = append(result.Events, event)
+			lot.RemainSat -= consumed
+			remaining -= consumed
+		}
+
+		if remaining > 0 {
+			result.UnmatchedSat += remaining
+		}
+	}
+
+	return result, nil
+}
+
+// candidateLots returns indices into sortedLots for lots acquired on or before
+// the disposal date, ordered by the accounting method.
+func candidateLots(sortedLots []Lot, disposedAt time.Time, method Method) []int {
+	var indices []int
+	for i, lot := range sortedLots {
+		if !lot.AcquiredAt.After(disposedAt) && lot.RemainSat > 0 {
+			indices = append(indices, i)
+		}
+	}
+
+	if method == LIFO {
+		// Reverse: most recent first.
+		for i, j := 0, len(indices)-1; i < j; i, j = i+1, j-1 {
+			indices[i], indices[j] = indices[j], indices[i]
+		}
+	}
+	// FIFO: indices are already in ascending (earliest first) order.
+	return indices
+}

--- a/internal/tax/costbasis_test.go
+++ b/internal/tax/costbasis_test.go
@@ -1,0 +1,315 @@
+package tax
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func date(y, m, d int) time.Time {
+	return time.Date(y, time.Month(m), d, 0, 0, 0, 0, time.UTC)
+}
+
+func assertClose(t *testing.T, label string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 0.01 {
+		t.Errorf("%s: got %.4f, want %.4f", label, got, want)
+	}
+}
+
+func TestMatch_FIFO_SingleLotSingleDisposal(t *testing.T) {
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2024, 1, 1), AmountSat: 1_000_000, PriceUSD: 430.00, Source: "strike"},
+	}
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 6, 1), AmountSat: 500_000, ProceedsUSD: 300.00, TxType: "sale"},
+	}
+
+	result, err := Match(lots, disposals, FIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+
+	e := result.Events[0]
+	if e.AmountSat != 500_000 {
+		t.Errorf("amount: got %d", e.AmountSat)
+	}
+	assertClose(t, "cost basis", e.CostBasisUSD, 215.00) // 500k/1M * 430
+	assertClose(t, "proceeds", e.ProceedsUSD, 300.00)
+	assertClose(t, "gain", e.GainLossUSD, 85.00)
+	if e.IsLongTerm {
+		t.Error("should be short-term (held < 1 year)")
+	}
+	if result.UnmatchedSat != 0 {
+		t.Errorf("unmatched: %d", result.UnmatchedSat)
+	}
+}
+
+func TestMatch_FIFO_MultipleLots(t *testing.T) {
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2023, 1, 1), AmountSat: 500_000, PriceUSD: 100.00, Source: "strike"},
+		{ID: 2, AcquiredAt: date(2023, 6, 1), AmountSat: 500_000, PriceUSD: 150.00, Source: "river"},
+		{ID: 3, AcquiredAt: date(2024, 1, 1), AmountSat: 500_000, PriceUSD: 200.00, Source: "coinbase"},
+	}
+	// Sell 750k sats — should consume lot 1 (500k) + lot 2 (250k) under FIFO.
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 7, 1), AmountSat: 750_000, ProceedsUSD: 500.00, TxType: "sale"},
+	}
+
+	result, err := Match(lots, disposals, FIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(result.Events))
+	}
+
+	// Event 1: lot 1 fully consumed (500k sats)
+	e1 := result.Events[0]
+	if e1.LotID != 1 || e1.AmountSat != 500_000 {
+		t.Errorf("event 1: lot=%d, amount=%d", e1.LotID, e1.AmountSat)
+	}
+	assertClose(t, "e1 cost", e1.CostBasisUSD, 100.00)
+	assertClose(t, "e1 proceeds", e1.ProceedsUSD, 500.0*500_000/750_000) // 333.33
+	if !e1.IsLongTerm {
+		t.Error("e1 should be long-term (2023-01 to 2024-07)")
+	}
+
+	// Event 2: lot 2 partially consumed (250k sats)
+	e2 := result.Events[1]
+	if e2.LotID != 2 || e2.AmountSat != 250_000 {
+		t.Errorf("event 2: lot=%d, amount=%d", e2.LotID, e2.AmountSat)
+	}
+	assertClose(t, "e2 cost", e2.CostBasisUSD, 75.00) // 250k/500k * 150
+	if !e2.IsLongTerm {
+		t.Error("e2 should be long-term (2023-06 to 2024-07)")
+	}
+
+	if result.UnmatchedSat != 0 {
+		t.Errorf("unmatched: %d", result.UnmatchedSat)
+	}
+}
+
+func TestMatch_LIFO_MultipleLots(t *testing.T) {
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2023, 1, 1), AmountSat: 500_000, PriceUSD: 100.00},
+		{ID: 2, AcquiredAt: date(2023, 6, 1), AmountSat: 500_000, PriceUSD: 150.00},
+		{ID: 3, AcquiredAt: date(2024, 1, 1), AmountSat: 500_000, PriceUSD: 200.00},
+	}
+	// Sell 600k sats — LIFO should consume lot 3 (500k) + lot 2 (100k).
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 7, 1), AmountSat: 600_000, ProceedsUSD: 400.00, TxType: "sale"},
+	}
+
+	result, err := Match(lots, disposals, LIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(result.Events))
+	}
+
+	// LIFO: lot 3 consumed first
+	e1 := result.Events[0]
+	if e1.LotID != 3 || e1.AmountSat != 500_000 {
+		t.Errorf("event 1: lot=%d, amount=%d", e1.LotID, e1.AmountSat)
+	}
+	assertClose(t, "e1 cost", e1.CostBasisUSD, 200.00)
+	if e1.IsLongTerm {
+		t.Error("e1 should be short-term (2024-01 to 2024-07)")
+	}
+
+	// Then lot 2 partially
+	e2 := result.Events[1]
+	if e2.LotID != 2 || e2.AmountSat != 100_000 {
+		t.Errorf("event 2: lot=%d, amount=%d", e2.LotID, e2.AmountSat)
+	}
+	assertClose(t, "e2 cost", e2.CostBasisUSD, 30.00) // 100k/500k * 150
+}
+
+func TestMatch_MultipleDisposals(t *testing.T) {
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2023, 1, 1), AmountSat: 1_000_000, PriceUSD: 300.00},
+	}
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 3, 1), AmountSat: 400_000, ProceedsUSD: 200.00, TxType: "sale"},
+		{DisposedAt: date(2024, 6, 1), AmountSat: 300_000, ProceedsUSD: 180.00, TxType: "sale"},
+	}
+
+	result, err := Match(lots, disposals, FIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(result.Events))
+	}
+
+	// Disposal 1: 400k sats from lot 1
+	assertClose(t, "d1 cost", result.Events[0].CostBasisUSD, 120.00) // 400k/1M * 300
+	assertClose(t, "d1 gain", result.Events[0].GainLossUSD, 80.00)
+
+	// Disposal 2: 300k sats from lot 1 (remaining 600k)
+	assertClose(t, "d2 cost", result.Events[1].CostBasisUSD, 90.00) // 300k/1M * 300
+	assertClose(t, "d2 gain", result.Events[1].GainLossUSD, 90.00)
+
+	if result.UnmatchedSat != 0 {
+		t.Errorf("unmatched: %d", result.UnmatchedSat)
+	}
+}
+
+func TestMatch_UnmatchedDisposal(t *testing.T) {
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2024, 1, 1), AmountSat: 100_000, PriceUSD: 50.00},
+	}
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 6, 1), AmountSat: 300_000, ProceedsUSD: 200.00, TxType: "sale"},
+	}
+
+	result, err := Match(lots, disposals, FIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+	if result.Events[0].AmountSat != 100_000 {
+		t.Errorf("matched amount: %d", result.Events[0].AmountSat)
+	}
+	if result.UnmatchedSat != 200_000 {
+		t.Errorf("unmatched: got %d, want 200000", result.UnmatchedSat)
+	}
+}
+
+func TestMatch_NoDisposals(t *testing.T) {
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2024, 1, 1), AmountSat: 1_000_000, PriceUSD: 500.00},
+	}
+
+	result, err := Match(lots, nil, FIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(result.Events))
+	}
+}
+
+func TestMatch_NoLots(t *testing.T) {
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 6, 1), AmountSat: 100_000, ProceedsUSD: 50.00, TxType: "sale"},
+	}
+
+	result, err := Match(nil, disposals, FIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.UnmatchedSat != 100_000 {
+		t.Errorf("unmatched: %d", result.UnmatchedSat)
+	}
+}
+
+func TestMatch_SendWithZeroProceeds(t *testing.T) {
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2023, 1, 1), AmountSat: 1_000_000, PriceUSD: 300.00},
+	}
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 3, 1), AmountSat: 500_000, ProceedsUSD: 0, TxType: "send"},
+	}
+
+	result, err := Match(lots, disposals, FIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := result.Events[0]
+	assertClose(t, "proceeds", e.ProceedsUSD, 0)
+	assertClose(t, "cost", e.CostBasisUSD, 150.00) // 500k/1M * 300
+	assertClose(t, "loss", e.GainLossUSD, -150.00)
+}
+
+func TestMatch_LongTermBoundary(t *testing.T) {
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2023, 1, 1), AmountSat: 100_000, PriceUSD: 50.00},
+	}
+
+	// Exactly 365 days later — still short-term (need > 365 days).
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 1, 1), AmountSat: 50_000, ProceedsUSD: 30.00, TxType: "sale"},
+	}
+	result, _ := Match(lots, disposals, FIFO)
+	if result.Events[0].IsLongTerm {
+		t.Error("exactly 365 days should be short-term")
+	}
+
+	// 366 days — long-term.
+	disposals2 := []Disposal{
+		{DisposedAt: date(2024, 1, 2), AmountSat: 50_000, ProceedsUSD: 30.00, TxType: "sale"},
+	}
+	result2, _ := Match(lots, disposals2, FIFO)
+	if !result2.Events[0].IsLongTerm {
+		t.Error("366 days should be long-term")
+	}
+}
+
+func TestMatch_InvalidMethod(t *testing.T) {
+	_, err := Match(nil, nil, "hifo")
+	if err == nil {
+		t.Error("expected error for invalid method")
+	}
+}
+
+func TestMatch_FutureLotNotConsumed(t *testing.T) {
+	// Lot acquired AFTER disposal should not be consumed.
+	lots := []Lot{
+		{ID: 1, AcquiredAt: date(2024, 6, 1), AmountSat: 1_000_000, PriceUSD: 500.00},
+	}
+	disposals := []Disposal{
+		{DisposedAt: date(2024, 1, 1), AmountSat: 500_000, ProceedsUSD: 250.00, TxType: "sale"},
+	}
+
+	result, err := Match(lots, disposals, FIFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Events) != 0 {
+		t.Errorf("future lot should not be matched, got %d events", len(result.Events))
+	}
+	if result.UnmatchedSat != 500_000 {
+		t.Errorf("unmatched: %d", result.UnmatchedSat)
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	mr := &MatchResult{
+		Events: []TaxableEvent{
+			{AmountSat: 500_000, CostBasisUSD: 100, ProceedsUSD: 200, GainLossUSD: 100, IsLongTerm: true},
+			{AmountSat: 300_000, CostBasisUSD: 80, ProceedsUSD: 50, GainLossUSD: -30, IsLongTerm: false},
+			{AmountSat: 200_000, CostBasisUSD: 60, ProceedsUSD: 90, GainLossUSD: 30, IsLongTerm: false},
+		},
+		UnmatchedSat: 10_000,
+	}
+
+	s := Summarize(mr)
+	assertClose(t, "total proceeds", s.TotalProceeds, 340.00)
+	assertClose(t, "total cost", s.TotalCostBasis, 240.00)
+	assertClose(t, "total gain", s.TotalGainLoss, 100.00)
+	assertClose(t, "long-term gain", s.LongTermGainLoss, 100.00)
+	assertClose(t, "short-term gain", s.ShortTermGainLoss, 0.00) // -30 + 30
+	if s.LongTermCount != 1 {
+		t.Errorf("long-term count: %d", s.LongTermCount)
+	}
+	if s.ShortTermCount != 2 {
+		t.Errorf("short-term count: %d", s.ShortTermCount)
+	}
+	if s.UnmatchedSat != 10_000 {
+		t.Errorf("unmatched: %d", s.UnmatchedSat)
+	}
+}

--- a/internal/tax/form8949.go
+++ b/internal/tax/form8949.go
@@ -1,0 +1,109 @@
+package tax
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"time"
+)
+
+// Form8949Row represents a single row on IRS Form 8949.
+type Form8949Row struct {
+	Description    string // e.g. "0.001 BTC"
+	DateAcquired   time.Time
+	DateSold       time.Time
+	Proceeds       float64
+	CostBasis      float64
+	GainOrLoss     float64
+	HoldingPeriod  string // "Short-term" or "Long-term"
+}
+
+// EventToForm8949Row converts a TaxableEvent to a Form 8949 row.
+func EventToForm8949Row(e TaxableEvent) Form8949Row {
+	btc := float64(e.AmountSat) / 1e8
+	period := "Short-term"
+	if e.IsLongTerm {
+		period = "Long-term"
+	}
+	return Form8949Row{
+		Description:   fmt.Sprintf("%.8f BTC", btc),
+		DateAcquired:  e.AcquiredAt,
+		DateSold:      e.DisposedAt,
+		Proceeds:      e.ProceedsUSD,
+		CostBasis:     e.CostBasisUSD,
+		GainOrLoss:    e.GainLossUSD,
+		HoldingPeriod: period,
+	}
+}
+
+// WriteForm8949CSV writes Form 8949 rows as a TurboTax-compatible CSV.
+func WriteForm8949CSV(w io.Writer, events []TaxableEvent) error {
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+
+	header := []string{
+		"Description of Property",
+		"Date Acquired",
+		"Date Sold",
+		"Proceeds",
+		"Cost or Other Basis",
+		"Gain or Loss",
+		"Holding Period",
+	}
+	if err := cw.Write(header); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	for _, e := range events {
+		row := EventToForm8949Row(e)
+		record := []string{
+			row.Description,
+			row.DateAcquired.Format("01/02/2006"),
+			row.DateSold.Format("01/02/2006"),
+			fmt.Sprintf("%.2f", row.Proceeds),
+			fmt.Sprintf("%.2f", row.CostBasis),
+			fmt.Sprintf("%.2f", row.GainOrLoss),
+			row.HoldingPeriod,
+		}
+		if err := cw.Write(record); err != nil {
+			return fmt.Errorf("write row: %w", err)
+		}
+	}
+
+	return cw.Error()
+}
+
+// TaxSummary holds aggregate tax stats for a period.
+type TaxSummary struct {
+	TotalProceeds       float64
+	TotalCostBasis      float64
+	TotalGainLoss       float64
+	ShortTermGainLoss   float64
+	LongTermGainLoss    float64
+	ShortTermCount      int
+	LongTermCount       int
+	TotalDisposals      int
+	UnmatchedSat        int64
+}
+
+// Summarize computes aggregate tax stats from a MatchResult.
+func Summarize(mr *MatchResult) TaxSummary {
+	var s TaxSummary
+	s.UnmatchedSat = mr.UnmatchedSat
+	s.TotalDisposals = len(mr.Events)
+
+	for _, e := range mr.Events {
+		s.TotalProceeds += e.ProceedsUSD
+		s.TotalCostBasis += e.CostBasisUSD
+		s.TotalGainLoss += e.GainLossUSD
+		if e.IsLongTerm {
+			s.LongTermGainLoss += e.GainLossUSD
+			s.LongTermCount++
+		} else {
+			s.ShortTermGainLoss += e.GainLossUSD
+			s.ShortTermCount++
+		}
+	}
+
+	return s
+}

--- a/internal/tax/form8949_test.go
+++ b/internal/tax/form8949_test.go
@@ -1,0 +1,119 @@
+package tax
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteForm8949CSV(t *testing.T) {
+	events := []TaxableEvent{
+		{
+			DisposedAt:   time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC),
+			AcquiredAt:   time.Date(2023, 1, 10, 0, 0, 0, 0, time.UTC),
+			AmountSat:    50_000_000, // 0.5 BTC
+			CostBasisUSD: 10000.00,
+			ProceedsUSD:  15000.00,
+			GainLossUSD:  5000.00,
+			IsLongTerm:   true,
+		},
+		{
+			DisposedAt:   time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC),
+			AcquiredAt:   time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			AmountSat:    10_000_000, // 0.1 BTC
+			CostBasisUSD: 4500.00,
+			ProceedsUSD:  4200.00,
+			GainLossUSD:  -300.00,
+			IsLongTerm:   false,
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteForm8949CSV(&buf, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := r.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Header + 2 data rows
+	if len(records) != 3 {
+		t.Fatalf("expected 3 rows (header + 2), got %d", len(records))
+	}
+
+	// Check header
+	if records[0][0] != "Description of Property" {
+		t.Errorf("header col 0: %q", records[0][0])
+	}
+
+	// Check row 1
+	if records[1][0] != "0.50000000 BTC" {
+		t.Errorf("row 1 description: %q", records[1][0])
+	}
+	if records[1][1] != "01/10/2023" {
+		t.Errorf("row 1 acquired: %q", records[1][1])
+	}
+	if records[1][2] != "06/15/2024" {
+		t.Errorf("row 1 sold: %q", records[1][2])
+	}
+	if records[1][3] != "15000.00" {
+		t.Errorf("row 1 proceeds: %q", records[1][3])
+	}
+	if records[1][4] != "10000.00" {
+		t.Errorf("row 1 cost: %q", records[1][4])
+	}
+	if records[1][5] != "5000.00" {
+		t.Errorf("row 1 gain: %q", records[1][5])
+	}
+	if records[1][6] != "Long-term" {
+		t.Errorf("row 1 period: %q", records[1][6])
+	}
+
+	// Check row 2
+	if records[2][5] != "-300.00" {
+		t.Errorf("row 2 loss: %q", records[2][5])
+	}
+	if records[2][6] != "Short-term" {
+		t.Errorf("row 2 period: %q", records[2][6])
+	}
+}
+
+func TestWriteForm8949CSV_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteForm8949CSV(&buf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := csv.NewReader(strings.NewReader(buf.String()))
+	records, _ := r.ReadAll()
+	if len(records) != 1 { // header only
+		t.Errorf("expected 1 row (header only), got %d", len(records))
+	}
+}
+
+func TestEventToForm8949Row(t *testing.T) {
+	e := TaxableEvent{
+		DisposedAt:   time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+		AcquiredAt:   time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
+		AmountSat:    100_000, // 0.001 BTC
+		CostBasisUSD: 30.00,
+		ProceedsUSD:  45.00,
+		GainLossUSD:  15.00,
+		IsLongTerm:   true,
+	}
+
+	row := EventToForm8949Row(e)
+	if row.Description != "0.00100000 BTC" {
+		t.Errorf("description: %q", row.Description)
+	}
+	if row.HoldingPeriod != "Long-term" {
+		t.Errorf("period: %q", row.HoldingPeriod)
+	}
+}

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/satsbook/satsbook/internal/db"
 	"github.com/satsbook/satsbook/internal/exchange"
+	"github.com/satsbook/satsbook/internal/license"
 	"github.com/satsbook/satsbook/internal/lnd"
 	"github.com/satsbook/satsbook/internal/monarch"
 	"github.com/satsbook/satsbook/internal/tax"
@@ -116,6 +117,7 @@ type Handler struct {
 	monarchSyncer    MonarchSyncer
 	monarchTxStore   MonarchTxStore
 	taxStore         TaxStore
+	licenseChecker   *license.DefaultChecker
 	onMonarchChange  func(MonarchSyncer)
 	pendingMonarch   *monarch.PendingClient
 	logger           *log.Logger
@@ -182,6 +184,11 @@ func (h *Handler) SetMonarchSyncer(ms MonarchSyncer) {
 // SetTaxStore sets the tax store for cost basis calculations.
 func (h *Handler) SetTaxStore(ts TaxStore) {
 	h.taxStore = ts
+}
+
+// SetLicenseChecker sets the license checker for runtime activation.
+func (h *Handler) SetLicenseChecker(lc *license.DefaultChecker) {
+	h.licenseChecker = lc
 }
 
 // OnMonarchChange registers a callback invoked when the Monarch syncer changes.
@@ -1089,4 +1096,74 @@ func (h *Handler) HandleTaxSummary(w http.ResponseWriter, r *http.Request) {
 	summary := tax.Summarize(result)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(summary)
+}
+
+// HandleLicenseActivate handles POST /api/settings/license.
+// Accepts a license key, saves it to settings, and verifies it.
+func (h *Handler) HandleLicenseActivate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	key := r.FormValue("license_key")
+	if key == "" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">License key is required.</div>`)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Save to settings DB
+	if h.settingsStore != nil {
+		if err := h.settingsStore.SetSetting(ctx, "license_key", key); err != nil {
+			h.logger.Printf("license: save setting: %v", err)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprint(w, `<div class="alert alert-error">Failed to save license key.</div>`)
+			return
+		}
+	}
+
+	// Verify with license server
+	if h.licenseChecker != nil {
+		if err := h.licenseChecker.SetKeyAndVerify(ctx, key); err != nil {
+			h.logger.Printf("license: verify: %v", err)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprintf(w, `<div class="alert alert-warning">Key saved but verification failed: %s. It will be retried automatically.</div>`, err)
+			return
+		}
+		tier := h.licenseChecker.CurrentTier()
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<div class="alert alert-success">License activated! Tier: <strong>%s</strong>. Refresh the page to see your new features.</div>`, tier)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, `<div class="alert alert-success">License key saved. Restart the app to activate.</div>`)
+}
+
+// HandleLicenseVerify handles POST /api/settings/license/verify.
+// Re-verifies the current license key with the license server.
+func (h *Handler) HandleLicenseVerify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.licenseChecker == nil {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">No license checker configured.</div>`)
+		return
+	}
+
+	if err := h.licenseChecker.Verify(r.Context()); err != nil {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<div class="alert alert-error">Verification failed: %s</div>`, err)
+		return
+	}
+
+	tier := h.licenseChecker.CurrentTier()
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<div class="alert alert-success">License verified. Tier: <strong>%s</strong></div>`, tier)
 }

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -118,6 +119,7 @@ type Handler struct {
 	monarchTxStore   MonarchTxStore
 	taxStore         TaxStore
 	licenseChecker   *license.DefaultChecker
+	checkoutBaseURL  string // e.g. "https://api.satsbook.io"
 	onMonarchChange  func(MonarchSyncer)
 	pendingMonarch   *monarch.PendingClient
 	logger           *log.Logger
@@ -189,6 +191,11 @@ func (h *Handler) SetTaxStore(ts TaxStore) {
 // SetLicenseChecker sets the license checker for runtime activation.
 func (h *Handler) SetLicenseChecker(lc *license.DefaultChecker) {
 	h.licenseChecker = lc
+}
+
+// SetCheckoutBaseURL sets the base URL for the license server (e.g. "https://api.satsbook.io").
+func (h *Handler) SetCheckoutBaseURL(url string) {
+	h.checkoutBaseURL = url
 }
 
 // OnMonarchChange registers a callback invoked when the Monarch syncer changes.
@@ -1166,4 +1173,66 @@ func (h *Handler) HandleLicenseVerify(w http.ResponseWriter, r *http.Request) {
 	tier := h.licenseChecker.CurrentTier()
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<div class="alert alert-success">License verified. Tier: <strong>%s</strong></div>`, tier)
+}
+
+// HandleSubscribe handles GET /api/subscribe?tier=pro|power.
+// It calls the license server's checkout API and redirects to Stripe Checkout.
+func (h *Handler) HandleSubscribe(w http.ResponseWriter, r *http.Request) {
+	tier := r.URL.Query().Get("tier")
+	if tier != "pro" && tier != "power" {
+		http.Error(w, "invalid tier — must be pro or power", http.StatusBadRequest)
+		return
+	}
+
+	if h.checkoutBaseURL == "" {
+		http.Error(w, "subscription not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Build the return URL — after Stripe payment, redirect back to our settings page
+	scheme := "http"
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+		scheme = "https"
+	}
+	returnURL := fmt.Sprintf("%s://%s/settings", scheme, r.Host)
+
+	// Call the license server's checkout endpoint
+	reqBody, _ := json.Marshal(map[string]string{
+		"tier":       tier,
+		"return_url": returnURL,
+	})
+
+	ctx := r.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.checkoutBaseURL+"/v1/checkout", bytes.NewReader(reqBody))
+	if err != nil {
+		h.logger.Printf("subscribe: create request: %v", err)
+		http.Error(w, "failed to create checkout", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.logger.Printf("subscribe: call checkout API: %v", err)
+		http.Error(w, "failed to reach subscription service", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		h.logger.Printf("subscribe: checkout API returned %d", resp.StatusCode)
+		http.Error(w, "subscription service error", http.StatusBadGateway)
+		return
+	}
+
+	var result struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil || result.URL == "" {
+		h.logger.Printf("subscribe: decode response: %v", err)
+		http.Error(w, "invalid response from subscription service", http.StatusBadGateway)
+		return
+	}
+
+	http.Redirect(w, r, result.URL, http.StatusFound)
 }

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/satsbook/satsbook/internal/exchange"
 	"github.com/satsbook/satsbook/internal/lnd"
 	"github.com/satsbook/satsbook/internal/monarch"
+	"github.com/satsbook/satsbook/internal/tax"
 )
 
 // DashboardStore defines the read operations needed by dashboard handlers.
@@ -96,6 +97,12 @@ type MonarchTxStore interface {
 	DistinctTransactionValues(ctx context.Context) (sources []string, txTypes []string, err error)
 }
 
+// TaxStore defines DB operations for tax/cost basis calculations.
+type TaxStore interface {
+	ListBTCLots(ctx context.Context) ([]db.BTCLot, error)
+	ListDisposals(ctx context.Context) ([]db.DisposalRow, error)
+}
+
 // Handler serves dashboard API and HTML endpoints.
 type Handler struct {
 	store            DashboardStore
@@ -108,6 +115,7 @@ type Handler struct {
 	txStore          TransactionStore
 	monarchSyncer    MonarchSyncer
 	monarchTxStore   MonarchTxStore
+	taxStore         TaxStore
 	onMonarchChange  func(MonarchSyncer)
 	pendingMonarch   *monarch.PendingClient
 	logger           *log.Logger
@@ -169,6 +177,11 @@ func (h *Handler) SetMonarchSyncer(ms MonarchSyncer) {
 	if h.onMonarchChange != nil {
 		h.onMonarchChange(ms)
 	}
+}
+
+// SetTaxStore sets the tax store for cost basis calculations.
+func (h *Handler) SetTaxStore(ts TaxStore) {
+	h.taxStore = ts
 }
 
 // OnMonarchChange registers a callback invoked when the Monarch syncer changes.
@@ -914,4 +927,166 @@ func (h *Handler) HandleClearImport(source string) http.HandlerFunc {
 			h.logger.Printf("failed to render clear result: %v", err)
 		}
 	}
+}
+
+// HandleTaxExport generates and downloads a Form 8949 CSV file.
+func (h *Handler) HandleTaxExport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.taxStore == nil {
+		http.Error(w, "tax export not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Load lots from DB.
+	dbLots, err := h.taxStore.ListBTCLots(ctx)
+	if err != nil {
+		h.logger.Printf("tax export: list lots: %v", err)
+		http.Error(w, "failed to load lots", http.StatusInternalServerError)
+		return
+	}
+
+	// Load disposals from DB.
+	dbDisposals, err := h.taxStore.ListDisposals(ctx)
+	if err != nil {
+		h.logger.Printf("tax export: list disposals: %v", err)
+		http.Error(w, "failed to load disposals", http.StatusInternalServerError)
+		return
+	}
+
+	// Convert to tax engine types.
+	lots := make([]tax.Lot, len(dbLots))
+	for i, l := range dbLots {
+		lots[i] = tax.Lot{
+			ID:         l.ID,
+			AcquiredAt: l.AcquiredAt,
+			AmountSat:  l.AmountSat,
+			PriceUSD:   l.PriceUSD,
+			Source:     l.Source,
+			ExternalID: l.ExternalID,
+		}
+	}
+
+	disposals := make([]tax.Disposal, len(dbDisposals))
+	for i, d := range dbDisposals {
+		disposals[i] = tax.Disposal{
+			DisposedAt:  d.DisposedAt,
+			AmountSat:   d.AmountSat,
+			ProceedsUSD: d.ProceedsUSD,
+			TxType:      d.TxType,
+			Source:      d.Source,
+			ExternalID:  d.ExternalID,
+		}
+	}
+
+	// Determine method (default FIFO).
+	method := tax.FIFO
+	if m := r.URL.Query().Get("method"); m == "lifo" {
+		method = tax.LIFO
+	}
+
+	// Run the cost basis engine.
+	result, err := tax.Match(lots, disposals, method)
+	if err != nil {
+		h.logger.Printf("tax export: match: %v", err)
+		http.Error(w, "failed to calculate cost basis", http.StatusInternalServerError)
+		return
+	}
+
+	// Filter by tax year if specified.
+	year := r.URL.Query().Get("year")
+	if year != "" {
+		yearInt, err := strconv.Atoi(year)
+		if err == nil {
+			var filtered []tax.TaxableEvent
+			for _, e := range result.Events {
+				if e.DisposedAt.Year() == yearInt {
+					filtered = append(filtered, e)
+				}
+			}
+			result.Events = filtered
+		}
+	}
+
+	// Return JSON summary or CSV download.
+	format := r.URL.Query().Get("format")
+	if format == "json" {
+		summary := tax.Summarize(result)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"summary":      summary,
+			"events_count": len(result.Events),
+			"method":       string(method),
+		})
+		return
+	}
+
+	// Default: CSV download.
+	filename := "form8949"
+	if year != "" {
+		filename += "_" + year
+	}
+	filename += "_" + string(method) + ".csv"
+
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+	if err := tax.WriteForm8949CSV(w, result.Events); err != nil {
+		h.logger.Printf("tax export: write csv: %v", err)
+	}
+}
+
+// HandleTaxSummary returns a JSON summary of tax calculations.
+func (h *Handler) HandleTaxSummary(w http.ResponseWriter, r *http.Request) {
+	if h.taxStore == nil {
+		http.Error(w, "tax not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+	dbLots, err := h.taxStore.ListBTCLots(ctx)
+	if err != nil {
+		http.Error(w, "failed to load lots", http.StatusInternalServerError)
+		return
+	}
+
+	dbDisposals, err := h.taxStore.ListDisposals(ctx)
+	if err != nil {
+		http.Error(w, "failed to load disposals", http.StatusInternalServerError)
+		return
+	}
+
+	lots := make([]tax.Lot, len(dbLots))
+	for i, l := range dbLots {
+		lots[i] = tax.Lot{
+			ID: l.ID, AcquiredAt: l.AcquiredAt, AmountSat: l.AmountSat,
+			PriceUSD: l.PriceUSD, Source: l.Source, ExternalID: l.ExternalID,
+		}
+	}
+	disposals := make([]tax.Disposal, len(dbDisposals))
+	for i, d := range dbDisposals {
+		disposals[i] = tax.Disposal{
+			DisposedAt: d.DisposedAt, AmountSat: d.AmountSat, ProceedsUSD: d.ProceedsUSD,
+			TxType: d.TxType, Source: d.Source, ExternalID: d.ExternalID,
+		}
+	}
+
+	method := tax.FIFO
+	if m := r.URL.Query().Get("method"); m == "lifo" {
+		method = tax.LIFO
+	}
+
+	result, err := tax.Match(lots, disposals, method)
+	if err != nil {
+		http.Error(w, "failed to calculate", http.StatusInternalServerError)
+		return
+	}
+
+	summary := tax.Summarize(result)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(summary)
 }

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -14,6 +14,7 @@ import (
 	"github.com/satsbook/satsbook/internal/license"
 	"github.com/satsbook/satsbook/internal/lnd"
 	"github.com/satsbook/satsbook/internal/monarch"
+	"github.com/satsbook/satsbook/internal/tax"
 )
 
 // DashboardData holds all data needed to render the dashboard page.
@@ -879,6 +880,137 @@ func (h *Handler) HandlePLPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := h.renderer.Render(w, "pl_layout", data); err != nil {
 		h.logger.Printf("failed to render P&L page: %v", err)
+	}
+}
+
+// TaxPageData holds data for the /tax page.
+type TaxPageData struct {
+	NodeAlias      string
+	NodePubKey     string
+	NodeSynced     bool
+	BlockHeight    uint32
+	LNDVersion     string
+	LastSyncedAt   time.Time
+	BTCPriceUSD    float64
+	PriceFetchedAt time.Time
+	Tier           string
+
+	Method       string
+	SelectedYear int
+	Years        []int
+
+	// Summary fields
+	TotalProceeds     float64
+	TotalCostBasis    float64
+	TotalGainLoss     float64
+	ShortTermGainLoss float64
+	LongTermGainLoss  float64
+	ShortTermCount    int
+	LongTermCount     int
+	TotalDisposals    int
+	UnmatchedSat      int64
+}
+
+// HandleTaxPage serves GET /tax.
+func (h *Handler) HandleTaxPage(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	method := r.URL.Query().Get("method")
+	if method != "lifo" {
+		method = "fifo"
+	}
+
+	yearStr := r.URL.Query().Get("year")
+	selectedYear := 0
+	if yearStr != "" {
+		if y, err := strconv.Atoi(yearStr); err == nil {
+			selectedYear = y
+		}
+	}
+
+	data := TaxPageData{
+		Method:       method,
+		SelectedYear: selectedYear,
+	}
+
+	// Fill node/price info
+	if info := h.getNodeInfo(ctx); info != nil {
+		data.NodeAlias = info.Alias
+		data.NodePubKey = info.PubKey
+		data.NodeSynced = info.Synced
+		data.BlockHeight = info.BlockHeight
+		data.LNDVersion = info.Version
+	}
+	data.LastSyncedAt, _ = h.store.LastSyncedAt(ctx)
+	if price, err := h.price.GetBTCPrice(ctx); err == nil {
+		data.BTCPriceUSD = price
+		data.PriceFetchedAt = h.price.FetchedAt()
+	}
+	data.Tier = string(TierFromContext(ctx))
+
+	// Generate year options
+	now := time.Now()
+	for y := now.Year(); y >= now.Year()-5; y-- {
+		data.Years = append(data.Years, y)
+	}
+
+	// Compute tax summary if taxStore is available
+	if h.taxStore != nil {
+		dbLots, err := h.taxStore.ListBTCLots(ctx)
+		if err == nil {
+			dbDisposals, err := h.taxStore.ListDisposals(ctx)
+			if err == nil {
+				lots := make([]tax.Lot, len(dbLots))
+				for i, l := range dbLots {
+					lots[i] = tax.Lot{
+						ID: l.ID, AcquiredAt: l.AcquiredAt, AmountSat: l.AmountSat,
+						PriceUSD: l.PriceUSD, Source: l.Source, ExternalID: l.ExternalID,
+					}
+				}
+				disposals := make([]tax.Disposal, len(dbDisposals))
+				for i, d := range dbDisposals {
+					disposals[i] = tax.Disposal{
+						DisposedAt: d.DisposedAt, AmountSat: d.AmountSat, ProceedsUSD: d.ProceedsUSD,
+						TxType: d.TxType, Source: d.Source, ExternalID: d.ExternalID,
+					}
+				}
+
+				taxMethod := tax.FIFO
+				if method == "lifo" {
+					taxMethod = tax.LIFO
+				}
+
+				result, err := tax.Match(lots, disposals, taxMethod)
+				if err == nil {
+					// Filter by year if specified
+					if selectedYear > 0 {
+						var filtered []tax.TaxableEvent
+						for _, e := range result.Events {
+							if e.DisposedAt.Year() == selectedYear {
+								filtered = append(filtered, e)
+							}
+						}
+						result.Events = filtered
+					}
+
+					summary := tax.Summarize(result)
+					data.TotalProceeds = summary.TotalProceeds
+					data.TotalCostBasis = summary.TotalCostBasis
+					data.TotalGainLoss = summary.TotalGainLoss
+					data.ShortTermGainLoss = summary.ShortTermGainLoss
+					data.LongTermGainLoss = summary.LongTermGainLoss
+					data.ShortTermCount = summary.ShortTermCount
+					data.LongTermCount = summary.LongTermCount
+					data.TotalDisposals = summary.TotalDisposals
+					data.UnmatchedSat = summary.UnmatchedSat
+				}
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "tax_layout", data); err != nil {
+		h.logger.Printf("failed to render tax page: %v", err)
 	}
 }
 

--- a/internal/web/handler_html.go
+++ b/internal/web/handler_html.go
@@ -1502,11 +1502,15 @@ func parseDateParam(r *http.Request, key string, defaultVal time.Time) (time.Tim
 // SettingsPageData holds data for the settings page.
 type SettingsPageData struct {
 	Tier             string
+	LicenseKey       string // masked
+	CheckoutURL      string // Stripe checkout URL for subscribing
 	MonarchToken     string
 	MonarchConnected bool
 	MonarchUnlocked  bool
 	Message          string
 	Error            string
+	// Auto-activation from Stripe redirect
+	AutoActivateKey  string
 	// Monarch transaction sync
 	MonarchSyncTypes    []string // currently selected tx types
 	MonarchSyncSources  []string // currently selected sources
@@ -1517,11 +1521,31 @@ type SettingsPageData struct {
 
 // HandleSettingsPage serves GET /settings.
 func (h *Handler) HandleSettingsPage(w http.ResponseWriter, r *http.Request) {
-	tier := TierFromContext(r.Context())
+	ctx := r.Context()
+	tier := TierFromContext(ctx)
+
+	// Handle auto-activation from Stripe redirect (?license_key=sk_xxx)
+	autoKey := r.URL.Query().Get("license_key")
+	if autoKey != "" && h.settingsStore != nil && h.licenseChecker != nil {
+		_ = h.settingsStore.SetSetting(ctx, "license_key", autoKey)
+		if err := h.licenseChecker.SetKeyAndVerify(ctx, autoKey); err != nil {
+			h.logger.Printf("auto-activate license: %v", err)
+		} else {
+			tier = h.licenseChecker.CurrentTier()
+		}
+	}
+
 	data := SettingsPageData{
 		Tier:            string(tier),
 		MonarchUnlocked: license.TierAtLeast(tier, license.TierPower),
+		AutoActivateKey: autoKey,
 	}
+
+	// Show masked license key
+	if h.licenseChecker != nil && h.licenseChecker.LicenseKey() != "" {
+		data.LicenseKey = maskToken(h.licenseChecker.LicenseKey())
+	}
+
 	if data.MonarchUnlocked && h.settingsStore != nil {
 		token, _ := h.settingsStore.GetSetting(r.Context(), "monarch_token")
 		if token != "" {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -32,6 +32,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/partials/forwarding", handler.HandleForwardingPartial)
 	mux.HandleFunc("/partials/portfolio-chart", handler.HandlePortfolioChartPartial)
 	mux.HandleFunc("/settings", handler.HandleSettingsPage)
+	mux.HandleFunc("/tax", handler.HandleTaxPage)
 	mux.HandleFunc("/transactions", handler.HandleTransactionsPage)
 
 	// Static assets (embedded)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -53,6 +53,8 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/api/wallets/refresh", handler.HandleRefreshWallet)
 	mux.HandleFunc("/api/wallets/refresh-all", handler.HandleRefreshAll)
 	mux.HandleFunc("/api/portfolio/backfill", handler.HandlePortfolioBackfill)
+	mux.HandleFunc("/api/settings/license", handler.HandleLicenseActivate)
+	mux.HandleFunc("/api/settings/license/verify", handler.HandleLicenseVerify)
 	mux.HandleFunc("/api/transactions/note", handler.HandleTransactionNoteSave)
 	mux.HandleFunc("/api/transactions/note/edit", handler.HandleTransactionNoteEdit)
 	mux.Handle("/api/import/strike/clear", handler.HandleClearImport("strike"))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -55,6 +55,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/api/portfolio/backfill", handler.HandlePortfolioBackfill)
 	mux.HandleFunc("/api/settings/license", handler.HandleLicenseActivate)
 	mux.HandleFunc("/api/settings/license/verify", handler.HandleLicenseVerify)
+	mux.HandleFunc("/api/subscribe", handler.HandleSubscribe)
 	mux.HandleFunc("/api/transactions/note", handler.HandleTransactionNoteSave)
 	mux.HandleFunc("/api/transactions/note/edit", handler.HandleTransactionNoteEdit)
 	mux.Handle("/api/import/strike/clear", handler.HandleClearImport("strike"))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -65,6 +65,9 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/api/monarch/sync", monarchGate(handler.HandleMonarchSync))
 	mux.HandleFunc("/api/monarch/sync-types", monarchGate(handler.HandleMonarchSyncTypes))
 	mux.HandleFunc("/api/monarch/tx-sync", monarchGate(handler.HandleMonarchTxSync))
+	proGate := requireTier(license.TierPro, handler.renderer)
+	mux.HandleFunc("/api/tax/export", proGate(handler.HandleTaxExport))
+	mux.HandleFunc("/api/tax/summary", proGate(handler.HandleTaxSummary))
 
 	return &Server{
 		httpServer: &http.Server{

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -123,6 +123,8 @@ func NewRenderer() *Renderer {
 			"templates/wallets_layout.html",
 			"templates/exchange_detail.html",
 			"templates/wallet_detail.html",
+			"templates/tax_layout.html",
+			"templates/tax.html",
 			"templates/settings_layout.html",
 			"templates/transactions_layout.html",
 			"templates/partials/transaction_note.html",

--- a/internal/web/templates/partials/nav.html
+++ b/internal/web/templates/partials/nav.html
@@ -6,6 +6,7 @@
   <a href="/import" class="nav-link{{if eq . "import"}} nav-active{{end}}">Import</a>
   <a href="/wallets" class="nav-link{{if eq . "wallets"}} nav-active{{end}}">Wallets</a>
   <a href="/pl" class="nav-link{{if eq . "pl"}} nav-active{{end}}">P&amp;L</a>
+  <a href="/tax" class="nav-link{{if eq . "tax"}} nav-active{{end}}">Tax</a>
   <a href="/settings" class="nav-link{{if eq . "settings"}} nav-active{{end}}">Settings</a>
 </nav>
 {{end}}

--- a/internal/web/templates/partials/upgrade_required.html
+++ b/internal/web/templates/partials/upgrade_required.html
@@ -9,9 +9,9 @@
     <p class="upgrade-hint">You are currently on the <strong>Pro</strong> tier. Upgrade to <strong>Power</strong> to unlock this feature.</p>
     {{end}}
     <div style="margin-top: 16px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap;">
-      <a href="https://satsbook.io" target="_blank"
+      <a href="/api/subscribe?tier={{.RequiredTier}}"
          style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
-        Subscribe Now
+        Subscribe to {{if eq .RequiredTier "power"}}Power{{else}}Pro{{end}}
       </a>
       <a href="/settings" style="color: #4fc3f7; font-size: 0.85rem;">
         Already have a key? Go to Settings

--- a/internal/web/templates/partials/upgrade_required.html
+++ b/internal/web/templates/partials/upgrade_required.html
@@ -8,6 +8,14 @@
     {{else if eq .CurrentTier "pro"}}
     <p class="upgrade-hint">You are currently on the <strong>Pro</strong> tier. Upgrade to <strong>Power</strong> to unlock this feature.</p>
     {{end}}
-    <p class="upgrade-cta">Set <code>SATSBOOK_LICENSE_KEY</code> in your Umbrel environment to activate.</p>
+    <div style="margin-top: 16px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap;">
+      <a href="https://satsbook.io" target="_blank"
+         style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
+        Subscribe Now
+      </a>
+      <a href="/settings" style="color: #4fc3f7; font-size: 0.85rem;">
+        Already have a key? Go to Settings
+      </a>
+    </div>
 </div>
 {{end}}

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -54,12 +54,43 @@
       {{end}}
 
       {{if not (tierAtLeast .Tier "pro")}}
-      <div style="margin-bottom: 12px;">
-        <a href="https://satsbook.io" target="_blank"
-           style="display: inline-block; padding: 8px 20px; border-radius: var(--radius, 6px); background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
-          Subscribe to Pro
+      <div style="display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 12px;">
+        <div style="flex: 1; min-width: 220px; border: 1px solid var(--border, #333); border-radius: 8px; padding: 16px;">
+          <h4 style="margin: 0 0 8px; color: var(--text, #e6e6e6);">Pro</h4>
+          <ul style="margin: 0 0 12px; padding-left: 18px; color: #aaa; font-size: 0.8rem; line-height: 1.6;">
+            <li>FIFO / LIFO cost basis engine</li>
+            <li>Form 8949 CSV export</li>
+            <li>Tax summary dashboard</li>
+          </ul>
+          <a href="/api/subscribe?tier=pro"
+             style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
+            Subscribe to Pro
+          </a>
+        </div>
+        <div style="flex: 1; min-width: 220px; border: 1px solid var(--border, #333); border-radius: 8px; padding: 16px;">
+          <h4 style="margin: 0 0 8px; color: var(--text, #e6e6e6);">Power</h4>
+          <ul style="margin: 0 0 12px; padding-left: 18px; color: #aaa; font-size: 0.8rem; line-height: 1.6;">
+            <li>Everything in Pro</li>
+            <li>Monarch Money net worth sync</li>
+            <li>Transaction export to Monarch</li>
+          </ul>
+          <a href="/api/subscribe?tier=power"
+             style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
+            Subscribe to Power
+          </a>
+        </div>
+      </div>
+      {{else if not (tierAtLeast .Tier "power")}}
+      <div style="margin-bottom: 12px; border: 1px solid var(--border, #333); border-radius: 8px; padding: 16px; max-width: 300px;">
+        <h4 style="margin: 0 0 8px; color: var(--text, #e6e6e6);">Upgrade to Power</h4>
+        <ul style="margin: 0 0 12px; padding-left: 18px; color: #aaa; font-size: 0.8rem; line-height: 1.6;">
+          <li>Monarch Money net worth sync</li>
+          <li>Transaction export to Monarch</li>
+        </ul>
+        <a href="/api/subscribe?tier=power"
+           style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
+          Upgrade to Power
         </a>
-        <span style="color: #666; font-size: 0.8rem; margin-left: 8px;">$9/month — tax export, cost basis tracking</span>
       </div>
       {{end}}
 

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -23,6 +23,57 @@
   <main class="container" style="padding: 24px 16px;">
     <h2>Settings</h2>
 
+    <!-- License Section -->
+    <section class="card" style="margin-top: 16px;">
+      <h3>License</h3>
+      <p style="color: #999; font-size: 0.85rem; margin-bottom: 12px;">
+        Unlock Pro and Power features like tax export, Monarch Money sync, and more.
+      </p>
+
+      {{if .AutoActivateKey}}
+      <div class="alert alert-success" style="margin-bottom: 12px;">
+        License activated! Your tier: <strong>{{.Tier}}</strong>
+      </div>
+      {{end}}
+
+      <div style="margin-bottom: 12px;">
+        <span style="font-size: 0.85rem; color: #aaa;">Current Tier:</span>
+        <span class="tier-badge tier-{{.Tier}}">{{.Tier}}</span>
+      </div>
+
+      {{if .LicenseKey}}
+      <div style="margin-bottom: 12px;">
+        <span style="font-size: 0.85rem; color: #aaa;">License Key:</span>
+        <code style="margin-left: 4px;">{{.LicenseKey}}</code>
+      </div>
+      <div style="display: flex; gap: 8px; margin-bottom: 12px;">
+        <button hx-post="/api/settings/license/verify" hx-target="#license-result" class="btn btn-primary" style="font-size: 0.85rem;">
+          Verify License
+        </button>
+      </div>
+      {{end}}
+
+      {{if not (tierAtLeast .Tier "pro")}}
+      <div style="margin-bottom: 12px;">
+        <a href="https://satsbook.io" target="_blank"
+           style="display: inline-block; padding: 8px 20px; border-radius: var(--radius, 6px); background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
+          Subscribe to Pro
+        </a>
+        <span style="color: #666; font-size: 0.8rem; margin-left: 8px;">$9/month — tax export, cost basis tracking</span>
+      </div>
+      {{end}}
+
+      <details style="margin-top: 8px;">
+        <summary style="cursor: pointer; color: #888; font-size: 0.8rem;">Enter license key manually</summary>
+        <form hx-post="/api/settings/license" hx-target="#license-result" style="display: flex; gap: 8px; align-items: flex-end; margin-top: 8px; max-width: 500px;">
+          <input type="text" name="license_key" placeholder="sk_..." style="flex: 1; font-size: 0.85rem;" required>
+          <button type="submit" class="btn btn-primary" style="font-size: 0.85rem;">Activate</button>
+        </form>
+      </details>
+
+      <div id="license-result" style="margin-top: 12px;"></div>
+    </section>
+
     <section class="card" style="margin-top: 16px;">
       <h3>Monarch Money Integration <span class="tier-badge tier-power">power</span></h3>
       <p style="color: #999; font-size: 0.85rem; margin-bottom: 12px;">

--- a/internal/web/templates/tax.html
+++ b/internal/web/templates/tax.html
@@ -1,4 +1,7 @@
 {{define "tax_content"}}
+{{if not (tierAtLeast .Tier "pro")}}
+{{template "upgrade_required" dict "RequiredTier" "pro" "CurrentTier" .Tier}}
+{{else}}
 <!-- Disclaimer -->
 <div style="background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 24px; font-size: 0.85rem; color: var(--text-muted);">
   This report is for informational purposes only and does not constitute tax, legal, or financial advice. Consult a qualified tax professional before filing.
@@ -79,6 +82,7 @@ function formatUSD(n) {
   return neg ? '-' + str : str;
 }
 </script>
+{{end}}
 {{end}}
 
 {{define "tax_summary_cards"}}

--- a/internal/web/templates/tax.html
+++ b/internal/web/templates/tax.html
@@ -1,6 +1,7 @@
 {{define "tax_content"}}
 {{if not (tierAtLeast .Tier "pro")}}
-{{template "upgrade_required" dict "RequiredTier" "pro" "CurrentTier" .Tier}}
+{{$upgrade := dict "RequiredTier" "pro" "CurrentTier" .Tier}}
+{{template "upgrade_required" $upgrade}}
 {{else}}
 <!-- Disclaimer -->
 <div style="background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 24px; font-size: 0.85rem; color: var(--text-muted);">

--- a/internal/web/templates/tax.html
+++ b/internal/web/templates/tax.html
@@ -1,7 +1,42 @@
 {{define "tax_content"}}
 {{if not (tierAtLeast .Tier "pro")}}
-{{$upgrade := dict "RequiredTier" "pro" "CurrentTier" .Tier}}
-{{template "upgrade_required" $upgrade}}
+<div class="upgrade-required">
+    <div class="upgrade-icon">&#x1f512;</div>
+    <h3>Pro Feature</h3>
+    <p>Tax export requires a paid subscription.</p>
+    <p class="upgrade-hint" style="margin-bottom: 16px;">You are currently on the <strong>Free</strong> tier.</p>
+
+    <div style="display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 16px;">
+      <div style="flex: 1; min-width: 220px; border: 1px solid var(--border, #333); border-radius: 8px; padding: 16px;">
+        <h4 style="margin: 0 0 8px; color: var(--text, #e6e6e6);">Pro</h4>
+        <ul style="margin: 0 0 12px; padding-left: 18px; color: #aaa; font-size: 0.8rem; line-height: 1.6;">
+          <li>FIFO / LIFO cost basis engine</li>
+          <li>Form 8949 CSV export</li>
+          <li>Tax summary dashboard</li>
+        </ul>
+        <a href="/api/subscribe?tier=pro"
+           style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
+          Subscribe to Pro
+        </a>
+      </div>
+      <div style="flex: 1; min-width: 220px; border: 1px solid var(--border, #333); border-radius: 8px; padding: 16px;">
+        <h4 style="margin: 0 0 8px; color: var(--text, #e6e6e6);">Power</h4>
+        <ul style="margin: 0 0 12px; padding-left: 18px; color: #aaa; font-size: 0.8rem; line-height: 1.6;">
+          <li>Everything in Pro</li>
+          <li>Monarch Money net worth sync</li>
+          <li>Transaction export to Monarch</li>
+        </ul>
+        <a href="/api/subscribe?tier=power"
+           style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
+          Subscribe to Power
+        </a>
+      </div>
+    </div>
+
+    <a href="/settings" style="color: #4fc3f7; font-size: 0.85rem;">
+      Already have a key? Go to Settings
+    </a>
+</div>
 {{else}}
 <!-- Disclaimer -->
 <div style="background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 24px; font-size: 0.85rem; color: var(--text-muted);">

--- a/internal/web/templates/tax.html
+++ b/internal/web/templates/tax.html
@@ -1,0 +1,113 @@
+{{define "tax_content"}}
+<!-- Disclaimer -->
+<div style="background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 24px; font-size: 0.85rem; color: var(--text-muted);">
+  This report is for informational purposes only and does not constitute tax, legal, or financial advice. Consult a qualified tax professional before filing.
+</div>
+
+<!-- Controls -->
+<div style="display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-bottom: 24px;">
+  <div>
+    <label style="font-size: 0.85rem; color: var(--text-muted); margin-right: 4px;">Method:</label>
+    <select id="tax-method" onchange="updateTaxSummary()" style="padding: 6px 12px; border-radius: var(--radius); background: var(--bg-card); color: var(--text); border: 1px solid var(--border);">
+      <option value="fifo" {{if eq .Method "fifo"}}selected{{end}}>FIFO (First In, First Out)</option>
+      <option value="lifo" {{if eq .Method "lifo"}}selected{{end}}>LIFO (Last In, First Out)</option>
+    </select>
+  </div>
+  <div>
+    <label style="font-size: 0.85rem; color: var(--text-muted); margin-right: 4px;">Tax Year:</label>
+    <select id="tax-year" onchange="updateTaxSummary()" style="padding: 6px 12px; border-radius: var(--radius); background: var(--bg-card); color: var(--text); border: 1px solid var(--border);">
+      <option value="">All Years</option>
+      {{range .Years}}
+      <option value="{{.}}" {{if eq . $.SelectedYear}}selected{{end}}>{{.}}</option>
+      {{end}}
+    </select>
+  </div>
+  <a id="download-btn" href="/api/tax/export?method={{.Method}}{{if .SelectedYear}}&year={{.SelectedYear}}{{end}}"
+     style="padding: 6px 16px; border-radius: var(--radius); background: var(--accent); color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
+    Download CSV
+  </a>
+</div>
+
+<!-- Summary Cards -->
+<div id="tax-summary">
+  {{template "tax_summary_cards" .}}
+</div>
+
+<script>
+function updateTaxSummary() {
+  var method = document.getElementById('tax-method').value;
+  var year = document.getElementById('tax-year').value;
+  var yearParam = year ? '&year=' + year : '';
+
+  // Update download link
+  document.getElementById('download-btn').href = '/api/tax/export?method=' + method + yearParam;
+
+  // Fetch and update summary
+  fetch('/api/tax/export?method=' + method + yearParam + '&format=json')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      var s = data.summary;
+      document.getElementById('total-proceeds').textContent = formatUSD(s.TotalProceeds);
+      document.getElementById('total-cost-basis').textContent = formatUSD(s.TotalCostBasis);
+      document.getElementById('total-gain-loss').textContent = formatUSD(s.TotalGainLoss);
+      document.getElementById('total-gain-loss').className = s.TotalGainLoss >= 0 ? 'card-value gain' : 'card-value loss';
+      document.getElementById('short-term-gain').textContent = formatUSD(s.ShortTermGainLoss);
+      document.getElementById('short-term-gain').className = s.ShortTermGainLoss >= 0 ? 'card-value gain' : 'card-value loss';
+      document.getElementById('long-term-gain').textContent = formatUSD(s.LongTermGainLoss);
+      document.getElementById('long-term-gain').className = s.LongTermGainLoss >= 0 ? 'card-value gain' : 'card-value loss';
+      document.getElementById('total-disposals').textContent = data.events_count;
+      document.getElementById('short-term-count').textContent = s.ShortTermCount;
+      document.getElementById('long-term-count').textContent = s.LongTermCount;
+      document.getElementById('unmatched-sat').textContent = s.UnmatchedSat > 0 ? s.UnmatchedSat.toLocaleString() + ' sats' : 'None';
+    });
+}
+
+function formatUSD(n) {
+  var neg = n < 0;
+  var abs = Math.abs(n);
+  var str = '$' + abs.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return neg ? '-' + str : str;
+}
+</script>
+{{end}}
+
+{{define "tax_summary_cards"}}
+<h2 style="font-size: 1rem; color: var(--text-muted); margin-bottom: 12px;">Summary</h2>
+<div class="cards">
+  <div class="card">
+    <div class="card-label">Total Proceeds</div>
+    <div class="card-value" id="total-proceeds">{{formatUSD .TotalProceeds}}</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Total Cost Basis</div>
+    <div class="card-value" id="total-cost-basis">{{formatUSD .TotalCostBasis}}</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Total Gain / Loss</div>
+    <div class="card-value {{if ge .TotalGainLoss 0.0}}gain{{else}}loss{{end}}" id="total-gain-loss">{{formatUSD .TotalGainLoss}}</div>
+  </div>
+</div>
+
+<h2 style="font-size: 1rem; color: var(--text-muted); margin: 24px 0 12px;">Breakdown</h2>
+<div class="cards">
+  <div class="card">
+    <div class="card-label">Short-Term Gain / Loss</div>
+    <div class="card-value {{if ge .ShortTermGainLoss 0.0}}gain{{else}}loss{{end}}" id="short-term-gain">{{formatUSD .ShortTermGainLoss}}</div>
+    <div class="card-sub" id="short-term-count">{{.ShortTermCount}} disposals</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Long-Term Gain / Loss</div>
+    <div class="card-value {{if ge .LongTermGainLoss 0.0}}gain{{else}}loss{{end}}" id="long-term-gain">{{formatUSD .LongTermGainLoss}}</div>
+    <div class="card-sub" id="long-term-count">{{.LongTermCount}} disposals</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Total Disposals</div>
+    <div class="card-value" id="total-disposals">{{.TotalDisposals}}</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Unmatched Sats</div>
+    <div class="card-value" id="unmatched-sat">{{if .UnmatchedSat}}{{formatSats .UnmatchedSat}} sats{{else}}None{{end}}</div>
+    <div class="card-sub" style="font-size: 0.75rem;">Sats sold without matching acquisition lot</div>
+  </div>
+</div>
+{{end}}

--- a/internal/web/templates/tax.html
+++ b/internal/web/templates/tax.html
@@ -4,6 +4,16 @@
   This report is for informational purposes only and does not constitute tax, legal, or financial advice. Consult a qualified tax professional before filing.
 </div>
 
+<!-- Method Explainer -->
+<div style="background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 24px; font-size: 0.85rem; line-height: 1.5;">
+  <strong style="color: var(--text);">FIFO vs LIFO</strong>
+  <p style="color: var(--text-muted); margin: 6px 0 0;">
+    <strong>FIFO</strong> (First In, First Out) sells your oldest Bitcoin first. If BTC has gone up over time, FIFO typically results in <em>higher gains</em> because your earliest, cheapest lots are matched first.
+    <strong>LIFO</strong> (Last In, First Out) sells your newest Bitcoin first. This often results in <em>lower gains</em> (or losses) because recent lots were likely purchased at higher prices.
+    Most tax software and CPAs default to FIFO. Once you choose a method for a tax year, the IRS expects you to use it consistently. When in doubt, ask your tax advisor.
+  </p>
+</div>
+
 <!-- Controls -->
 <div style="display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-bottom: 24px;">
   <div>

--- a/internal/web/templates/tax_layout.html
+++ b/internal/web/templates/tax_layout.html
@@ -1,0 +1,46 @@
+{{define "tax_layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Satsbook — Tax Export</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="/static/htmx.min.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <div class="header-top">
+        <a class="logo" href="/">Satsbook</a>
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
+      {{template "nav" "tax"}}
+      <div class="node-info-bar">
+        {{if .NodeAlias}}
+          <strong>{{.NodeAlias}}</strong> &middot;
+          <span class="truncate" title="{{.NodePubKey}}">{{.NodePubKey}}</span> &middot;
+          {{if .NodeSynced}}<span class="synced">synced</span>{{else}}<span class="not-synced">not synced</span>{{end}}
+          &middot; block {{.BlockHeight}} &middot; LND {{.LNDVersion}}
+        {{else}}
+          <span class="not-synced">node unreachable</span>
+        {{end}}
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    {{template "tax_content" .}}
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Last synced: {{timeAgo .LastSyncedAt}}</span>
+      <span>
+        {{if .BTCPriceUSD}}BTC {{formatUSD .BTCPriceUSD}} (mempool.space, {{timeAgo .PriceFetchedAt}}){{else}}BTC price unavailable{{end}}
+      </span>
+    </div>
+  </footer>
+</body>
+</html>{{end}}


### PR DESCRIPTION
## Summary

- **FIFO/LIFO cost basis matching engine** (`internal/tax/costbasis.go`) — pairs BTC acquisition lots with disposals, handles partial lot consumption, long-term/short-term classification (>365 days), and future-lot filtering
- **Form 8949 CSV export** (`internal/tax/form8949.go`) — TurboTax-compatible CSV writer with `TaxSummary` aggregation (proceeds, cost basis, gain/loss by holding period)
- **DB queries** — `ListBTCLots`, `ListDisposals`, `SaveDisposals` in `internal/db/queries.go`
- **HTTP endpoints** — `GET /api/tax/export?method=fifo|lifo&year=YYYY&format=csv|json` and `GET /api/tax/summary`, both Pro-tier gated
- **Tax UI** — `/tax` page with FIFO/LIFO selector, year filter, summary cards, CSV download, FIFO vs LIFO explainer
- **Tier gating** — Tax page locked behind Pro tier with upgrade prompt showing Pro and Power options
- **License activation** — Self-service subscribe flow via Stripe, auto-activation from Settings, runtime key changes without restart
- **Settings UI** — License section with tier badge, subscription cards, manual key input, verify button
- **DB test coverage** — 18 new tests covering settings, monarch sync, distinct values, BTCLots, disposals (76.5% → 83.4%)
- **15 tests, 94.8% coverage** on `internal/tax/`

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `go test ./internal/tax/ -cover` — 94.8%
- [x] `go test ./internal/db/ -cover` — 83.4%
- [x] Manual test: import exchange CSV, hit `/api/tax/export?method=fifo&format=csv` with Pro license
- [x] Manual test: verify `/api/tax/summary` JSON output matches CSV totals
- [x] Verify 402 response without Pro tier
- [x] Manual test: FIFO vs LIFO results differ as expected (FIFO higher gains, LIFO lower/negative)
- [x] Manual test: year filter returns correct subset of disposals
- [x] Manual test: CSV download from UI works with correct headers and data
- [x] Manual test: tax page shows upgrade prompt on free tier with Pro and Power options

Closes #17, Closes #18, Closes #19