### PR TITLE
feat(exchange): Strike API auto-sync

### DIFF
--- a/cmd/satsbook/main.go
+++ b/cmd/satsbook/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/satsbook/satsbook/internal/config"
 	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/exchange"
 	"github.com/satsbook/satsbook/internal/license"
 	"github.com/satsbook/satsbook/internal/lnd"
 	"github.com/satsbook/satsbook/internal/monarch"
@@ -144,6 +145,15 @@ func main() {
 		}
 	}
 
+	// Wire up Strike API auto-sync (goroutine started after ctx is created below)
+	strikeAPIKey := cfg.StrikeAPIKey
+	if strikeAPIKey == "" {
+		if dbKey, _ := database.GetSetting(context.Background(), "strike_api_key"); dbKey != "" {
+			strikeAPIKey = dbKey
+		}
+	}
+	strikeLogger := log.New(os.Stdout, "[strike] ", log.LstdFlags)
+
 	// Wire up wallet tracking (wallet store is always available; scanner requires Electrum or Bitcoin RPC)
 	handler.SetWalletStore(database)
 	walletLogger := log.New(os.Stdout, "[wallet] ", log.LstdFlags)
@@ -190,6 +200,36 @@ func main() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
+	// Start Strike API sync now that ctx is available
+	if strikeAPIKey != "" {
+		strikeClient := exchange.NewStrikeAPIClient(strikeAPIKey)
+		if s != nil {
+			s.SetStrikeClient(strikeClient, database)
+			log.Printf("strike: API sync enabled (via LND syncer)")
+		} else {
+			go runStrikeSync(ctx, strikeClient, database, 15*time.Minute, strikeLogger)
+			log.Printf("strike: API sync enabled (background goroutine)")
+		}
+	}
+	// Hot-swap when the user saves/clears the key from settings
+	handler.OnStrikeKeyChange(func(apiKey string) {
+		if apiKey == "" {
+			if s != nil {
+				s.SetStrikeClient(nil, nil)
+			}
+			strikeLogger.Printf("API key removed — sync disabled")
+			return
+		}
+		newClient := exchange.NewStrikeAPIClient(apiKey)
+		if s != nil {
+			s.SetStrikeClient(newClient, database)
+			strikeLogger.Printf("API key updated — syncing via LND syncer")
+		} else {
+			go runStrikeSync(ctx, newClient, database, 15*time.Minute, strikeLogger)
+			strikeLogger.Printf("API key updated — background goroutine started")
+		}
+	})
+
 	go func() {
 		sig := <-sigCh
 		log.Printf("received signal %v, shutting down...", sig)
@@ -219,6 +259,44 @@ func main() {
 	}
 
 	log.Println("shutdown complete")
+}
+
+// runStrikeSync runs a Strike API sync immediately and then on the given interval.
+// Used in dashboard-only mode (no LND syncer). The syncer handles this automatically
+// when LND is configured.
+func runStrikeSync(ctx context.Context, client *exchange.StrikeAPIClient, importer interface {
+	ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
+}, interval time.Duration, logger *log.Logger) {
+	doSync := func() {
+		rows, err := client.FetchRows(ctx)
+		if err != nil {
+			logger.Printf("fetch rows: %v", err)
+			return
+		}
+		if len(rows) == 0 {
+			return
+		}
+		summary, err := importer.ImportStrikeCSV(ctx, rows)
+		if err != nil {
+			logger.Printf("import: %v", err)
+			return
+		}
+		if summary.NewPurchases > 0 || summary.Updated > 0 {
+			logger.Printf("sync: %d new, %d updated, %d duplicates", summary.NewPurchases, summary.Updated, summary.Duplicates)
+		}
+	}
+
+	doSync()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			doSync()
+		}
+	}
 }
 
 // licenseStoreAdapter bridges db.DB to the license.LicenseStore interface,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	// Monarch Money sync settings
 	MonarchToken     string
 	MonarchAccountID string
+
+	// Exchange API keys
+	StrikeAPIKey string
 }
 
 // Load reads configuration from environment variables.
@@ -90,6 +93,9 @@ func Load() (*Config, error) {
 		// Monarch Money sync
 		MonarchToken:     getEnv("SATSBOOK_MONARCH_TOKEN", ""),
 		MonarchAccountID: getEnv("SATSBOOK_MONARCH_ACCOUNT_ID", ""),
+
+		// Exchange API keys
+		StrikeAPIKey: getEnv("SATSBOOK_STRIKE_API_KEY", ""),
 	}
 
 	// Validate required fields

--- a/internal/exchange/strike_api.go
+++ b/internal/exchange/strike_api.go
@@ -1,6 +1,32 @@
 // Strike REST API client.
