### PR TITLE
fix(monarch): prevent duplicate account creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display
 
+replace github.com/eshaffer321/monarchmoney-go => github.com/brewgator/monarchmoney-go v0.0.0-20260701172826-8355789eb4f6
+
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/brewgator/monarchmoney-go v0.0.0-20260701172826-8355789eb4f6 h1:BynJLIcS3PEU6dNfMLf6uxWSxXsPYLKZVhjrbehHICE=
+github.com/brewgator/monarchmoney-go v0.0.0-20260701172826-8355789eb4f6/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=
@@ -187,8 +189,6 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
-github.com/eshaffer321/monarchmoney-go v1.1.0 h1:tB7O6EuvUyoNTRfpnkf0thGrz6chkKKEW4sJ1NZo5A4=
-github.com/eshaffer321/monarchmoney-go v1.1.0/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fergusstrange/embedded-postgres v1.25.0 h1:sa+k2Ycrtz40eCRPOzI7Ry7TtkWXXJ+YRsxpKMDhxK0=

--- a/internal/monarch/sync.go
+++ b/internal/monarch/sync.go
@@ -145,17 +145,29 @@ func NewSyncerWithClients(accounts AccountClient, transactions TransactionClient
 }
 
 // findAccount looks for an existing satsbook account by name.
+// If duplicates exist, it keeps the first and deletes the rest.
 func (s *Syncer) findAccount(ctx context.Context) (string, error) {
 	accounts, err := s.accounts.List(ctx)
 	if err != nil {
 		return "", fmt.Errorf("list accounts: %w", err)
 	}
+	var found []string
 	for _, a := range accounts {
 		if a.DisplayName == accountName {
-			return a.ID, nil
+			found = append(found, a.ID)
 		}
 	}
-	return "", nil
+	if len(found) == 0 {
+		return "", nil
+	}
+	// Clean up duplicates — keep the first, delete the rest
+	for _, dup := range found[1:] {
+		log.Printf("monarch: deleting duplicate account %s (%s)", accountName, dup)
+		if err := s.accounts.Delete(ctx, dup); err != nil {
+			log.Printf("monarch: warning: failed to delete duplicate %s: %v", dup, err)
+		}
+	}
+	return found[0], nil
 }
 
 // ensureAccount finds or creates the satsbook investment account.
@@ -246,17 +258,28 @@ func (s *Syncer) ensureTxAccount(ctx context.Context) (string, error) {
 		return s.txAccountID, nil
 	}
 
-	// Look for existing tx account
+	// Look for existing tx account, cleaning up duplicates
 	accounts, err := s.accounts.List(ctx)
 	if err != nil {
 		return "", fmt.Errorf("list accounts: %w", err)
 	}
+	var found []string
 	for _, a := range accounts {
 		if a.DisplayName == txAccountName {
-			s.txAccountID = a.ID
-			log.Printf("monarch: found existing tx account %s (%s)", txAccountName, a.ID)
-			return a.ID, nil
+			found = append(found, a.ID)
 		}
+	}
+	if len(found) > 0 {
+		// Clean up duplicates
+		for _, dup := range found[1:] {
+			log.Printf("monarch: deleting duplicate tx account %s (%s)", txAccountName, dup)
+			if err := s.accounts.Delete(ctx, dup); err != nil {
+				log.Printf("monarch: warning: failed to delete duplicate tx account %s: %v", dup, err)
+			}
+		}
+		s.txAccountID = found[0]
+		log.Printf("monarch: found existing tx account %s (%s)", txAccountName, found[0])
+		return found[0], nil
 	}
 
 	// Create a manual checking account for transactions
@@ -471,10 +494,11 @@ func notesForTx(tx TxToSync) string {
 }
 
 // recreateAccount deletes the existing account and creates a fresh one.
