### PR TITLE
feat: CSV transaction export and onboarding empty states

### DIFF
--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -1285,3 +1285,97 @@ func TestHandleHealth_LNDConfigured(t *testing.T) {
 		t.Errorf("expected lnd_configured true, got %s", w.Body.String())
 	}
 }
+
+// --- mockTransactionStore for export tests ---
+
+type mockTransactionStore struct {
+	result *db.UnifiedTransactionPage
+	err    error
+}
+
+func (m *mockTransactionStore) ListUnifiedTransactions(_ context.Context, _ db.TransactionFilter) (*db.UnifiedTransactionPage, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.result != nil {
+		return m.result, nil
+	}
+	return &db.UnifiedTransactionPage{}, nil
+}
+
+func (m *mockTransactionStore) SetTransactionNote(_ context.Context, _, _ string) error { return nil }
+func (m *mockTransactionStore) DistinctTransactionValues(_ context.Context) ([]string, []string, error) {
+	return nil, nil, nil
+}
+
+func TestHandleExportTransactions_CSV(t *testing.T) {
+	ts := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	store := &mockTransactionStore{
+		result: &db.UnifiedTransactionPage{
+			Transactions: []db.UnifiedTransaction{
+				{Source: "strike", SourceID: "tx-1", Time: ts, TxType: "buy", AmountSat: 500000, AmountUSD: 300.00, FeeSat: 100, FeeUSD: 0.06, Memo: "DCA purchase"},
+				{Source: "lnd_forward", SourceID: "fwd-1", Time: ts, TxType: "fee_income", AmountSat: 250, Memo: ""},
+			},
+			Total: 2,
+		},
+	}
+
+	h := newTestHandler(&mockStore{}, nil, &mockPrice{})
+	h.SetTransactionStore(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/export/transactions", nil)
+	w := httptest.NewRecorder()
+	h.HandleExportTransactions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/csv" {
+		t.Errorf("expected text/csv, got %s", ct)
+	}
+	if !strings.Contains(w.Header().Get("Content-Disposition"), "attachment") {
+		t.Error("expected attachment content-disposition")
+	}
+
+	body := w.Body.String()
+	if !strings.HasPrefix(body, "date,type,source,amount_sats,amount_usd,fee_sats,fee_usd,txid,memo") {
+		t.Errorf("unexpected CSV header: %q", strings.SplitN(body, "\n", 2)[0])
+	}
+	if !strings.Contains(body, "strike") {
+		t.Error("expected strike row in CSV")
+	}
+	if !strings.Contains(body, "DCA purchase") {
+		t.Error("expected memo in CSV")
+	}
+	if !strings.Contains(body, "500000") {
+		t.Error("expected amount_sats in CSV")
+	}
+}
+
+func TestHandleExportTransactions_NoStore(t *testing.T) {
+	h := newTestHandler(&mockStore{}, nil, &mockPrice{})
+	// txStore intentionally not set
+
+	req := httptest.NewRequest(http.MethodGet, "/api/export/transactions", nil)
+	w := httptest.NewRecorder()
+	h.HandleExportTransactions(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandleExportTransactions_StoreError(t *testing.T) {
+	store := &mockTransactionStore{err: errors.New("db error")}
+
+	h := newTestHandler(&mockStore{}, nil, &mockPrice{})
+	h.SetTransactionStore(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/export/transactions", nil)
+	w := httptest.NewRecorder()
+	h.HandleExportTransactions(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}

--- a/internal/web/handler_transactions.go
+++ b/internal/web/handler_transactions.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"encoding/csv"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -265,4 +267,56 @@ type transferBadgeData struct {
 type transferCandidatesData struct {
 	SourceID   string
 	Candidates []db.TransferCandidate
+}
+
+// HandleExportTransactions serves GET /api/export/transactions — downloads all transactions as CSV.
+func (h *Handler) HandleExportTransactions(w http.ResponseWriter, r *http.Request) {
+	if h.txStore == nil {
+		http.Error(w, "transaction store not available", http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+	result, err := h.txStore.ListUnifiedTransactions(ctx, db.TransactionFilter{
+		SortCol: "ts",
+		SortDir: "desc",
+		Limit:   1_000_000,
+	})
+	if err != nil {
+		h.logger.Printf("export transactions: %v", err)
+		http.Error(w, "failed to load transactions", http.StatusInternalServerError)
+		return
+	}
+
+	filename := fmt.Sprintf("satsbook-transactions-%s.csv", time.Now().Format("2006-01-02"))
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+
+	cw := csv.NewWriter(w)
+	_ = cw.Write([]string{"date", "type", "source", "amount_sats", "amount_usd", "fee_sats", "fee_usd", "txid", "memo"})
+	for _, tx := range result.Transactions {
+		amountUSD := ""
+		if tx.AmountUSD != 0 {
+			amountUSD = strconv.FormatFloat(tx.AmountUSD, 'f', 2, 64)
+		}
+		feeUSD := ""
+		if tx.FeeUSD != 0 {
+			feeUSD = strconv.FormatFloat(tx.FeeUSD, 'f', 2, 64)
+		}
+		_ = cw.Write([]string{
+			tx.Time.Format(time.RFC3339),
+			tx.TxType,
+			tx.Source,
+			strconv.FormatInt(tx.AmountSat, 10),
+			amountUSD,
+			strconv.FormatInt(tx.FeeSat, 10),
+			feeUSD,
+			tx.SourceID,
+			tx.Memo,
+		})
+	}
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		h.logger.Printf("export transactions: csv flush: %v", err)
+	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -66,6 +66,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/api/transactions/transfer", handler.HandleTransferToggle)
 	mux.HandleFunc("/api/transactions/transfer/bulk", handler.HandleTransferBulk)
 	mux.HandleFunc("/api/transactions/transfer/candidates", handler.HandleTransferCandidates)
+	mux.HandleFunc("/api/export/transactions", handler.HandleExportTransactions)
 	mux.Handle("/api/import/strike/clear", handler.HandleClearImport("strike"))
 	mux.Handle("/api/import/river/clear", handler.HandleClearImport("river"))
 	mux.Handle("/api/import/coinbase/clear", handler.HandleClearImport("coinbase"))

--- a/internal/web/templates/portfolio.html
+++ b/internal/web/templates/portfolio.html
@@ -44,7 +44,19 @@
   <div id="source-flows-detail" style="flex: 1; min-width: 280px; display: none;"></div>
 </div>
 {{else}}
-<div class="chart-empty" style="margin: 24px 0;">No portfolio data yet. Import exchange data or connect your LND node to see your allocation breakdown.</div>
+<div style="display: flex; flex-wrap: wrap; gap: 24px; align-items: center; justify-content: center; margin: 24px 0;">
+  <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" style="width:200px;height:200px;flex-shrink:0;opacity:0.25;">
+    <circle cx="100" cy="100" r="70" fill="none" stroke="var(--border,#333)" stroke-width="30"/>
+    <text x="100" y="107" text-anchor="middle" font-size="13" fill="var(--text-muted,#888)">No data</text>
+  </svg>
+  <div style="font-size:0.9rem; color:var(--text-muted);">
+    <p style="margin:0 0 12px;">Your portfolio breakdown will appear here once you have data.</p>
+    <ul style="list-style:none;padding:0;margin:0;line-height:2;">
+      <li><a href="/import" style="color:var(--accent,#f7931a);">Import exchange CSVs →</a> <span style="font-size:0.8em;">(Strike, River, Coinbase, Swan)</span></li>
+      <li><a href="/" style="color:var(--text-muted);">Return to dashboard</a></li>
+    </ul>
+  </div>
+</div>
 {{end}}
 
 <!-- Net Flows -->

--- a/internal/web/templates/transactions_layout.html
+++ b/internal/web/templates/transactions_layout.html
@@ -35,7 +35,10 @@
   </header>
 
   <main class="container" style="padding: 24px 16px;">
-    <h1 style="margin: 0 0 16px; font-size: 1.25rem;">All Transactions</h1>
+    <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px; margin-bottom: 16px;">
+      <h1 style="margin: 0; font-size: 1.25rem;">All Transactions</h1>
+      <a href="/api/export/transactions" style="font-size: 0.8rem; padding: 6px 14px; background: var(--bg-card); color: var(--text-muted); border: 1px solid var(--border); border-radius: 4px; text-decoration: none;">↓ Export CSV</a>
+    </div>
 
     <!-- Filters -->
     <form method="GET" action="/transactions" class="tx-filters">


### PR DESCRIPTION
## Summary
- Adds `GET /api/export/transactions` — downloads all transactions as a dated CSV file (free tier)
- Adds an "Export CSV" button to the Transactions page header
- Improves portfolio empty state with a visual placeholder donut and action links to /import
- Dashboard and Transactions empty states were already present from prior work

Closes #103, Closes #104

## Test plan
- [x] `TestHandleExportTransactions_CSV` — verifies CSV headers, row content, Content-Disposition
- [x] `TestHandleExportTransactions_NoStore` — 500 when txStore not configured
- [x] `TestHandleExportTransactions_StoreError` — 500 on DB error
- [x] Full test suite passes
- [x] Manual: visit /transactions, click "Export CSV", verify file downloads
- [x] Manual: fresh install (no data) — verify portfolio shows placeholder SVG with /import link