### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,14 @@ test:
 	go test -v ./...
 
 # Build Docker image (local platform)
+VERSION ?= 2.0.0
 docker:
-	docker build -t satsbook:latest .
+	docker build --build-arg VERSION=$(VERSION) -t satsbook:$(VERSION) -t satsbook:latest .
 
 # Build multi-arch Docker image (amd64 + arm64 for Umbrel/Raspberry Pi)
 docker-multiarch:
-	docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/satsbook/satsbook:latest .
+	docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=$(VERSION) \
+		-t ghcr.io/satsbook/satsbook:$(VERSION) -t ghcr.io/satsbook/satsbook:latest --push .
 
 # Clean build artifacts
 clean:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 3000
 
   server:
-    image: ghcr.io/satsbook/satsbook:1.1.0
+    image: ghcr.io/satsbook/satsbook:2.0.0
     container_name: satsbook-satsbook_server_1
     restart: on-failure
     stop_grace_period: 1m

--- a/umbrel-app.yml
+++ b/umbrel-app.yml
@@ -2,13 +2,15 @@ manifestVersion: 1
 id: satsbook
 category: bitcoin
 name: Satsbook
-version: "1.0.0"
-tagline: Bitcoin node analytics and accounting for Lightning operators
+version: "2.0.0"
+tagline: Bitcoin accounting and tax export for Lightning node operators
 description: >-
-  Track routing fees, manage cost basis from exchange imports, and view
-  profit & loss — all on your own hardware. Satsbook connects to your
-  LND node and provides a privacy-first dashboard with fee analytics,
-  Strike CSV import, and a basic P&L view. No cloud services required.
+  Track routing fees, import exchange transactions (Strike, River, Coinbase, Swan),
+  and view your full Bitcoin portfolio — all on your own hardware. Satsbook connects
+  to your LND node and provides a privacy-first dashboard with fee analytics,
+  interactive portfolio breakdown, unified transaction ledger, and transfer tagging.
+  Upgrade to Pro ($9/mo) for FIFO/LIFO tax export (Form 8949), or Power ($19/mo)
+  to sync your BTC holdings to Monarch Money. No cloud required.
 developer: brewgator
 website: https://github.com/satsbook/satsbook
 repo: https://github.com/satsbook/satsbook
@@ -20,6 +22,12 @@ gallery: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""
-releaseNotes: ""
+releaseNotes: >-
+  v2.0.0 — Major release with paid tiers and full accounting.
+  Free: interactive portfolio donut chart, unified transaction ledger,
+  transfer tagging (auto-detects channel opens/closes), 4 exchange
+  CSV imports (Strike, River, Coinbase, Swan), watched wallet tracking.
+  Pro ($9/mo): FIFO/LIFO cost basis engine, Form 8949 tax export.
+  Power ($19/mo): Monarch Money BTC holdings and transaction sync.
 submitter: brewgator
 submission: https://github.com/getumbrel/umbrel-apps/pull/5451


### PR DESCRIPTION
## Summary
Version bump to 2.0.0 for Umbrel release.

### What's new since v1.1.3

**Free tier (complete):**
- Interactive portfolio donut chart with hover tooltips and click-to-drill source flows
- Unified transaction ledger across LND + all exchange imports
- Transfer tagging — auto-detects channel opens/closes, manual toggle, find-match suggestions
- Coinbase and Swan CSV import (added to existing Strike and River)
- Watched wallet tracking (xpub/address via Electrum)
- Transaction notes (inline edit)
- Portfolio net flows with period filtering and USD values

**Pro tier ($9/mo):**
- FIFO/LIFO cost basis engine (95% test coverage)
- Form 8949 CSV export (TurboTax-compatible)
- Tax summary dashboard with per-year breakdown

**Power tier ($19/mo):**
- Monarch Money BTC holdings sync (investment account)
- Transaction export to Monarch (checking account with dedup)

**Infrastructure:**
- Ed25519 license validation with 7-day grace period and offline cache
- Stripe Checkout + webhook integration for subscriptions
- License validation server and customer database
- Tier middleware gating (Pro/Power endpoints return 402 or upgrade prompt)

### Files changed
- `umbrel-app.yml` — version 2.0.0, updated description and release notes
- `docker-compose.yml` — image tag 2.0.0
- `Makefile` — VERSION build-arg for docker targets

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `go build ./...` — clean build
- [ ] `make docker` — builds image tagged 2.0.0
- [ ] `make docker-multiarch` — builds amd64 + arm64, pushes to ghcr.io
- [ ] Install on Umbrel — app loads, dashboard renders
- [ ] Activate Pro key — tax export works
- [ ] Activate Power key — Monarch sync works