### PR TITLE
feat: tier comparison page and contextual upgrade CTAs

### DIFF
--- a/internal/web/handler_html_test.go
+++ b/internal/web/handler_html_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/satsbook/satsbook/internal/db"
 	"github.com/satsbook/satsbook/internal/exchange"
+	"github.com/satsbook/satsbook/internal/license"
 	"github.com/satsbook/satsbook/internal/lnd"
 )
 
@@ -1054,5 +1055,76 @@ func TestHandleRemoveWallet_InvalidID(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- Plans page tests ---
+
+func TestHandlePlansPage_Free(t *testing.T) {
+	h := newTestHandler(&mockStore{}, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/plans", nil)
+	// No tier in context → defaults to free
+	w := httptest.NewRecorder()
+	h.HandlePlansPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Upgrade to Pro") {
+		t.Error("expected Pro upgrade CTA for free tier")
+	}
+	if !strings.Contains(body, "Upgrade to Power") {
+		t.Error("expected Power upgrade CTA for free tier")
+	}
+	if !strings.Contains(body, "Current") {
+		t.Error("expected Current badge on free plan")
+	}
+	if !strings.Contains(body, "Free forever") {
+		t.Error("expected 'Free forever' label on free plan card")
+	}
+}
+
+func TestHandlePlansPage_Pro(t *testing.T) {
+	h := newTestHandler(&mockStore{}, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/plans", nil)
+	ctx := context.WithValue(req.Context(), tierContextKey, license.TierPro)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	h.HandlePlansPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Current plan") {
+		t.Error("expected 'Current plan' on Pro card")
+	}
+	if !strings.Contains(body, "Upgrade to Power") {
+		t.Error("expected Power upgrade CTA for pro tier")
+	}
+}
+
+func TestHandlePlansPage_Power(t *testing.T) {
+	h := newTestHandler(&mockStore{}, nil, &mockPrice{})
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/plans", nil)
+	ctx := context.WithValue(req.Context(), tierContextKey, license.TierPower)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	h.HandlePlansPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Count(body, "Current plan") < 1 {
+		t.Error("expected 'Current plan' badge for power tier")
+	}
+	// No upgrade CTAs should be active
+	if strings.Contains(body, `href="/api/subscribe`) {
+		t.Error("should not show subscribe links when already on Power")
 	}
 }

--- a/internal/web/handler_settings.go
+++ b/internal/web/handler_settings.go
@@ -90,6 +90,23 @@ func (h *Handler) HandleSettingsPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// PlansPageData holds data for the /settings/plans page.
+type PlansPageData struct {
+	Tier string
+}
+
+// HandlePlansPage serves GET /settings/plans.
+func (h *Handler) HandlePlansPage(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	data := PlansPageData{
+		Tier: string(TierFromContext(ctx)),
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.renderer.Render(w, "plans_layout", data); err != nil {
+		h.logger.Printf("failed to render plans page: %v", err)
+	}
+}
+
 // HandleMonarchSave handles POST /api/monarch/save — logs into Monarch and stores the auth token.
 // Supports two-step flow: if OTP is required, returns an OTP input form.
 func (h *Handler) HandleMonarchSave(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -59,6 +59,7 @@ func requireTier(minTier license.Tier, renderer *Renderer) func(http.HandlerFunc
 }
 
 type upgradeData struct {
-	RequiredTier string
-	CurrentTier  string
+	RequiredTier   string
+	CurrentTier    string
+	FeatureMessage string
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -34,6 +34,7 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/portfolio", handler.HandlePortfolioPage)
 	mux.HandleFunc("/portfolio/source-flows", handler.HandlePortfolioSourceFlows)
 	mux.HandleFunc("/settings", handler.HandleSettingsPage)
+	mux.HandleFunc("/settings/plans", handler.HandlePlansPage)
 	mux.HandleFunc("/tax", handler.HandleTaxPage)
 	mux.HandleFunc("/transactions", handler.HandleTransactionsPage)
 

--- a/internal/web/template.go
+++ b/internal/web/template.go
@@ -138,6 +138,7 @@ func NewRenderer() *Renderer {
 			"templates/portfolio_layout.html",
 			"templates/portfolio.html",
 			"templates/settings_layout.html",
+			"templates/plans_layout.html",
 			"templates/transactions_layout.html",
 			"templates/partials/transaction_note.html",
 			"templates/partials/upgrade_required.html",

--- a/internal/web/templates/partials/upgrade_required.html
+++ b/internal/web/templates/partials/upgrade_required.html
@@ -2,7 +2,11 @@
 <div class="upgrade-required">
     <div class="upgrade-icon">&#x1f512;</div>
     <h3>{{if eq .RequiredTier "power"}}Power{{else}}Pro{{end}} Feature</h3>
+    {{if .FeatureMessage}}
+    <p>{{.FeatureMessage}}</p>
+    {{else}}
     <p>This feature requires a <strong>{{if eq .RequiredTier "power"}}Power{{else}}Pro{{end}}</strong> subscription.</p>
+    {{end}}
     {{if eq .CurrentTier "free"}}
     <p class="upgrade-hint">You are currently on the <strong>Free</strong> tier.</p>
     {{else if eq .CurrentTier "pro"}}
@@ -11,11 +15,10 @@
     <div style="margin-top: 16px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap;">
       <a href="/api/subscribe?tier={{.RequiredTier}}"
          style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
-        Subscribe to {{if eq .RequiredTier "power"}}Power{{else}}Pro{{end}}
+        Upgrade to {{if eq .RequiredTier "power"}}Power{{else}}Pro{{end}}
       </a>
-      <a href="/settings" style="color: #4fc3f7; font-size: 0.85rem;">
-        Already have a key? Go to Settings
-      </a>
+      <a href="/settings/plans" style="color: #4fc3f7; font-size: 0.85rem;">Compare plans →</a>
+      <a href="/settings" style="color: #888; font-size: 0.85rem;">Already have a key?</a>
     </div>
 </div>
 {{end}}

--- a/internal/web/templates/plans_layout.html
+++ b/internal/web/templates/plans_layout.html
@@ -1,0 +1,135 @@
+{{define "plans_layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Satsbook — Plans</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="/static/htmx.min.js"></script>
+  <style>
+    .plans-grid { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 24px; }
+    .plan-card {
+      flex: 1; min-width: 220px; border: 1px solid var(--border, #333);
+      border-radius: 10px; padding: 24px; position: relative;
+    }
+    .plan-card.current { border-color: var(--accent, #f7931a); }
+    .plan-name { font-size: 1.15rem; font-weight: 700; margin: 0 0 4px; }
+    .plan-price { font-size: 1.5rem; font-weight: 700; margin: 8px 0 4px; }
+    .plan-price span { font-size: 0.8rem; font-weight: 400; color: var(--text-muted); }
+    .plan-badge {
+      position: absolute; top: 16px; right: 16px;
+      background: var(--accent, #f7931a); color: #000;
+      font-size: 0.7rem; font-weight: 700; padding: 2px 8px; border-radius: 10px;
+    }
+    .plan-features { list-style: none; padding: 0; margin: 16px 0 20px; font-size: 0.85rem; color: var(--text-muted); line-height: 2; }
+    .plan-features li::before { content: "✓ "; color: var(--accent, #f7931a); font-weight: 700; }
+    .plan-features li.muted::before { content: "— "; color: var(--border); }
+    .plan-features li.muted { color: var(--border); }
+    .plan-cta {
+      display: inline-block; padding: 8px 20px; border-radius: 6px;
+      background: var(--accent, #f7931a); color: #000; text-decoration: none;
+      font-size: 0.85rem; font-weight: 700; width: 100%; text-align: center; box-sizing: border-box;
+    }
+    .plan-cta.current-cta {
+      background: transparent; color: var(--text-muted);
+      border: 1px solid var(--border); cursor: default; pointer-events: none;
+    }
+  </style>
+</head>
+<body hx-indicator="#htmx-progress">
+  <div id="htmx-progress" class="htmx-indicator"></div>
+  <header>
+    <div class="container header-inner">
+      <div class="header-top">
+        <a class="logo" href="/">Satsbook</a>
+        <button class="hamburger" id="hamburger" aria-label="Toggle menu" onclick="document.getElementById('main-nav').classList.toggle('nav-open'); this.classList.toggle('hamburger-open');">
+          <span></span><span></span><span></span>
+        </button>
+      </div>
+      {{template "nav" "settings"}}
+    </div>
+  </header>
+
+  <main class="container" style="padding: 24px 16px;">
+    <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 4px;">
+      <h2 style="margin: 0;">Plans</h2>
+      <a href="/settings" style="font-size: 0.8rem; color: var(--text-muted);">← Back to Settings</a>
+    </div>
+    <p style="color: var(--text-muted); font-size: 0.9rem; margin: 0 0 8px;">
+      Your current plan: <span class="tier-badge tier-{{.Tier}}">{{.Tier}}</span>
+    </p>
+
+    <div class="plans-grid">
+
+      <!-- Free -->
+      <div class="plan-card{{if eq .Tier "free"}} current{{end}}">
+        {{if eq .Tier "free"}}<div class="plan-badge">Current</div>{{end}}
+        <div class="plan-name">Free</div>
+        <div class="plan-price">$0 <span>/ forever</span></div>
+        <ul class="plan-features">
+          <li>Lightning node dashboard</li>
+          <li>Routing fee tracking</li>
+          <li>Exchange CSV imports</li>
+          <li>Unified transaction ledger</li>
+          <li>Portfolio breakdown</li>
+          <li>Cold storage wallet tracking</li>
+          <li>Raw data export (CSV)</li>
+          <li class="muted">Tax cost basis engine</li>
+          <li class="muted">Form 8949 export</li>
+          <li class="muted">Monarch Money sync</li>
+        </ul>
+        <span class="plan-cta current-cta">Free forever</span>
+      </div>
+
+      <!-- Pro -->
+      <div class="plan-card{{if eq .Tier "pro"}} current{{end}}">
+        {{if eq .Tier "pro"}}<div class="plan-badge">Current</div>{{end}}
+        <div class="plan-name">Pro</div>
+        <div class="plan-price">$9 <span>/ month</span></div>
+        <ul class="plan-features">
+          <li>Everything in Free</li>
+          <li>FIFO / LIFO cost basis engine</li>
+          <li>Form 8949 CSV export</li>
+          <li>Tax summary dashboard</li>
+          <li class="muted">Monarch Money sync</li>
+        </ul>
+        {{if eq .Tier "free"}}
+        <a href="/api/subscribe?tier=pro" class="plan-cta">Upgrade to Pro</a>
+        {{else if eq .Tier "pro"}}
+        <span class="plan-cta current-cta">Current plan</span>
+        {{else}}
+        <span class="plan-cta current-cta">Included in Power</span>
+        {{end}}
+      </div>
+
+      <!-- Power -->
+      <div class="plan-card{{if eq .Tier "power"}} current{{end}}">
+        {{if eq .Tier "power"}}<div class="plan-badge">Current</div>{{end}}
+        <div class="plan-name">Power</div>
+        <div class="plan-price">$19 <span>/ month</span></div>
+        <ul class="plan-features">
+          <li>Everything in Pro</li>
+          <li>Monarch Money net worth sync</li>
+          <li>Transaction export to Monarch</li>
+        </ul>
+        {{if eq .Tier "power"}}
+        <span class="plan-cta current-cta">Current plan</span>
+        {{else}}
+        <a href="/api/subscribe?tier=power" class="plan-cta">Upgrade to Power</a>
+        {{end}}
+      </div>
+
+    </div>
+
+    <p style="margin-top: 24px; font-size: 0.8rem; color: var(--text-muted);">
+      Already have a license key? <a href="/settings" style="color: var(--accent);">Enter it in Settings →</a>
+    </p>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Satsbook</span>
+    </div>
+  </footer>
+</body>
+</html>{{end}}

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -95,6 +95,10 @@
       </div>
       {{end}}
 
+      <p style="margin: 4px 0 8px; font-size: 0.8rem;">
+        <a href="/settings/plans" style="color: var(--accent);">Compare all plans →</a>
+      </p>
+
       <details style="margin-top: 8px;">
         <summary style="cursor: pointer; color: #888; font-size: 0.8rem;">Enter license key manually</summary>
         <form hx-post="/api/settings/license" hx-target="#license-result" style="display: flex; gap: 8px; align-items: flex-end; margin-top: 8px; max-width: 500px;">
@@ -114,12 +118,7 @@
       </p>
 
       {{if not .MonarchUnlocked}}
-        <div style="padding: 12px; border: 1px solid #555; border-radius: 6px; background: #1a1a1a;">
-          <p style="margin: 0; color: #aaa;">
-            Monarch Money sync requires the <strong>Power</strong> tier.
-            {{if .Tier}}Your current tier: <span class="tier-badge tier-{{.Tier}}">{{.Tier}}</span>{{end}}
-          </p>
-        </div>
+        {{template "upgrade_required" (dict "RequiredTier" "power" "CurrentTier" .Tier "FeatureMessage" "Sync your total BTC holdings and transactions to Monarch Money with Power.")}}
       {{else if .MonarchConnected}}
         <div style="margin-bottom: 12px;">
           <span style="color: #4caf50;">Connected</span> &middot;

--- a/internal/web/templates/tax.html
+++ b/internal/web/templates/tax.html
@@ -1,42 +1,6 @@
 {{define "tax_content"}}
 {{if not (tierAtLeast .Tier "pro")}}
-<div class="upgrade-required">
-    <div class="upgrade-icon">&#x1f512;</div>
-    <h3>Pro Feature</h3>
-    <p>Tax export requires a paid subscription.</p>
-    <p class="upgrade-hint" style="margin-bottom: 16px;">You are currently on the <strong>Free</strong> tier.</p>
-
-    <div style="display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 16px;">
-      <div style="flex: 1; min-width: 220px; border: 1px solid var(--border, #333); border-radius: 8px; padding: 16px;">
-        <h4 style="margin: 0 0 8px; color: var(--text, #e6e6e6);">Pro</h4>
-        <ul style="margin: 0 0 12px; padding-left: 18px; color: #aaa; font-size: 0.8rem; line-height: 1.6;">
-          <li>FIFO / LIFO cost basis engine</li>
-          <li>Form 8949 CSV export</li>
-          <li>Tax summary dashboard</li>
-        </ul>
-        <a href="/api/subscribe?tier=pro"
-           style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
-          Subscribe to Pro
-        </a>
-      </div>
-      <div style="flex: 1; min-width: 220px; border: 1px solid var(--border, #333); border-radius: 8px; padding: 16px;">
-        <h4 style="margin: 0 0 8px; color: var(--text, #e6e6e6);">Power</h4>
-        <ul style="margin: 0 0 12px; padding-left: 18px; color: #aaa; font-size: 0.8rem; line-height: 1.6;">
-          <li>Everything in Pro</li>
-          <li>Monarch Money net worth sync</li>
-          <li>Transaction export to Monarch</li>
-        </ul>
-        <a href="/api/subscribe?tier=power"
-           style="display: inline-block; padding: 8px 20px; border-radius: 6px; background: #f7931a; color: #000; text-decoration: none; font-size: 0.85rem; font-weight: 600;">
-          Subscribe to Power
-        </a>
-      </div>
-    </div>
-
-    <a href="/settings" style="color: #4fc3f7; font-size: 0.85rem;">
-      Already have a key? Go to Settings
-    </a>
-</div>
+{{template "upgrade_required" (dict "RequiredTier" "pro" "CurrentTier" .Tier "FeatureMessage" "Unlock the FIFO/LIFO cost basis engine and Form 8949 CSV export with Pro.")}}
 {{else}}
 <!-- Disclaimer -->
 <div style="background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 24px; font-size: 0.85rem; color: var(--text-muted);">


### PR DESCRIPTION
## Summary
- Adds `/settings/plans` — 3-column Free / Pro / Power comparison table with current plan badge and upgrade CTAs
- Updates `upgrade_required` partial to accept a `FeatureMessage` for contextual messaging
- Replaces generic inline upgrade blocks in tax and settings pages with the shared partial
- Adds "Compare plans →" link to all gated prompts and the settings license section

Closes #107

## Test plan
- [x] `TestHandlePlansPage_Free` — upgrade CTAs present, free plan labeled
- [x] `TestHandlePlansPage_Pro` — "Current plan" on Pro, Power upgrade CTA visible
- [x] `TestHandlePlansPage_Power` — no active subscribe links
- [x] Full test suite passes
- [x] Manual: visit `/settings/plans` as free user — all 3 columns, Free shows "Current", Pro/Power show upgrade buttons
- [x] Manual: visit `/tax` as free user — contextual message "Unlock the FIFO/LIFO..." with "Compare plans →" link
- [x] Manual: visit `/settings` as free/pro user — Monarch gate shows "Sync your BTC holdings..." with "Compare plans →"