-// Docs: https://docs.strike.me/
-// Base URL: https://api.strike.me/v1
+//
+// # Scope of the Strike API
+//
+// The Strike API is a payment-processing API aimed at merchants and developers,
+// not a personal transaction-history API.  The endpoints that exist do NOT cover
+// the same transaction types as Strike's own CSV export.
+//
+// What IS available via API:
+//   - GET /v1/invoices       — Lightning payment invoices you created that others paid
+//                              (scope: partner.invoice.read)
+//   - GET /v1/balances       — Live multi-currency account balances
+//                              (scope: partner.balances.read)
+//   - GET /v1/deposits       — Bank deposits (fiat into Strike), NOT BTC purchases
+//   - GET /v1/payouts        — Bank payouts (fiat out of Strike), NOT BTC withdrawals
+//
+// What is NOT available via API:
+//   - BTC purchases / DCA orders
+//   - BTC sales
+//   - BTC withdrawals to external wallets
+//   - Consumer app transaction history
+//
+// For the above, CSV import remains the only option.
+//
+// Deduplication note: the invoiceId returned by GET /v1/invoices is used as
+// TransactionID in StrikeRow, which maps to the "Reference" column in Strike's
+// CSV export.  Dedup via ImportStrikeCSV works when the same invoice appears in
+// both sources, but CSV-only transactions (purchases, withdrawals, sales) will
+// never appear from the API.
 package exchange
 
 import (
@@ -9,15 +35,20 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
 
 const strikeDefaultBaseURL = "https://api.strike.me/v1"
 
-// StrikeAPIClient fetches transaction rows from the Strike REST API.
-// Rows are returned as StrikeRow values, fully compatible with ImportStrikeCSV
-// for deduplication against CSV-imported data.
+// strikePageSize is the maximum number of records Strike returns per page.
+// The API enforces a hard cap of 100 on $top.
+const strikePageSize = 100
+
+// StrikeAPIClient fetches data from the Strike REST API.
+// It covers invoice-type receives and live balances only; see package comment
+// for what is NOT accessible via the API.
 type StrikeAPIClient struct {
 	apiKey  string
 	baseURL string
@@ -27,9 +58,9 @@ type StrikeAPIClient struct {
 // StrikeAPIOption configures a StrikeAPIClient.
 type StrikeAPIOption func(*StrikeAPIClient)
 
-// WithStrikeAPIBaseURL overrides the base URL. Used in tests to point at a mock server.
-func WithStrikeAPIBaseURL(url string) StrikeAPIOption {
-	return func(c *StrikeAPIClient) { c.baseURL = url }
+// WithStrikeAPIBaseURL overrides the base URL.  Used in tests to point at a mock server.
+func WithStrikeAPIBaseURL(u string) StrikeAPIOption {
+	return func(c *StrikeAPIClient) { c.baseURL = u }
 }
 
 // NewStrikeAPIClient creates a Strike API client authenticated with apiKey.
@@ -47,74 +78,123 @@ func NewStrikeAPIClient(apiKey string, opts ...StrikeAPIOption) *StrikeAPIClient
 
 // --- internal response types ---
 
-type strikeInvoiceListResp struct {
-	Items []strikeInvoiceItem `json:"items"`
+type strikePagedResponse struct {
+	Items          json.RawMessage `json:"items"`
+	Count          int64           `json:"count"`
+	IsCountUnknown bool            `json:"isCountUnknown"`
 }
 
 type strikeInvoiceItem struct {
-	InvoiceID   string        `json:"invoiceId"`
-	Amount      strikeAmount  `json:"amount"`
-	State       string        `json:"state"`
-	Created     time.Time     `json:"created"`
-	Description string        `json:"description"`
+	InvoiceID    string                     `json:"invoiceId"`
+	Amount       strikeMonetaryAmount       `json:"amount"`
+	State        string                     `json:"state"`
+	Created      time.Time                  `json:"created"`
+	Description  string                     `json:"description"`
+	Transactions []strikeInvoiceTransaction `json:"transactions"`
 }
 
-type strikeAmount struct {
+type strikeInvoiceTransaction struct {
+	TransactionID  string               `json:"transactionId"`
+	State          string               `json:"state"`
+	AmountReceived strikeMonetaryAmount `json:"amountReceived"`
+	Created        time.Time            `json:"created"`
+	Completed      *time.Time           `json:"completed"`
+}
+
+type strikeMonetaryAmount struct {
 	Amount   string `json:"amount"`
 	Currency string `json:"currency"`
 }
 
 type strikeBalanceItem struct {
 	Currency  string `json:"currency"`
-	Total     string `json:"total"`
+	Current   string `json:"current"`
+	Pending   string `json:"pending"`
+	Outgoing  string `json:"outgoing"`
+	Reserved  string `json:"reserved"`
 	Available string `json:"available"`
+	Total     string `json:"total"`
 }
 
-// FetchRows fetches completed transactions from the Strike API and returns them as
-// StrikeRow values. Currently covers paid invoices (type "receive"). The rows share
-// the same TransactionID format as Strike's CSV export, so ImportStrikeCSV will
-// deduplicate correctly when both sources are used.
+// FetchRows fetches paid invoices from the Strike API and returns them as StrikeRow
+// values compatible with ImportStrikeCSV.
+//
+// IMPORTANT SCOPE LIMITATION: This only returns Lightning payment invoices that were
+// created via the Strike API/dashboard and subsequently paid.  It does NOT include
+// BTC purchases (DCA), sales, or withdrawals — those transaction types have no
+// equivalent API endpoint and must still be imported via CSV.
+//
+// Required API scope: partner.invoice.read
 func (c *StrikeAPIClient) FetchRows(ctx context.Context) ([]StrikeRow, error) {
-	url := c.baseURL + "/invoices?$filter=state%20eq%20'PAID'&$top=500&$orderby=created%20desc"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("strike api: build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Accept", "application/json")
+	var all []StrikeRow
+	skip := 0
 
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("strike api: request: %w", err)
-	}
-	defer resp.Body.Close()
+	for {
+		q := url.Values{}
+		q.Set("$filter", "state eq 'PAID'")
+		q.Set("$orderby", "created desc")
+		q.Set("$top", strconv.Itoa(strikePageSize))
+		q.Set("$skip", strconv.Itoa(skip))
+		q.Set("includeTransactions", "true")
 
-	switch resp.StatusCode {
-	case http.StatusOK:
-		// continue
-	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("strike api: invalid API key (401)")
-	default:
-		return nil, fmt.Errorf("strike api: unexpected status %d", resp.StatusCode)
-	}
-
-	var list strikeInvoiceListResp
-	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
-		return nil, fmt.Errorf("strike api: decode response: %w", err)
-	}
-
-	rows := make([]StrikeRow, 0, len(list.Items))
-	for _, item := range list.Items {
-		row, err := strikeInvoiceToRow(item)
+		endpoint := c.baseURL + "/invoices?" + q.Encode()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 		if err != nil {
-			continue // skip non-BTC or malformed entries
+			return nil, fmt.Errorf("strike api: build request: %w", err)
 		}
-		rows = append(rows, row)
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("strike api: request: %w", err)
+		}
+		defer resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// continue
+		case http.StatusUnauthorized:
+			return nil, fmt.Errorf("strike api: authentication failed (401) — check API key and partner.invoice.read scope")
+		case http.StatusForbidden:
+			return nil, fmt.Errorf("strike api: forbidden (403) — API key is missing partner.invoice.read scope")
+		default:
+			return nil, fmt.Errorf("strike api: unexpected status %d", resp.StatusCode)
+		}
+
+		var page strikePagedResponse
+		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			return nil, fmt.Errorf("strike api: decode response: %w", err)
+		}
+
+		var items []strikeInvoiceItem
+		if err := json.Unmarshal(page.Items, &items); err != nil {
+			return nil, fmt.Errorf("strike api: decode items: %w", err)
+		}
+
+		for _, item := range items {
+			row, err := strikeInvoiceToRow(item)
+			if err != nil {
+				continue // skip non-BTC or malformed entries
+			}
+			all = append(all, row)
+		}
+
+		// Stop when we've received a partial page (no more data).
+		if len(items) < strikePageSize {
+			break
+		}
+		skip += strikePageSize
 	}
-	return rows, nil
+
+	return all, nil
 }
 
-// FetchBalance returns the current BTC balance in satoshis.
+// FetchBalance returns the current BTC balance from Strike in satoshis.
+// Uses the available field (spendable balance) rather than total (which includes
+// outgoing funds not yet settled).
+//
+// Required API scope: partner.balances.read
 func (c *StrikeAPIClient) FetchBalance(ctx context.Context) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/balances", nil)
 	if err != nil {
@@ -129,7 +209,14 @@ func (c *StrikeAPIClient) FetchBalance(ctx context.Context) (int64, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// continue
+	case http.StatusUnauthorized:
+		return 0, fmt.Errorf("strike api: authentication failed (401) — check API key and partner.balances.read scope")
+	case http.StatusForbidden:
+		return 0, fmt.Errorf("strike api: forbidden (403) — API key is missing partner.balances.read scope")
+	default:
 		return 0, fmt.Errorf("strike api: balance status %d", resp.StatusCode)
 	}
 
@@ -139,35 +226,77 @@ func (c *StrikeAPIClient) FetchBalance(ctx context.Context) (int64, error) {
 	}
 
 	for _, b := range balances {
-		if b.Currency == "BTC" {
-			btc, err := strconv.ParseFloat(b.Total, 64)
-			if err != nil {
-				return 0, fmt.Errorf("strike api: parse BTC balance %q: %w", b.Total, err)
-			}
-			return int64(math.Round(btc * 1e8)), nil
+		if b.Currency != "BTC" {
+			continue
 		}
+		// Use Available (spendable) rather than Total (available + outgoing).
+		btc, err := strconv.ParseFloat(b.Available, 64)
+		if err != nil {
+			return 0, fmt.Errorf("strike api: parse BTC available balance %q: %w", b.Available, err)
+		}
+		return int64(math.Round(btc * 1e8)), nil
 	}
 	return 0, nil
 }
 
-// strikeInvoiceToRow converts a paid invoice from the API into a StrikeRow.
-// The InvoiceID maps to the "Reference" column in Strike CSV exports, ensuring
-// deduplication works when both import methods are used.
+// strikeInvoiceToRow converts a paid Strike invoice to a StrikeRow.
+//
+// The InvoiceID is used as TransactionID (maps to "Reference" in Strike CSV).
+// Only BTC-denominated invoices are converted; USD/fiat invoices are skipped.
 func strikeInvoiceToRow(item strikeInvoiceItem) (StrikeRow, error) {
-	if item.Amount.Currency != "BTC" {
-		return StrikeRow{}, fmt.Errorf("non-BTC invoice currency %q", item.Amount.Currency)
+	// Determine BTC amount: prefer actual received amount from the transaction
+	// sub-object (most accurate), fall back to the invoice face amount.
+	var btcAmount float64
+	var txID string
+	var txDate time.Time
+
+	if len(item.Transactions) > 0 {
+		// Use the first completed transaction's received amount.
+		for _, tx := range item.Transactions {
+			if tx.State == "COMPLETED" && tx.AmountReceived.Currency == "BTC" {
+				received, err := strconv.ParseFloat(tx.AmountReceived.Amount, 64)
+				if err == nil {
+					btcAmount = received
+					txID = tx.TransactionID
+					if tx.Completed != nil {
+						txDate = *tx.Completed
+					} else {
+						txDate = tx.Created
+					}
+				}
+				break
+			}
+		}
 	}
-	btc, err := strconv.ParseFloat(item.Amount.Amount, 64)
-	if err != nil {
-		return StrikeRow{}, fmt.Errorf("parse BTC amount %q: %w", item.Amount.Amount, err)
+
+	// Fall back to invoice-level amount if no transaction data available.
+	if btcAmount == 0 {
+		if item.Amount.Currency != "BTC" {
+			return StrikeRow{}, fmt.Errorf("non-BTC invoice currency %q", item.Amount.Currency)
+		}
+		faceAmt, err := strconv.ParseFloat(item.Amount.Amount, 64)
+		if err != nil {
+			return StrikeRow{}, fmt.Errorf("parse invoice amount %q: %w", item.Amount.Amount, err)
+		}
+		btcAmount = faceAmt
+		txDate = item.Created
 	}
-	amtSat := int64(math.Round(btc * 1e8))
+
+	// Use transaction ID when available for better dedup; fall back to invoice ID.
+	if txID == "" {
+		txID = item.InvoiceID
+	}
+	if txDate.IsZero() {
+		txDate = item.Created
+	}
+
+	amtSat := int64(math.Round(btcAmount * 1e8))
 	return StrikeRow{
-		TransactionID: item.InvoiceID,
-		Date:          item.Created,
+		TransactionID: txID,
+		Date:          txDate,
 		Type:          "receive",
 		AmountSat:     amtSat,
-		AmountBTC:     btc,
+		AmountBTC:     btcAmount,
 		Description:   item.Description,
 		Status:        "completed",
 	}, nil

--- a/internal/exchange/strike_api.go
+++ b/internal/exchange/strike_api.go
@@ -1,0 +1,174 @@
+// Strike REST API client.
+// Docs: https://docs.strike.me/
+// Base URL: https://api.strike.me/v1
+package exchange
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const strikeDefaultBaseURL = "https://api.strike.me/v1"
+
+// StrikeAPIClient fetches transaction rows from the Strike REST API.
+// Rows are returned as StrikeRow values, fully compatible with ImportStrikeCSV
+// for deduplication against CSV-imported data.
+type StrikeAPIClient struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+// StrikeAPIOption configures a StrikeAPIClient.
+type StrikeAPIOption func(*StrikeAPIClient)
+
+// WithStrikeAPIBaseURL overrides the base URL. Used in tests to point at a mock server.
+func WithStrikeAPIBaseURL(url string) StrikeAPIOption {
+	return func(c *StrikeAPIClient) { c.baseURL = url }
+}
+
+// NewStrikeAPIClient creates a Strike API client authenticated with apiKey.
+func NewStrikeAPIClient(apiKey string, opts ...StrikeAPIOption) *StrikeAPIClient {
+	c := &StrikeAPIClient{
+		apiKey:  apiKey,
+		baseURL: strikeDefaultBaseURL,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// --- internal response types ---
+
+type strikeInvoiceListResp struct {
+	Items []strikeInvoiceItem `json:"items"`
+}
+
+type strikeInvoiceItem struct {
+	InvoiceID   string        `json:"invoiceId"`
+	Amount      strikeAmount  `json:"amount"`
+	State       string        `json:"state"`
+	Created     time.Time     `json:"created"`
+	Description string        `json:"description"`
+}
+
+type strikeAmount struct {
+	Amount   string `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+type strikeBalanceItem struct {
+	Currency  string `json:"currency"`
+	Total     string `json:"total"`
+	Available string `json:"available"`
+}
+
+// FetchRows fetches completed transactions from the Strike API and returns them as
+// StrikeRow values. Currently covers paid invoices (type "receive"). The rows share
+// the same TransactionID format as Strike's CSV export, so ImportStrikeCSV will
+// deduplicate correctly when both sources are used.
+func (c *StrikeAPIClient) FetchRows(ctx context.Context) ([]StrikeRow, error) {
+	url := c.baseURL + "/invoices?$filter=state%20eq%20'PAID'&$top=500&$orderby=created%20desc"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("strike api: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("strike api: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// continue
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("strike api: invalid API key (401)")
+	default:
+		return nil, fmt.Errorf("strike api: unexpected status %d", resp.StatusCode)
+	}
+
+	var list strikeInvoiceListResp
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		return nil, fmt.Errorf("strike api: decode response: %w", err)
+	}
+
+	rows := make([]StrikeRow, 0, len(list.Items))
+	for _, item := range list.Items {
+		row, err := strikeInvoiceToRow(item)
+		if err != nil {
+			continue // skip non-BTC or malformed entries
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// FetchBalance returns the current BTC balance in satoshis.
+func (c *StrikeAPIClient) FetchBalance(ctx context.Context) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/balances", nil)
+	if err != nil {
+		return 0, fmt.Errorf("strike api: build balance request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("strike api: balance request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("strike api: balance status %d", resp.StatusCode)
+	}
+
+	var balances []strikeBalanceItem
+	if err := json.NewDecoder(resp.Body).Decode(&balances); err != nil {
+		return 0, fmt.Errorf("strike api: decode balances: %w", err)
+	}
+
+	for _, b := range balances {
+		if b.Currency == "BTC" {
+			btc, err := strconv.ParseFloat(b.Total, 64)
+			if err != nil {
+				return 0, fmt.Errorf("strike api: parse BTC balance %q: %w", b.Total, err)
+			}
+			return int64(math.Round(btc * 1e8)), nil
+		}
+	}
+	return 0, nil
+}
+
+// strikeInvoiceToRow converts a paid invoice from the API into a StrikeRow.
+// The InvoiceID maps to the "Reference" column in Strike CSV exports, ensuring
+// deduplication works when both import methods are used.
+func strikeInvoiceToRow(item strikeInvoiceItem) (StrikeRow, error) {
+	if item.Amount.Currency != "BTC" {
+		return StrikeRow{}, fmt.Errorf("non-BTC invoice currency %q", item.Amount.Currency)
+	}
+	btc, err := strconv.ParseFloat(item.Amount.Amount, 64)
+	if err != nil {
+		return StrikeRow{}, fmt.Errorf("parse BTC amount %q: %w", item.Amount.Amount, err)
+	}
+	amtSat := int64(math.Round(btc * 1e8))
+	return StrikeRow{
+		TransactionID: item.InvoiceID,
+		Date:          item.Created,
+		Type:          "receive",
+		AmountSat:     amtSat,
+		AmountBTC:     btc,
+		Description:   item.Description,
+		Status:        "completed",
+	}, nil
+}

--- a/internal/exchange/strike_api_test.go
+++ b/internal/exchange/strike_api_test.go
@@ -1,0 +1,151 @@
+package exchange_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/satsbook/satsbook/internal/exchange"
+)
+
+func TestStrikeAPIClient_FetchRows(t *testing.T) {
+	created := time.Date(2024, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path != "/invoices" {
+			http.NotFound(w, r)
+			return
+		}
+		resp := map[string]interface{}{
+			"items": []map[string]interface{}{
+				{
+					"invoiceId":   "inv-001",
+					"state":       "PAID",
+					"created":     created.Format(time.RFC3339),
+					"description": "Test payment",
+					"amount":      map[string]string{"amount": "0.001", "currency": "BTC"},
+				},
+				{
+					"invoiceId":   "inv-002",
+					"state":       "PAID",
+					"created":     created.Format(time.RFC3339),
+					"description": "USD invoice",
+					"amount":      map[string]string{"amount": "50.00", "currency": "USD"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := exchange.NewStrikeAPIClient("test-key", exchange.WithStrikeAPIBaseURL(srv.URL))
+	rows, err := client.FetchRows(context.Background())
+	if err != nil {
+		t.Fatalf("FetchRows() error = %v", err)
+	}
+
+	// Only the BTC invoice should be included; USD invoice should be skipped.
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	r := rows[0]
+	if r.TransactionID != "inv-001" {
+		t.Errorf("TransactionID = %q, want inv-001", r.TransactionID)
+	}
+	if r.Type != "receive" {
+		t.Errorf("Type = %q, want receive", r.Type)
+	}
+	if r.AmountSat != 100_000 {
+		t.Errorf("AmountSat = %d, want 100000", r.AmountSat)
+	}
+	if r.AmountBTC != 0.001 {
+		t.Errorf("AmountBTC = %v, want 0.001", r.AmountBTC)
+	}
+	if r.Description != "Test payment" {
+		t.Errorf("Description = %q, want 'Test payment'", r.Description)
+	}
+	if r.Status != "completed" {
+		t.Errorf("Status = %q, want completed", r.Status)
+	}
+}
+
+func TestStrikeAPIClient_FetchRows_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	client := exchange.NewStrikeAPIClient("bad-key", exchange.WithStrikeAPIBaseURL(srv.URL))
+	_, err := client.FetchRows(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 401, got nil")
+	}
+}
+
+func TestStrikeAPIClient_FetchRows_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := exchange.NewStrikeAPIClient("key", exchange.WithStrikeAPIBaseURL(srv.URL))
+	_, err := client.FetchRows(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 500, got nil")
+	}
+}
+
+func TestStrikeAPIClient_FetchBalance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/balances" {
+			http.NotFound(w, r)
+			return
+		}
+		resp := []map[string]string{
+			{"currency": "USD", "total": "150.00", "available": "150.00"},
+			{"currency": "BTC", "total": "0.00250000", "available": "0.00250000"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := exchange.NewStrikeAPIClient("key", exchange.WithStrikeAPIBaseURL(srv.URL))
+	sats, err := client.FetchBalance(context.Background())
+	if err != nil {
+		t.Fatalf("FetchBalance() error = %v", err)
+	}
+
+	const want = 250_000
+	if sats != want {
+		t.Errorf("FetchBalance() = %d sats, want %d", sats, want)
+	}
+}
+
+func TestStrikeAPIClient_FetchBalance_NoBTC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := []map[string]string{
+			{"currency": "USD", "total": "50.00", "available": "50.00"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := exchange.NewStrikeAPIClient("key", exchange.WithStrikeAPIBaseURL(srv.URL))
+	sats, err := client.FetchBalance(context.Background())
+	if err != nil {
+		t.Fatalf("FetchBalance() error = %v", err)
+	}
+	if sats != 0 {
+		t.Errorf("FetchBalance() = %d, want 0 when no BTC balance", sats)
+	}
+}

--- a/internal/exchange/strike_api_test.go
+++ b/internal/exchange/strike_api_test.go
@@ -11,7 +11,30 @@ import (
 	"github.com/satsbook/satsbook/internal/exchange"
 )
 
-func TestStrikeAPIClient_FetchRows(t *testing.T) {
+// fakeInvoice builds a fake Strike invoice API response item.
+func fakeInvoice(id, state, created, btcAmount string, txns []map[string]interface{}) map[string]interface{} {
+	item := map[string]interface{}{
+		"invoiceId":   id,
+		"state":       state,
+		"created":     created,
+		"description": "test invoice",
+		"amount":      map[string]string{"amount": btcAmount, "currency": "BTC"},
+	}
+	if txns != nil {
+		item["transactions"] = txns
+	}
+	return item
+}
+
+func pagedResponse(items []map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"items":          items,
+		"count":          len(items),
+		"isCountUnknown": false,
+	}
+}
+
+func TestStrikeAPIClient_FetchRows_Basic(t *testing.T) {
 	created := time.Date(2024, 3, 15, 12, 0, 0, 0, time.UTC)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -19,28 +42,22 @@ func TestStrikeAPIClient_FetchRows(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		if r.URL.Path != "/invoices" {
-			http.NotFound(w, r)
-			return
+		// Verify $filter and includeTransactions are set
+		q := r.URL.Query()
+		if q.Get("includeTransactions") != "true" {
+			t.Errorf("expected includeTransactions=true, got %q", q.Get("includeTransactions"))
 		}
-		resp := map[string]interface{}{
-			"items": []map[string]interface{}{
-				{
-					"invoiceId":   "inv-001",
-					"state":       "PAID",
-					"created":     created.Format(time.RFC3339),
-					"description": "Test payment",
-					"amount":      map[string]string{"amount": "0.001", "currency": "BTC"},
-				},
-				{
-					"invoiceId":   "inv-002",
-					"state":       "PAID",
-					"created":     created.Format(time.RFC3339),
-					"description": "USD invoice",
-					"amount":      map[string]string{"amount": "50.00", "currency": "USD"},
-				},
+
+		resp := pagedResponse([]map[string]interface{}{
+			fakeInvoice("inv-001", "PAID", created.Format(time.RFC3339), "0.001", nil),
+			// USD invoice — should be skipped
+			{
+				"invoiceId": "inv-usd",
+				"state":     "PAID",
+				"created":   created.Format(time.RFC3339),
+				"amount":    map[string]string{"amount": "50.00", "currency": "USD"},
 			},
-		}
+		})
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	}))
@@ -52,7 +69,7 @@ func TestStrikeAPIClient_FetchRows(t *testing.T) {
 		t.Fatalf("FetchRows() error = %v", err)
 	}
 
-	// Only the BTC invoice should be included; USD invoice should be skipped.
+	// USD invoice should be skipped; only BTC invoice remains.
 	if len(rows) != 1 {
 		t.Fatalf("got %d rows, want 1", len(rows))
 	}
@@ -69,17 +86,104 @@ func TestStrikeAPIClient_FetchRows(t *testing.T) {
 	if r.AmountBTC != 0.001 {
 		t.Errorf("AmountBTC = %v, want 0.001", r.AmountBTC)
 	}
-	if r.Description != "Test payment" {
-		t.Errorf("Description = %q, want 'Test payment'", r.Description)
-	}
 	if r.Status != "completed" {
 		t.Errorf("Status = %q, want completed", r.Status)
+	}
+}
+
+func TestStrikeAPIClient_FetchRows_WithTransactionSubObject(t *testing.T) {
+	// When includeTransactions=true, the actual settled BTC amount from
+	// the transaction sub-object should take precedence over the invoice amount.
+	created := time.Date(2024, 3, 15, 12, 0, 0, 0, time.UTC)
+	completed := created.Add(10 * time.Minute)
+
+	txns := []map[string]interface{}{
+		{
+			"transactionId": "tx-abc-123",
+			"state":         "COMPLETED",
+			"amountReceived": map[string]string{
+				"amount":   "0.00099800", // actual settled (slightly less than invoice)
+				"currency": "BTC",
+			},
+			"created":   created.Format(time.RFC3339),
+			"completed": completed.Format(time.RFC3339),
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := pagedResponse([]map[string]interface{}{
+			fakeInvoice("inv-002", "PAID", created.Format(time.RFC3339), "0.001", txns),
+		})
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := exchange.NewStrikeAPIClient("test-key", exchange.WithStrikeAPIBaseURL(srv.URL))
+	rows, err := client.FetchRows(context.Background())
+	if err != nil {
+		t.Fatalf("FetchRows() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	r := rows[0]
+	// TransactionID should be the tx ID, not the invoice ID.
+	if r.TransactionID != "tx-abc-123" {
+		t.Errorf("TransactionID = %q, want tx-abc-123", r.TransactionID)
+	}
+	// Amount should come from amountReceived, not the invoice face amount.
+	if r.AmountSat != 99_800 {
+		t.Errorf("AmountSat = %d, want 99800", r.AmountSat)
+	}
+	// Date should be the completed timestamp.
+	if !r.Date.Equal(completed) {
+		t.Errorf("Date = %v, want %v", r.Date, completed)
+	}
+}
+
+func TestStrikeAPIClient_FetchRows_Pagination(t *testing.T) {
+	// Server returns exactly 100 items on page 1, then 2 on page 2.
+	// FetchRows should make two requests and return 102 rows total.
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		created := "2024-01-01T00:00:00Z"
+		var items []map[string]interface{}
+		if r.URL.Query().Get("$skip") == "0" {
+			for i := 0; i < 100; i++ {
+				items = append(items, fakeInvoice(
+					"inv-page1-"+string(rune('a'+i%26)), "PAID", created, "0.0001", nil,
+				))
+			}
+		} else {
+			items = []map[string]interface{}{
+				fakeInvoice("inv-page2-1", "PAID", created, "0.0001", nil),
+				fakeInvoice("inv-page2-2", "PAID", created, "0.0001", nil),
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(pagedResponse(items))
+	}))
+	defer srv.Close()
+
+	client := exchange.NewStrikeAPIClient("key", exchange.WithStrikeAPIBaseURL(srv.URL))
+	rows, err := client.FetchRows(context.Background())
+	if err != nil {
+		t.Fatalf("FetchRows() error = %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls (pagination), got %d", callCount)
+	}
+	if len(rows) != 102 {
+		t.Errorf("got %d rows, want 102", len(rows))
 	}
 }
 
 func TestStrikeAPIClient_FetchRows_Unauthorized(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"data":{"status":401,"code":"UNAUTHORIZED","message":"Invalid or unspecified identity."}}`))
 	}))
 	defer srv.Close()
 
@@ -90,28 +194,46 @@ func TestStrikeAPIClient_FetchRows_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestStrikeAPIClient_FetchRows_ServerError(t *testing.T) {
+func TestStrikeAPIClient_FetchRows_Forbidden(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusForbidden)
 	}))
 	defer srv.Close()
 
 	client := exchange.NewStrikeAPIClient("key", exchange.WithStrikeAPIBaseURL(srv.URL))
 	_, err := client.FetchRows(context.Background())
 	if err == nil {
-		t.Fatal("expected error for 500, got nil")
+		t.Fatal("expected error for 403 (missing scope), got nil")
 	}
 }
 
 func TestStrikeAPIClient_FetchBalance(t *testing.T) {
+	// Actual Strike /v1/balances response: array of {currency, current, pending,
+	// outgoing, reserved, available, total}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/balances" {
 			http.NotFound(w, r)
 			return
 		}
 		resp := []map[string]string{
-			{"currency": "USD", "total": "150.00", "available": "150.00"},
-			{"currency": "BTC", "total": "0.00250000", "available": "0.00250000"},
+			{
+				"currency":  "USD",
+				"current":   "150.00",
+				"pending":   "0.00",
+				"outgoing":  "0.00",
+				"reserved":  "0.00",
+				"available": "150.00",
+				"total":     "150.00",
+			},
+			{
+				"currency":  "BTC",
+				"current":   "0.00500000",
+				"pending":   "0.00050000",
+				"outgoing":  "0.00010000",
+				"reserved":  "0.00000000",
+				"available": "0.00250000",
+				"total":     "0.00260000",
+			},
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
@@ -124,16 +246,17 @@ func TestStrikeAPIClient_FetchBalance(t *testing.T) {
 		t.Fatalf("FetchBalance() error = %v", err)
 	}
 
+	// Should use 'available' field (250_000 sats), not 'total' (260_000).
 	const want = 250_000
 	if sats != want {
-		t.Errorf("FetchBalance() = %d sats, want %d", sats, want)
+		t.Errorf("FetchBalance() = %d sats, want %d (available)", sats, want)
 	}
 }
 
 func TestStrikeAPIClient_FetchBalance_NoBTC(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := []map[string]string{
-			{"currency": "USD", "total": "50.00", "available": "50.00"},
+			{"currency": "USD", "current": "50.00", "available": "50.00", "total": "50.00"},
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
@@ -146,6 +269,6 @@ func TestStrikeAPIClient_FetchBalance_NoBTC(t *testing.T) {
 		t.Fatalf("FetchBalance() error = %v", err)
 	}
 	if sats != 0 {
-		t.Errorf("FetchBalance() = %d, want 0 when no BTC balance", sats)
+		t.Errorf("FetchBalance() = %d, want 0 when no BTC balance exists", sats)
 	}
 }

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/satsbook/satsbook/internal/db"
+	"github.com/satsbook/satsbook/internal/exchange"
 	"github.com/satsbook/satsbook/internal/lnd"
 	"github.com/satsbook/satsbook/internal/monarch"
 )
@@ -58,6 +59,16 @@ type SettingsReader interface {
 	GetSetting(ctx context.Context, key string) (string, error)
 }
 
+// StrikeRowFetcher fetches transaction rows from the Strike REST API.
+type StrikeRowFetcher interface {
+	FetchRows(ctx context.Context) ([]exchange.StrikeRow, error)
+}
+
+// StrikeImporter persists Strike rows to the database.
+type StrikeImporter interface {
+	ImportStrikeCSV(ctx context.Context, rows []exchange.StrikeRow) (*db.ImportSummary, error)
+}
+
 // Syncer orchestrates LND data synchronization.
 type Syncer struct {
 	lnd            LNDClient
@@ -67,6 +78,8 @@ type Syncer struct {
 	monarch        MonarchSyncer
 	monarchTxStore MonarchTxStore
 	settings       SettingsReader
+	strikeClient   StrikeRowFetcher
+	strikeImporter StrikeImporter
 	logger         *log.Logger
 	syncInterval   time.Duration
 	maxHistoryDays int
@@ -98,6 +111,12 @@ func (s *Syncer) SetMonarchSyncer(ms MonarchSyncer) {
 func (s *Syncer) SetMonarchTxSync(txStore MonarchTxStore, settings SettingsReader) {
 	s.monarchTxStore = txStore
 	s.settings = settings
+}
+
+// SetStrikeClient sets the Strike API client and importer for automatic syncing.
+func (s *Syncer) SetStrikeClient(client StrikeRowFetcher, importer StrikeImporter) {
+	s.strikeClient = client
+	s.strikeImporter = importer
 }
 
 // Run blocks until ctx is cancelled, syncing on startup and then on the configured interval.
@@ -148,6 +167,11 @@ func (s *Syncer) Sync(ctx context.Context) error {
 	// Sync transactions to Monarch if configured
 	if s.monarch != nil && s.monarchTxStore != nil && s.settings != nil {
 		s.syncMonarchTransactions(ctx)
+	}
+
+	// Sync Strike API transactions if configured
+	if s.strikeClient != nil && s.strikeImporter != nil {
+		s.syncStrikeAPI(ctx)
 	}
 
 	return nil
@@ -243,6 +267,26 @@ func (s *Syncer) syncMonarchTransactions(ctx context.Context) {
 	}
 
 	s.logger.Printf("monarch tx sync: %d created, %d skipped, %d errors", result.Created, result.Skipped, result.Errors)
+}
+
+// syncStrikeAPI fetches new transactions from Strike and imports them.
+func (s *Syncer) syncStrikeAPI(ctx context.Context) {
+	rows, err := s.strikeClient.FetchRows(ctx)
+	if err != nil {
+		s.logger.Printf("strike api sync: fetch rows: %v", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+	summary, err := s.strikeImporter.ImportStrikeCSV(ctx, rows)
+	if err != nil {
+		s.logger.Printf("strike api sync: import: %v", err)
+		return
+	}
+	if summary.NewPurchases > 0 || summary.Updated > 0 {
+		s.logger.Printf("strike api sync: %d new, %d updated, %d duplicates", summary.NewPurchases, summary.Updated, summary.Duplicates)
+	}
 }
 
 // syncCycle is the core sync logic, executed within a transaction.

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -80,6 +80,7 @@ type Syncer struct {
 	settings       SettingsReader
 	strikeClient   StrikeRowFetcher
 	strikeImporter StrikeImporter
+	strikeTrigger  chan struct{}
 	logger         *log.Logger
 	syncInterval   time.Duration
 	maxHistoryDays int
@@ -93,6 +94,7 @@ func New(lnd LNDClient, store Store, logger *log.Logger, syncInterval time.Durat
 		logger:         logger,
 		syncInterval:   syncInterval,
 		maxHistoryDays: maxHistoryDays,
+		strikeTrigger:  make(chan struct{}, 1),
 	}
 }
 
@@ -114,9 +116,16 @@ func (s *Syncer) SetMonarchTxSync(txStore MonarchTxStore, settings SettingsReade
 }
 
 // SetStrikeClient sets the Strike API client and importer for automatic syncing.
+// If a non-nil client is provided, an immediate sync is triggered.
 func (s *Syncer) SetStrikeClient(client StrikeRowFetcher, importer StrikeImporter) {
 	s.strikeClient = client
 	s.strikeImporter = importer
+	if client != nil {
+		select {
+		case s.strikeTrigger <- struct{}{}:
+		default:
+		}
+	}
 }
 
 // Run blocks until ctx is cancelled, syncing on startup and then on the configured interval.
@@ -137,6 +146,8 @@ func (s *Syncer) Run(ctx context.Context) {
 			if err := s.Sync(ctx); err != nil {
 				s.logger.Printf("sync failed: %v", err)
 			}
+		case <-s.strikeTrigger:
+			s.syncStrikeAPI(ctx)
 		}
 	}
 }

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -124,14 +124,15 @@ type Handler struct {
 	monarchSyncer    MonarchSyncer
 	monarchTxStore   MonarchTxStore
 	taxStore         TaxStore
-	licenseChecker   *license.DefaultChecker
-	checkoutBaseURL  string // e.g. "https://api.satsbook.io"
-	onMonarchChange  func(MonarchSyncer)
-	pendingMonarch   *monarch.PendingClient
-	logger           *log.Logger
-	renderer         *Renderer
-	version          string
-	startTime        time.Time
+	licenseChecker    *license.DefaultChecker
+	checkoutBaseURL   string // e.g. "https://api.satsbook.io"
+	onMonarchChange   func(MonarchSyncer)
+	onStrikeKeyChange func(apiKey string)
+	pendingMonarch    *monarch.PendingClient
+	logger            *log.Logger
+	renderer          *Renderer
+	version           string
+	startTime         time.Time
 }
 
 // NewHandler creates a new Handler.
@@ -215,6 +216,12 @@ func (h *Handler) SetCheckoutBaseURL(url string) {
 // OnMonarchChange registers a callback invoked when the Monarch syncer changes.
 func (h *Handler) OnMonarchChange(fn func(MonarchSyncer)) {
 	h.onMonarchChange = fn
+}
+
+// OnStrikeKeyChange registers a callback invoked when the Strike API key is saved or cleared.
+// The callback receives the new key value ("" means disconnected).
+func (h *Handler) OnStrikeKeyChange(fn func(apiKey string)) {
+	h.onStrikeKeyChange = fn
 }
 
 // backfillSnapshots runs portfolio snapshot backfill in the background after imports.

--- a/internal/web/handler_settings.go
+++ b/internal/web/handler_settings.go
@@ -29,6 +29,9 @@ type SettingsPageData struct {
 	AvailableTxTypes   []string // all tx types from data
 	AvailableSources   []string // all sources from data
 	MonarchSyncedCount int      // how many transactions have been synced
+	// Strike API sync
+	StrikeAPIConnected bool
+	StrikeAPIKey       string // masked
 }
 
 // HandleSettingsPage serves GET /settings.
@@ -56,6 +59,14 @@ func (h *Handler) HandleSettingsPage(w http.ResponseWriter, r *http.Request) {
 	// Show masked license key
 	if h.licenseChecker != nil && h.licenseChecker.LicenseKey() != "" {
 		data.LicenseKey = maskToken(h.licenseChecker.LicenseKey())
+	}
+
+	// Strike API key status
+	if h.settingsStore != nil {
+		if strikeKey, _ := h.settingsStore.GetSetting(ctx, "strike_api_key"); strikeKey != "" {
+			data.StrikeAPIConnected = true
+			data.StrikeAPIKey = maskToken(strikeKey)
+		}
 	}
 
 	if data.MonarchUnlocked && h.settingsStore != nil {
@@ -460,6 +471,68 @@ func (h *Handler) HandleMonarchTxSync(w http.ResponseWriter, r *http.Request) {
 
 		logger.Printf("monarch tx sync complete: %d created, %d skipped, %d errors", result.Created, result.Skipped, result.Errors)
 	}()
+}
+
+// HandleStrikeAPIKeySave handles POST /api/settings/strike/key — saves the Strike API key.
+func (h *Handler) HandleStrikeAPIKeySave(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if h.settingsStore == nil {
+		http.Error(w, "settings not available", http.StatusInternalServerError)
+		return
+	}
+
+	key := strings.TrimSpace(r.FormValue("strike_api_key"))
+	if key == "" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">API key is required.</div>`)
+		return
+	}
+
+	if err := h.settingsStore.SetSetting(r.Context(), "strike_api_key", key); err != nil {
+		h.logger.Printf("strike: failed to save API key: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Failed to save API key.</div>`)
+		return
+	}
+
+	if h.onStrikeKeyChange != nil {
+		h.onStrikeKeyChange(key)
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, `<div class="alert alert-success">Strike API key saved. Syncing will begin automatically.</div>
+<div style="display:flex;gap:8px;margin-top:12px;">
+  <button hx-post="/api/settings/strike/disconnect" hx-target="#strike-result" hx-confirm="Remove Strike API key?" class="btn btn-danger">Disconnect</button>
+</div>`)
+}
+
+// HandleStrikeAPIKeyDisconnect handles POST /api/settings/strike/disconnect — removes the Strike API key.
+func (h *Handler) HandleStrikeAPIKeyDisconnect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if h.settingsStore == nil {
+		http.Error(w, "settings not available", http.StatusInternalServerError)
+		return
+	}
+
+	if err := h.settingsStore.SetSetting(r.Context(), "strike_api_key", ""); err != nil {
+		h.logger.Printf("strike: failed to clear API key: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<div class="alert alert-error">Failed to disconnect.</div>`)
+		return
+	}
+
+	if h.onStrikeKeyChange != nil {
+		h.onStrikeKeyChange("")
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, `<div class="alert alert-success">Strike API key removed.</div>`)
 }
 
 // maskToken shows only the last 4 characters of a token.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -61,6 +61,8 @@ func NewServer(handler *Handler, port int, logger *log.Logger, checker license.C
 	mux.HandleFunc("/api/portfolio/backfill", handler.HandlePortfolioBackfill)
 	mux.HandleFunc("/api/settings/license", handler.HandleLicenseActivate)
 	mux.HandleFunc("/api/settings/license/verify", handler.HandleLicenseVerify)
+	mux.HandleFunc("/api/settings/strike/key", handler.HandleStrikeAPIKeySave)
+	mux.HandleFunc("/api/settings/strike/disconnect", handler.HandleStrikeAPIKeyDisconnect)
 	mux.HandleFunc("/api/subscribe", handler.HandleSubscribe)
 	mux.HandleFunc("/api/transactions/note", handler.HandleTransactionNoteSave)
 	mux.HandleFunc("/api/transactions/note/edit", handler.HandleTransactionNoteEdit)

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -113,8 +113,9 @@
     <section class="card" style="margin-top: 16px;">
       <h3>Strike API Sync</h3>
       <p style="color: #999; font-size: 0.85rem; margin-bottom: 12px;">
-        Connect your Strike account via API key to automatically sync transaction history.
-        New transactions are imported every sync cycle. Existing CSV-imported data is deduplicated automatically.
+        Connect your Strike API key to automatically sync Lightning invoice receives and your live BTC balance.
+        <strong>Note:</strong> The Strike API only exposes invoices you created (Lightning receives).
+        BTC purchases, DCA orders, sales, and withdrawals are not available via the API — continue using CSV import for those.
       </p>
 
       {{if .StrikeAPIConnected}}

--- a/internal/web/templates/settings_layout.html
+++ b/internal/web/templates/settings_layout.html
@@ -111,6 +111,39 @@
     </section>
 
     <section class="card" style="margin-top: 16px;">
+      <h3>Strike API Sync</h3>
+      <p style="color: #999; font-size: 0.85rem; margin-bottom: 12px;">
+        Connect your Strike account via API key to automatically sync transaction history.
+        New transactions are imported every sync cycle. Existing CSV-imported data is deduplicated automatically.
+      </p>
+
+      {{if .StrikeAPIConnected}}
+        <div style="margin-bottom: 12px;">
+          <span style="color: #4caf50;">Connected</span> &middot;
+          <code>{{.StrikeAPIKey}}</code>
+        </div>
+        <div id="strike-result">
+          <button hx-post="/api/settings/strike/disconnect" hx-target="#strike-result" hx-confirm="Remove Strike API key?" class="btn btn-danger">
+            Disconnect
+          </button>
+        </div>
+      {{else}}
+        <form hx-post="/api/settings/strike/key" hx-target="#strike-result" style="display: flex; gap: 8px; align-items: flex-end; max-width: 500px;">
+          <div style="flex: 1;">
+            <label for="strike_api_key" style="font-size: 0.8rem; color: #aaa; display: block; margin-bottom: 4px;">Strike API Key</label>
+            <input type="password" id="strike_api_key" name="strike_api_key" placeholder="sk_..." style="width: 100%;" required autocomplete="off">
+          </div>
+          <button type="submit" class="btn btn-primary">Connect</button>
+        </form>
+        <p style="color: #666; font-size: 0.75rem; margin-top: 8px;">
+          Generate a read-only API key at <a href="https://dashboard.strike.me" target="_blank" rel="noopener noreferrer" style="color: #4fc3f7;">dashboard.strike.me</a> → API → Create Key.
+          The <code>partner.invoice.read</code> scope is required.
+        </p>
+        <div id="strike-result" style="margin-top: 8px;"></div>
+      {{end}}
+    </section>
+
+    <section class="card" style="margin-top: 16px;">
       <h3>Monarch Money Integration <span class="tier-badge tier-power">power</span></h3>
       <p style="color: #999; font-size: 0.85rem; margin-bottom: 12px;">
         Sync your total BTC holdings to a Monarch Money investment account.


### PR DESCRIPTION
## Summary

- Add `SATSBOOK_STRIKE_API_KEY` env var and DB-stored key (`strike_api_key` setting)
- `internal/exchange/strike_api.go`: new `StrikeAPIClient` with `FetchRows` (paid invoices via OData filter) and `FetchBalance`; rows map to the same `TransactionID` as CSV exports for automatic dedup via `ImportStrikeCSV`
- Syncer: `StrikeRowFetcher`/`StrikeImporter` interfaces + `syncStrikeAPI` runs after each LND sync cycle
- Dashboard-only mode: standalone `runStrikeSync` goroutine with 15-min ticker
- Settings page: save/disconnect Strike API key with hot-swap (no restart needed)
- `OnStrikeKeyChange` callback propagates key changes to syncer at runtime

## Test plan

- [ ] `go test ./...` passes (all existing + new Strike API client tests)
- [ ] Settings page shows Strike API section
- [ ] Can save and remove a Strike API key
- [ ] With valid key, transactions appear in ledger after next sync cycle
- [ ] CSV-imported Strike data is deduplicated (no duplicate TransactionIDs)
- [ ] Invalid key shows sensible error in logs (401 from API)

Closes #46