+// Returns an error if the old account cannot be deleted to prevent duplicates.
 func (s *Syncer) recreateAccount(ctx context.Context, btcQuantity float64) error {
 	if s.accountID != "" {
 		if err := s.accounts.Delete(ctx, s.accountID); err != nil {
-			log.Printf("monarch: warning: failed to delete account %s: %v", s.accountID, err)
+			return fmt.Errorf("delete old account %s before recreate: %w", s.accountID, err)
 		}
 		s.accountID = ""
 	}

--- a/internal/monarch/sync_test.go
+++ b/internal/monarch/sync_test.go
@@ -20,7 +20,7 @@ type mockAccountClient struct {
 	createHoldErr error
 
 	createdInvAccount *mm.CreateInvestmentsAccountParams
-	deletedAccountID  string
+	deletedAccountIDs []string
 	deletedHoldingID  string
 	createdHolding    *mm.CreateHoldingParams
 	createInvCount    int
@@ -35,7 +35,7 @@ func (m *mockAccountClient) Create(ctx context.Context, params *mm.CreateAccount
 }
 
 func (m *mockAccountClient) Delete(ctx context.Context, accountID string) error {
-	m.deletedAccountID = accountID
+	m.deletedAccountIDs = append(m.deletedAccountIDs, accountID)
 	return m.deleteErr
 }
 
@@ -144,7 +144,7 @@ func TestSyncHolding(t *testing.T) {
 			},
 			btcQty: 2.0,
 			check: func(t *testing.T, m *mockAccountClient) {
-				if m.deletedAccountID != "existing-id" {
+				if len(m.deletedAccountIDs) == 0 || m.deletedAccountIDs[len(m.deletedAccountIDs)-1] != "existing-id" {
 					t.Error("expected account deletion on fallback")
 				}
 				if m.createInvCount != 1 {
@@ -161,11 +161,27 @@ func TestSyncHolding(t *testing.T) {
 			},
 			btcQty: 2.0,
 			check: func(t *testing.T, m *mockAccountClient) {
-				if m.deletedAccountID != "existing-id" {
+				if len(m.deletedAccountIDs) == 0 || m.deletedAccountIDs[len(m.deletedAccountIDs)-1] != "existing-id" {
 					t.Error("expected account deletion on fallback")
 				}
 				if m.createInvCount != 1 {
 					t.Errorf("expected 1 account recreation, got %d", m.createInvCount)
+				}
+			},
+		},
+		{
+			name:   "recreate fails when account delete fails",
+			initID: "existing-id",
+			mock: &mockAccountClient{
+				holdings:   []*mm.Holding{{ID: "h1", Symbol: "BTC", Quantity: 1.0}},
+				delHoldErr: errors.New("hold delete failed"),
+				deleteErr:  errors.New("account delete failed"),
+			},
+			btcQty:  2.0,
+			wantErr: true,
+			check: func(t *testing.T, m *mockAccountClient) {
+				if m.createInvCount != 0 {
+					t.Error("should not create new account when delete fails")
 				}
 			},
 		},
@@ -195,6 +211,9 @@ func TestSyncHolding(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+				}
+				if tt.check != nil {
+					tt.check(t, tt.mock)
 				}
 				return
 			}
@@ -623,4 +642,35 @@ func TestEnsureDefaultCategory(t *testing.T) {
 			t.Fatal("expected error for nil category lister")
 		}
 	})
+}
+
+func TestFindAccount_CleansDuplicates(t *testing.T) {
+	mock := &mockAccountClient{
+		accounts: []*mm.Account{
+			{ID: "acct-1", DisplayName: "Bitcoin (Satsbook)"},
+			{ID: "acct-2", DisplayName: "Bitcoin (Satsbook)"},
+			{ID: "acct-3", DisplayName: "Bitcoin (Satsbook)"},
+			{ID: "other", DisplayName: "Other Account"},
+		},
+		holdings: []*mm.Holding{{ID: "h1", Symbol: "BTC", Quantity: 1.0}},
+	}
+
+	s := NewSyncerWithClient(mock, "")
+	err := s.SyncHolding(context.Background(), 1.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have kept acct-1 and deleted acct-2 and acct-3
+	if len(mock.deletedAccountIDs) != 2 {
+		t.Fatalf("expected 2 deletions, got %d: %v", len(mock.deletedAccountIDs), mock.deletedAccountIDs)
+	}
+	if mock.deletedAccountIDs[0] != "acct-2" || mock.deletedAccountIDs[1] != "acct-3" {
+		t.Errorf("expected deletions of acct-2 and acct-3, got %v", mock.deletedAccountIDs)
+	}
+
+	// Should have used the first account
+	if s.accountID != "acct-1" {
+		t.Errorf("expected accountID acct-1, got %s", s.accountID)
+	}
 }


### PR DESCRIPTION
## Summary
- `findAccount` now detects all accounts named "Bitcoin (Satsbook)", keeps the first, and deletes duplicates
- `recreateAccount` returns an error if the old account can't be deleted, preventing silent duplicate creation
- Same dedup logic applied to `ensureTxAccount` for the transactions account
- Added tests for duplicate cleanup and recreate-on-delete-failure scenarios

## Context
Multiple "Bitcoin (Satsbook)" accounts were being created in Monarch when holding updates failed and fell back to `recreateAccount`, which only logged a warning on delete failure and created a new account anyway. This also caused stale balances since the syncer might find and update a different account than the one visible in the UI.

## Test plan
- [x] `TestFindAccount_CleansDuplicates` — verifies duplicates are deleted, first account kept
- [x] `TestSyncHolding/recreate_fails_when_account_delete_fails` — verifies no new account created on delete failure
- [x] All existing monarch sync tests pass